### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,21 @@
+"""Text helper utilities for Infiquetra scripts."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """
+    Return a word in its plural form based on a count.
+
+    If word is empty, returns empty string.
+    If count is 1, returns word unchanged.
+    Otherwise, returns plural if provided, else word + "s".
+    """
+    if not word:
+        return ""
+
+    if count == 1:
+        return word
+
+    if plural is not None:
+        return plural
+
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,40 @@
+"""Tests for text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to sys.path to import text_helpers
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_singular():
+    """Test pluralize with count 1 returns singular word."""
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_regular_plural():
+    """Test pluralize with count != 1 returns regular plural (word + 's')."""
+    assert pluralize("cat", 2) == "cats"
+    assert pluralize("dog", 0) == "dogs"
+    assert pluralize("bird", -1) == "birds"
+
+
+def test_pluralize_custom_plural():
+    """Test pluralize with count != 1 returns custom plural if provided."""
+    assert pluralize("child", 2, plural="children") == "children"
+    assert pluralize("goose", 0, plural="geese") == "geese"
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    """Test pluralize with count 0 uses plural form."""
+    assert pluralize("cat", 0) == "cats"
+    assert pluralize("child", 0, plural="children") == "children"
+
+
+def test_pluralize_empty_string_returns_empty_string():
+    """Test pluralize with empty string returns empty string regardless of count."""
+    assert pluralize("", 1) == ""
+    assert pluralize("", 2) == ""
+    assert pluralize("", 0) == ""


### PR DESCRIPTION
## Linked card

Closes #17

## What changed

- Added `scripts/text_helpers.py` with the `pluralize()` function.
- Added `tests/test_text_helpers.py` with pytest cases covering singular, regular plural, custom plural, zero count, and empty string behaviors.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
./venv/bin/pytest -o "addopts=" tests/test_text_helpers.py -v
```

Output:
```
tests/test_text_helpers.py::test_pluralize_singular PASSED
tests/test_text_helpers.py::test_pluralize_regular_plural PASSED
tests/test_text_helpers.py::test_pluralize_custom_plural PASSED
tests/test_text_helpers.py::test_pluralize_zero_count_uses_plural_form PASSED
tests/test_text_helpers.py::test_pluralize_empty_string_returns_empty_string PASSED
============================== 5 passed in 0.04s ===============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
- AC 2: All named tests pass the verification command
- AC 3: No dependencies added unless absolutely required

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

- Function signature: `pluralize(word: str, count: int, *, plural: str | None = None) -> str`
- Pyright clean on `scripts/text_helpers.py`.
- `tests/test_text_helpers.py` uses the project's `sys.path` pattern to import the script.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/text_helpers.py
- All named tests pass the verification command: ✓ addressed in tests/test_text_helpers.py
- No dependencies added unless absolutely required: ✓ addressed (no changes to pyproject.toml)