### PR TITLE
[BENCH t03] feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,31 @@
+"""Dictionary helper utilities for safe nested value lookup."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default=None) -> Any:
+    """
+    Safely retrieve a nested value from a dictionary using a dotted path.
+
+    Args:
+        data: The dictionary to traverse
+        path: A dotted string like "a.b.c" specifying the nested path
+        default: Value to return if any key in the path is missing or
+                 if we encounter a non-dict before the final segment
+
+    Returns:
+        The value at the nested path, or default if the path is invalid
+    """
+    # Handle empty path - return entire data
+    if path == "":
+        return data
+
+    current: Any = data
+
+    for segment in path.split("."):
+        # Only continue if current is a dict and the key exists
+        if not isinstance(current, dict) or segment not in current:
+            return default
+        current = current[segment]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,35 @@
+"""Tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+def test_get_nested_happy_path():
+    """Test basic dotted path lookup returns the nested value."""
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_nested_missing_key_returns_default():
+    """Test missing key returns default value."""
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+
+def test_get_nested_non_dict_mid_path_returns_default():
+    """Test stepping into a non-dict returns default."""
+    assert get_nested({"a": 1}, "a.b") is None
+
+
+def test_get_nested_empty_path_returns_entire_data():
+    """Test empty path returns the entire data dict."""
+    data = {}
+    assert get_nested(data, "") == data
+
+
+def test_get_nested_three_plus_levels():
+    """Test lookup works with 3+ levels of nesting."""
+    data = {"a": {"b": {"c": {"d": 2}}}}
+    assert get_nested(data, "a.b.c.d") == 2


### PR DESCRIPTION
## Linked card

Closes #13

## What changed

- **scripts/dict_helpers.py** (new): Added `get_nested(data: dict, path: str, default=None) -> Any` helper function for safe dotted-path dictionary traversal.
  - Handles empty path by returning the entire data dict
  - Iterates through `path.split(".")` segments
  - Returns `default` if key is missing or current value is not a dict
  - Does not mutate the input dict

- **tests/test_dict_helpers.py** (new): Added pytest coverage for all required behaviors:
  - `test_get_nested_happy_path`: basic dotted path lookup
  - `test_get_nested_missing_key_returns_default`: missing key returns custom default
  - `test_get_nested_non_dict_mid_path_returns_default`: stepping into non-dict returns None
  - `test_get_nested_empty_path_returns_entire_data`: empty path returns entire data dict
  - `test_get_nested_three_plus_levels`: 4-level nested lookup works correctly

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
source venv/bin/activate
python3 -m pytest tests/test_dict_helpers.py -v -o "addopts="
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
collecting ... collected 5 items

tests/test_dict_helpers.py::test_get_nested_happy_path PASSED            [ 20%]
tests/test_dict_helpers.py::test_get_nested_missing_key_returns_default PASSED [ 40%]
tests/test_dict_helpers.py::test_get_nested_non_dict_mid_path_returns_default PASSED [ 60%]
tests/test_dict_helpers.py::test_get_nested_empty_path_returns_entire_data PASSED [ 80%]
tests/test_dict_helpers.py::test_get_nested_three_plus_levels PASSED     [100%]

============================== 5 passed in 0.03s ===============================
```

Linter check (ruff) passes on both files.

## Acceptance criteria coverage

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in scripts/dict_helpers.py:`get_nested()` lines 8-31
  - empty path → return entire data: handled by explicit `if path == "": return data` branch (lines 16-17)
  - dotted traversal: handled by `for segment in path.split("."):` (line 19)
  - missing key / non-dict handling: returns default if key missing or current not a dict (lines 22-23)
  - no mutation: function only reads from data via local `current` variable
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_dict_helpers.py - all 5 tests pass (see verification output)
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - no pyproject.toml, lockfile, or dependency changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only scripts/dict_helpers.py and tests/test_dict_helpers.py modified
- Do NOT add third-party dependencies unless required by the task body: not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - new files only, no refactoring

## Notes

None - plan followed as written.