### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,20 @@
+"""Text helper utilities for Infiquetra plugins."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of a word based on count.
+
+    Args:
+        word: The singular form of the word.
+        count: The quantity determining which form to use.
+        plural: Optional override for the plural form.
+
+    Returns:
+        The word unchanged if count is 1, otherwise the plural form.
+        Returns empty string if word is empty.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else word + "s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,34 @@
+"""Tests for scripts/text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_singular() -> None:
+    """Singular count returns word unchanged."""
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_regular_plural() -> None:
+    """Count > 1 without custom plural appends 's'."""
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_custom_plural() -> None:
+    """Custom plural form is used when count is not 1."""
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count() -> None:
+    """Zero count returns plural form."""
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string() -> None:
+    """Empty string returns empty string regardless of count."""
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #16

## What changed

- Added `pluralize(word: str, count: int, *, plural: str | None = None) -> str` to `scripts/text_helpers.py`
- Added `tests/test_text_helpers.py` with 5 pytest cases covering singular, regular plural, custom plural, zero count, and empty string

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```

Output:
```
tests/test_text_helpers.py::test_pluralize_singular PASSED
tests/test_text_helpers.py::test_pluralize_regular_plural PASSED
tests/test_text_helpers.py::test_pluralize_custom_plural PASSED
tests/test_text_helpers.py::test_pluralize_zero_count PASSED
tests/test_text_helpers.py::test_pluralize_empty_string PASSED
5 passed in 0.06s
```

`ruff check scripts/text_helpers.py tests/test_text_helpers.py` — All checks passed!

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): pluralize() in scripts/text_helpers.py implements empty-string guard, count==1 singular branch, plural override, and word+"s" fallback
- AC 2 (All named tests pass the verification command): 5/5 pytest cases pass
- AC 3 (No dependencies added unless absolutely required): No new dependencies — only stdlib used in implementation, pytest already in dev deps

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only scripts/text_helpers.py and tests/test_text_helpers.py changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

Import convention follows existing repo pattern (sys.path.insert to add source directory, matching tests/test_test_runner.py).

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/text_helpers.py pluralize()
- All named tests pass the verification command: ✓ addressed in tests/test_text_helpers.py (5 test cases)
- No dependencies added unless absolutely required: ✓ confirmed — only stdlib + existing pytest dev dependency