### PR TITLE
[BENCH t03 deepseek-v3.2-c] feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,29 @@
+"""Helper utilities for dictionary traversal."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Get a nested value from a dict using a dotted path.
+
+    Args:
+        data: The dict to traverse.
+        path: Dotted string representing the key path (e.g., "a.b.c").
+        default: Value to return if any step fails (missing key or non‑dict).
+
+    Returns:
+        The value at the deepest matching key if traversal succeeds;
+        otherwise returns default.
+    """
+    if not path:
+        return data
+
+    current = data
+    for segment in path.split("."):
+        if not isinstance(current, dict):
+            return default
+        if segment not in current:
+            return default
+        current = current[segment]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,44 @@
+"""Unit tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import dict_helpers
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+def test_get_nested_happy_path():
+    """Test happy path nested lookup."""
+    data = {"a": {"b": 1}}
+    result = get_nested(data, "a.b")
+    assert result == 1
+
+
+def test_get_nested_missing_key_returns_default():
+    """Test missing key returns given default."""
+    data = {"a": {"b": 1}}
+    result = get_nested(data, "a.c", default=-1)
+    assert result == -1
+
+
+def test_get_nested_returns_default_when_stepping_into_non_dict():
+    """Test stepping into a non-dict returns default."""
+    data = {"a": 1}
+    result = get_nested(data, "a.b")
+    assert result is None
+
+
+def test_get_nested_empty_path_returns_original_data():
+    """Test empty path returns original dict."""
+    data = {"x": "y"}
+    result = get_nested(data, "")
+    assert result == data
+
+
+def test_get_nested_three_level_lookup():
+    """Test nested lookup three levels deep."""
+    data = {"a": {"b": {"c": {"d": "value"}}}}
+    result = get_nested(data, "a.b.c")
+    assert result == {"d": "value"}


### PR DESCRIPTION
## Linked card

Closes #5

## What changed

- Added `scripts/dict_helpers.py` with `get_nested(data: dict, path: str, default=None) -> Any` implementation.
- Added `tests/test_dict_helpers.py` with pytest cases covering:
  - Happy path (`{"a": {"b": 1}}`, `"a.b"` → `1`)
  - Missing key with explicit default (`{"a": {"b": 1}}`, `"a.c"`, `default=-1` → `-1`)
  - Stepping into a non‑dict (`{"a": 1}`, `"a.b"` → `None`)
  - Empty path returning the original object (`{}`, `""` → `{}`)
  - 3‑level nested lookup (`{"a": {"b": {"c": {"d": "value"}}}}`, `"a.b.c"` → `{"d": "value"}`)

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_dict_helpers.py -v
```

Output digest:
```
5 passed in 0.06s.
All named tests (`test_get_nested_happy_path`, `test_get_nested_missing_key_returns_default`, `test_get_nested_returns_default_when_stepping_into_non_dict`, `test_get_nested_empty_path_returns_original_data`, `test_get_nested_three_level_lookup`) pass.
```

Ran `ruff check scripts/dict_helpers.py tests/test_dict_helpers.py --fix` (linted and fixed trailing newlines).

## Acceptance criteria coverage

- AC: `Implementation matches all behaviors described in the task body (see Notes)` – Addressed in `scripts/dict_helpers.py:get_nested`:
  - Dotted path traversal (`path.split(".")`)
  - Return default on missing key (`segment not in current`)
  - Return default when stepping into non‑dict (`isinstance(current, dict)`)
  - Empty path returns entire data (`if not path: return data`)
  - Does not mutate `data` (read‑only traversal)
- AC: `All named tests pass the verification command` – Verified via `pytest tests/test_dict_helpers.py -v`; all five named test functions pass.
- AC: `No dependencies added unless absolutely required` – Only standard‑library imports (`typing.Any`); no new third‑party dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below – No files outside `scripts/dict_helpers.py` and `tests/test_dict_helpers.py` were changed.
- Do NOT add third-party dependencies unless required by the task body – No dependencies added.
- Do NOT refactor unrelated code in the touched files – Only added new helper and new test file; no existing code modified.

## Notes

- Added minimal implementation matching the spec (29 lines including docstring).
- Test file follows the existing convention (`sys.path.insert` to import from `scripts/`).
- No existing symbols named `get_nested` found (`git grep`) – clean implementation.
- Linting passes (`ruff check --fix` resolved two trailing‑newline warnings).

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in `scripts/dict_helpers.py` lines 8‑29
- AC 2 (All named tests pass the verification command): ✓ verified via `pytest tests/test_dict_helpers.py -v`
- AC 3 (No dependencies added unless absolutely required): ✓ no dependencies added