### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,33 @@
+"""Path-aware JSON loader helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load and parse a JSON file, returning a default on failure.
+
+    Args:
+        path: Path to the JSON file. Accepts str or Path.
+        default: Value to return when the file is missing, empty,
+            or contains invalid JSON. Defaults to None.
+
+    Returns:
+        The parsed JSON object on success, otherwise the default value.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return default
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return default
+    if not content:
+        return default
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,57 @@
+"""Unit tests for json_helpers.py."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import json_helpers
+
+
+class TestSafeJsonLoad:
+    """Tests for safe_json_load()."""
+
+    def test_safe_json_load_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Missing file returns None."""
+        result = json_helpers.safe_json_load(tmp_path / "does_not_exist.json")
+        assert result is None
+
+    def test_safe_json_load_missing_file_returns_supplied_default(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing file returns the caller-supplied default."""
+        result = json_helpers.safe_json_load(
+            tmp_path / "does_not_exist.json", default={}
+        )
+        assert result == {}
+
+    def test_safe_json_load_empty_file_returns_default(self, tmp_path: Path) -> None:
+        """Empty file returns the supplied default."""
+        file_path = tmp_path / "empty.json"
+        file_path.touch()
+        result = json_helpers.safe_json_load(file_path, default=[])
+        assert result == []
+
+    def test_safe_json_load_malformed_json_returns_default(
+        self, tmp_path: Path
+    ) -> None:
+        """Malformed JSON returns the supplied default."""
+        file_path = tmp_path / "broken.json"
+        file_path.write_text("{ not valid json", encoding="utf-8")
+        result = json_helpers.safe_json_load(file_path, default=[])
+        assert result == []
+
+    def test_safe_json_load_valid_json_accepts_path_and_str(
+        self, tmp_path: Path
+    ) -> None:
+        """Valid JSON is parsed and returned for both Path and str arguments."""
+        data = {"key": "value", "number": 42}
+        file_path = tmp_path / "good.json"
+        file_path.write_text(json.dumps(data), encoding="utf-8")
+
+        result_str = json_helpers.safe_json_load(str(file_path))
+        result_path = json_helpers.safe_json_load(file_path)
+
+        assert result_str == data
+        assert result_path == data


### PR DESCRIPTION
## Linked card

Closes #21

## What changed

- Added `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any`
- Added `tests/test_json_helpers.py` with five pytest cases covering missing file, empty file, malformed JSON, and valid JSON with str/Path args

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
./venv/bin/pytest tests/test_json_helpers.py -v -o addopts=""
\`\`\`

Output: 5 passed in 0.04s

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in `scripts/json_helpers.py:safe_json_load` — returns `default` on missing file, empty file, or JSON decode error; returns parsed object for valid JSON; accepts both `str` and `Path`
- AC 2 (All named tests pass verification): ✓ addressed in `tests/test_json_helpers.py` — 5/5 tests pass: `test_safe_json_load_missing_file_returns_none`, `test_safe_json_load_missing_file_returns_supplied_default`, `test_safe_json_load_empty_file_returns_default`, `test_safe_json_load_malformed_json_returns_default`, `test_safe_json_load_valid_json_accepts_path_and_str`
- AC 3 (No dependencies added): ✓ addressed in `scripts/json_helpers.py` — uses only stdlib (`json`, `pathlib.Path`, `typing.Any`)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/json_helpers.py` and `tests/test_json_helpers.py` changed
- Do NOT add third-party dependencies unless required: not violated — stdlib only
- Do NOT refactor unrelated code: not violated — no unrelated changes

## Notes

- No existing `safe_json_load` symbol found in repo — clean addition
- `ruff check` passes with zero new warnings on both modified files

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/json_helpers.py:safe_json_load`
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_json_helpers.py` — 5/5 passed
- AC 3 (No dependencies added unless absolutely required): ✓ addressed in `scripts/json_helpers.py` — stdlib only