### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """
+    Get a value from a nested dictionary using a dotted path.
+
+    Args:
+        data: The dictionary to search.
+        path: A dotted string path like "a.b.c".
+        default: The value to return if the path is not found or a step is not a dict.
+
+    Returns:
+        The value at the path or the default value.
+    """
+    if not path:
+        return data
+
+    current = data
+    for segment in path.split("."):
+        if isinstance(current, dict) and segment in current:
+            current = current[segment]
+        else:
+            return default
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,25 @@
+from scripts.dict_helpers import get_nested
+
+
+def test_get_nested_happy_path():
+    data = {"a": {"b": 1}}
+    assert get_nested(data, "a.b") == 1
+
+def test_get_nested_missing_key_returns_default():
+    data = {"a": {"b": 1}}
+    assert get_nested(data, "a.c", default=-1) == -1
+    assert get_nested(data, "x") is None
+
+def test_get_nested_non_dict_step_returns_none():
+    data = {"a": 1}
+    assert get_nested(data, "a.b") is None
+
+def test_get_nested_empty_path_returns_original_data():
+    data = {"a": 1}
+    assert get_nested(data, "") == data
+    assert get_nested({}, "") == {}
+
+def test_get_nested_three_level_lookup():
+    data = {"a": {"b": {"c": 42}}}
+    assert get_nested(data, "a.b.c") == 42
+    assert get_nested(data, "a.b.d", default="missing") == "missing"


### PR DESCRIPTION
## Linked card

Closes #10

## What changed

- Created `scripts/dict_helpers.py` with `get_nested()` function for safe dotted-path lookups in dictionaries.
- Created `tests/test_dict_helpers.py` with comprehensive unit tests (happy path, missing keys, non-dict steps, empty path, deep nesting).
- Followed repo standards: Python 3.12+ type hints, Ruff linting, and pytest.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
PYTHONPATH=. .venv/bin/pytest tests/test_dict_helpers.py -v
```
Output: All 5 tests passed (test_get_nested_happy_path, test_get_nested_missing_key_returns_default, test_get_nested_non_dict_step_returns_none, test_get_nested_empty_path_returns_original_data, test_get_nested_three_level_lookup).

## Acceptance criteria coverage

- AC 1: Implementation safe lookups and dotted paths: ✓ addressed in `scripts/dict_helpers.py`
- AC 2: All named tests pass: ✓ addressed by `tests/test_dict_helpers.py`
- AC 3: No new dependencies: ✓ addressed (std lib only)

## Non-goals acknowledged

- Do NOT modify files beyond expected set: not violated
- Do NOT add third-party dependencies: not violated
- Do NOT refactor unrelated code: not violated

## Notes

- Added a virtual environment `.venv` to install dev dependencies for verification.
- Required `PYTHONPATH=.` for pytest to find the `scripts` module, as the directory doesn't have an `__init__.py` file (matching existing repo patterns).

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/dict_helpers.py`
- All named tests pass the verification command: ✓ addressed in `tests/test_dict_helpers.py`
- No dependencies added unless absolutely required: ✓ addressed (using standard library only)