### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,36 @@
+"""Helper functions for dictionary operations."""
+
+from typing import Any
+
+
+def get_nested(data: dict[str, Any], path: str, default: Any = None) -> Any:
+    """
+    Get a nested value from a dictionary using a dotted path string.
+
+    Args:
+        data: The dictionary to traverse
+        path: Dot-separated path string (e.g., "a.b.c")
+        default: Default value to return if path not found
+
+    Returns:
+        The value at the nested path, or default if not found
+    """
+    # Handle empty path case
+    if path == "":
+        return data
+
+    # Traverse the path
+    current = data
+    for segment in path.split("."):
+        # Check if current is a dictionary
+        if not isinstance(current, dict):
+            return default
+
+        # Check if segment exists in current dictionary
+        if segment not in current:
+            return default
+
+        # Move to the next level
+        current = current[segment]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,56 @@
+"""Unit tests for dict_helpers.py."""
+
+import pytest
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+class TestGetNested:
+    """Test get_nested function."""
+
+    def test_get_nested_happy_path(self):
+        """Test happy path with valid nested dict and path."""
+        data = {"a": {"b": {"c": 1}}}
+        result = get_nested(data, "a.b.c")
+        assert result == 1
+
+    def test_get_nested_missing_key_returns_default(self):
+        """Test that missing key returns default value."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "a.c", default=-1)
+        assert result == -1
+
+    def test_get_nested_non_dict_step_returns_default(self):
+        """Test that stepping into non-dict value returns default."""
+        data = {"a": 1}
+        result = get_nested(data, "a.b", default="default")
+        assert result == "default"
+
+    def test_get_nested_empty_path_returns_entire_data(self):
+        """Test that empty path returns entire data."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "")
+        assert result == data
+
+    def test_get_nested_three_level_lookup(self):
+        """Test lookup with three levels of nesting."""
+        data = {"level1": {"level2": {"level3": "deep_value"}}}
+        result = get_nested(data, "level1.level2.level3")
+        assert result == "deep_value"
+
+    def test_get_nested_does_not_mutate_input(self):
+        """Test that the original data structure is not mutated."""
+        data = {"a": {"b": {"c": 1}}}
+        original_data = data.copy()
+        get_nested(data, "a.b.c")
+        assert data == original_data
+        
+        # Also check nested mutation
+        get_nested(data, "a.b")
+        assert data == original_data


### PR DESCRIPTION
## Linked card

Closes #9

## What changed

- Added `get_nested(data: dict, path: str, default=None) -> Any` function to `scripts/dict_helpers.py`
- Added comprehensive test suite in `tests/test_dict_helpers.py` with 6 test cases:
  - Happy path traversal
  - Missing key handling with default value
  - Stepping into non-dict values
  - Empty path returning entire data
  - Three-level nested lookup
  - Mutation prevention test

## How verified

```
$ python -m pytest tests/test_dict_helpers.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/agent/workspace/infiquetra/infiquetra-claude-plugins/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0
collecting ... collected 6 items

tests/test_dict_helpers.py::TestGetNested::test_get_nested_happy_path PASSED [ 16%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_missing_key_returns_default PASSED [ 33%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_non_dict_step_returns_default PASSED [ 50%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_empty_path_returns_entire_data PASSED [ 66%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_three_level_lookup PASSED [ 83%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_does_not_mutate_input PASSED [100%]

============================== 6 passed in 0.09s ===============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - covered by the `get_nested` function implementation which correctly handles all edge cases including empty paths, missing keys, and non-dict values
- AC 2: All named tests pass the verification command - all 6 tests pass as shown in the verification output above
- AC 3: No dependencies added unless absolutely required - no new dependencies were added, only standard Python features and existing test infrastructure

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Not violated - only created `scripts/dict_helpers.py` and `tests/test_dict_helpers.py`
- Do NOT add third-party dependencies unless required by the task body: Not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: Not violated - only added new functionality

## Notes

- Follows repository coding conventions as seen in `scripts/validate_plugins.py`
- Uses proper type hints with modern Python typing syntax (`dict[str, Any]` instead of `Dict[str, Any]`)
- Test file follows the pattern seen in other test files in the repository by adding the scripts directory to `sys.path`

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/dict_helpers.py
- [ ] All named tests pass the verification command: ✓ addressed in tests/test_dict_helpers.py
- [ ] No dependencies added unless absolutely required: ✓ verified by checking pyproject.toml and git diff