### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,36 @@
+"""Helper utilities for JSON file handling."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from a file, returning default on any failure.
+
+    Args:
+        path: Path to the JSON file (str or Path).
+        default: Value to return if file doesn't exist, is empty,
+                 or contains invalid JSON.
+
+    Returns:
+        Parsed JSON data if valid, otherwise the default value.
+    """
+    json_path = Path(path)
+
+    if not json_path.exists():
+        return default
+
+    try:
+        content = json_path.read_text(encoding="utf-8")
+    except OSError:
+        return default
+
+    stripped = content.strip()
+    if not stripped:
+        return default
+
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,65 @@
+"""Tests for json_helpers.py."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add script directory to path
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "scripts")
+)
+
+from json_helpers import safe_json_load
+
+
+def test_safe_json_load_returns_default_for_missing_file(tmp_path: Path) -> None:
+    """Should return default when file does not exist."""
+    missing_file = tmp_path / "does_not_exist.json"
+    assert safe_json_load(missing_file) is None
+    assert safe_json_load(missing_file, default={}) == {}
+    assert safe_json_load(missing_file, default=[]) == []
+
+
+def test_safe_json_load_returns_default_for_empty_file(tmp_path: Path) -> None:
+    """Should return default when file is empty."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("")
+    assert safe_json_load(empty_file) is None
+    assert safe_json_load(empty_file, default={}) == {}
+
+
+def test_safe_json_load_returns_default_for_whitespace_only_file(tmp_path: Path) -> None:
+    """Should return default when file contains only whitespace."""
+    ws_file = tmp_path / "whitespace.json"
+    ws_file.write_text("   \n\t  \n")
+    assert safe_json_load(ws_file) is None
+    assert safe_json_load(ws_file, default="default") == "default"
+
+
+def test_safe_json_load_returns_default_for_malformed_json(tmp_path: Path) -> None:
+    """Should return default when file contains invalid JSON."""
+    bad_file = tmp_path / "broken.json"
+    bad_file.write_text('{"key": invalid json here}')
+    assert safe_json_load(bad_file) is None
+    assert safe_json_load(bad_file, default=[]) == []
+
+
+def test_safe_json_load_returns_parsed_value_for_valid_json(tmp_path: Path) -> None:
+    """Should return parsed data for valid JSON."""
+    good_file = tmp_path / "good.json"
+    data = {"name": "test", "value": 42, "nested": {"a": [1, 2, 3]}}
+    good_file.write_text(json.dumps(data))
+    assert safe_json_load(good_file) == data
+
+
+def test_safe_json_load_accepts_str_and_path(tmp_path: Path) -> None:
+    """Should accept both str and Path arguments for path."""
+    good_file = tmp_path / "good.json"
+    data = {"key": "value"}
+    good_file.write_text(json.dumps(data))
+
+    # Test with Path object
+    assert safe_json_load(good_file) == data
+
+    # Test with str
+    assert safe_json_load(str(good_file)) == data


### PR DESCRIPTION
## Linked card

Closes #3

## What changed

- Created  with  helper function
- Created  with pytest fixtures using tmp_path for testing

## How verified

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0
collecting ... collected 6 items

tests/test_json_helpers.py::test_safe_json_load_returns_default_for_missing_file PASSED [ 16%]
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_empty_file PASSED [ 33%]
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_whitespace_only_file PASSED [ 50%]
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_malformed_json PASSED [ 66%]
tests/test_json_helpers.py::test_safe_json_load_returns_parsed_value_for_valid_json PASSED [ 83%]
tests/test_json_helpers.py::test_safe_json_load_accepts_str_and_path PASSED [100%]
WARNING: Failed to generate report: No data to report.



============================== 6 passed in 0.08s ===============================

Output:


Ruff linting:


## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in  - handles all required cases (missing file, empty file, malformed JSON, valid JSON, str/Path input)
- AC 2 (All named tests pass the verification command): ✓ addressed in  - all 6 tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - uses only Python stdlib modules (json, pathlib, typing)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ not violated
- Do NOT add third-party dependencies unless required by the task body: ✓ not violated
- Do NOT refactor unrelated code in the touched files: ✓ not violated

## Notes

Implementation uses only Python stdlib imports: , , and . Normalizes input with  so both  and  inputs follow the same code path. Follows existing test convention from  for importing standalone script modules.