### PR TITLE
feat(scripts): add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,31 @@
+"""JSON helper utilities for safe file loading."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from a file, returning a default value on any error.
+
+    Args:
+        path: Path to the JSON file (accepts str or Path).
+        default: Value to return if file is missing, empty, or invalid (default: None).
+
+    Returns:
+        The parsed JSON object, or the default value if loading fails.
+    """
+    normalized_path = Path(path)
+
+    if not normalized_path.exists():
+        return default
+
+    content = normalized_path.read_text()
+
+    if not content.strip():
+        return default
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,63 @@
+"""Unit tests for safe_json_load function."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+class TestSafeJsonLoad:
+    """Test safe_json_load function."""
+
+    def test_safe_json_load_returns_none_for_missing_file(self, tmp_path):
+        """Test that missing file returns None when default is omitted."""
+        missing_file = tmp_path / "does_not_exist.json"
+        result = safe_json_load(missing_file)
+        assert result is None
+
+    def test_safe_json_load_returns_custom_default_for_missing_file(self, tmp_path):
+        """Test that missing file returns the caller-provided default object."""
+        missing_file = tmp_path / "does_not_exist.json"
+        custom_default = {"fallback": "value"}
+        result = safe_json_load(missing_file, default=custom_default)
+        assert result == custom_default
+
+    def test_safe_json_load_returns_default_for_empty_file(self, tmp_path):
+        """Test that empty file returns the provided default."""
+        empty_file = tmp_path / "empty.json"
+        empty_file.write_text("")
+        custom_default = []
+        result = safe_json_load(empty_file, default=custom_default)
+        assert result == custom_default
+
+    def test_safe_json_load_returns_default_for_malformed_json(self, tmp_path):
+        """Test that malformed JSON returns the provided default."""
+        broken_file = tmp_path / "broken.json"
+        broken_file.write_text("{ invalid json }")
+        custom_default = []
+        result = safe_json_load(broken_file, default=custom_default)
+        assert result == custom_default
+
+    def test_safe_json_load_returns_parsed_object_for_valid_json(self, tmp_path):
+        """Test that valid JSON returns the parsed object."""
+        valid_file = tmp_path / "valid.json"
+        expected = {"name": "test", "count": 42}
+        valid_file.write_text(json.dumps(expected))
+        result = safe_json_load(valid_file)
+        assert result == expected
+
+    def test_safe_json_load_accepts_path_and_str_arguments(self, tmp_path):
+        """Test that both str and Path arguments produce the same parsed result."""
+        valid_file = tmp_path / "valid.json"
+        expected = {"data": [1, 2, 3]}
+        valid_file.write_text(json.dumps(expected))
+
+        result_str = safe_json_load(str(valid_file))
+        result_path = safe_json_load(valid_file)
+
+        assert result_str == expected
+        assert result_path == expected
+        assert result_str == result_path


### PR DESCRIPTION
## Linked card

Closes #22

## What changed

- Created `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any` function
- Created `tests/test_json_helpers.py` with 6 pytest test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
.venv/bin/python -m pytest tests/test_json_helpers.py -v
```

Output:
```
============================= test session starts ==============================
6 passed in 0.07s
```

Ruff check:
```
.venv/bin/ruff check scripts/json_helpers.py tests/test_json_helpers.py
All checks passed!
```

Mypy:
```
.venv/bin/mypy scripts/json_helpers.py tests/test_json_helpers.py
Success: no issues found in 2 source files
```

## Acceptance criteria coverage

- AC 1: ✓ addressed in `scripts/json_helpers.py` - `safe_json_load()` function handles missing files, empty files, malformed JSON, and valid JSON; accepts both str and Path arguments
- AC 2: ✓ addressed in `tests/test_json_helpers.py` - 6 test cases cover all named behaviors, verification command passes
- AC 3: ✓ addressed - implementation uses only stdlib modules (json, pathlib, typing), no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only scripts/json_helpers.py and tests/test_json_helpers.py modified
- Do NOT add third-party dependencies unless required by the task body: not violated - stdlib only
- Do NOT refactor unrelated code in the touched files: not violated - new files only, no unrelated changes

## Notes

None - implementation matches approved plan exactly.

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/json_helpers.py:safe_json_load()
- AC 2 (verbatim): All named tests pass the verification command: ✓ addressed in tests/test_json_helpers.py (6 tests pass)
- AC 3 (verbatim): No dependencies added unless absolutely required: ✓ addressed - stdlib only (json, pathlib, typing)
