### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,30 @@
+"""JSON helper utilities for safe loading of JSON files."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default=None) -> Any:
+    """
+    Safely load JSON from a file path.
+
+    Args:
+        path: Path to the JSON file (str or Path object)
+        default: Default value to return if file doesn't exist or is invalid
+
+    Returns:
+        Parsed JSON object if successful, otherwise default value
+    """
+    json_path = Path(path)
+
+    # If file doesn't exist, return default
+    if not json_path.exists():
+        return default
+
+    try:
+        # Try to parse the JSON content
+        return json.loads(json_path.read_text())
+    except json.JSONDecodeError:
+        # If JSON is invalid or empty, return default
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,57 @@
+"""Tests for json_helpers.py"""
+
+import json
+from pathlib import Path
+
+from scripts.json_helpers import safe_json_load
+
+
+def test_safe_json_load_missing_file_returns_none(tmp_path: Path):
+    """Test that missing file returns None by default."""
+    missing_file = tmp_path / "missing.json"
+    assert safe_json_load(missing_file) is None
+
+
+def test_safe_json_load_missing_file_returns_custom_default(tmp_path: Path):
+    """Test that missing file returns custom default."""
+    missing_file = tmp_path / "missing.json"
+    custom_default = {"default": True}
+    assert safe_json_load(missing_file, default=custom_default) == custom_default
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path: Path):
+    """Test that empty file returns default."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("")
+    assert safe_json_load(empty_file, default="empty") == "empty"
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path: Path):
+    """Test that malformed JSON returns default."""
+    broken_file = tmp_path / "broken.json"
+    broken_file.write_text("{ invalid json }")
+    assert safe_json_load(broken_file, default="malformed") == "malformed"
+
+
+def test_safe_json_load_valid_json_returns_parsed_object(tmp_path: Path):
+    """Test that valid JSON returns parsed object."""
+    valid_file = tmp_path / "valid.json"
+    test_data = {"key": "value", "number": 42}
+    valid_file.write_text(json.dumps(test_data))
+    assert safe_json_load(valid_file) == test_data
+
+
+def test_safe_json_load_accepts_path_and_str(tmp_path: Path):
+    """Test that both Path and str arguments work."""
+    valid_file = tmp_path / "valid.json"
+    test_data = {"key": "value"}
+    valid_file.write_text(json.dumps(test_data))
+
+    # Test with Path object
+    result_path = safe_json_load(valid_file)
+    # Test with string path
+    result_str = safe_json_load(str(valid_file))
+
+    assert result_path == test_data
+    assert result_str == test_data
+    assert result_path == result_str


### PR DESCRIPTION
## Linked card

Closes #6

## What changed

- Added `scripts/json_helpers.py` with a new `safe_json_load()` function
- Added `tests/test_json_helpers.py` with comprehensive test coverage

## How verified

Ran tests with:
```
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python -m pytest tests/test_json_helpers.py -v
```
All 6 tests passed successfully.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body → ✓ addressed in `scripts/json_helpers.py` 
- AC 2: All named tests pass the verification command → ✓ addressed in `tests/test_json_helpers.py`
- AC 3: No dependencies added unless absolutely required → ✓ no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

The implementation follows Python 3.12+ conventions and uses only standard library modules (json, pathlib, typing).

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/json_helpers.py
- [ ] All named tests pass the verification command: ✓ addressed in tests/test_json_helpers.py
- [ ] No dependencies added unless absolutely required: ✓ addressed - no new dependencies