### PR TITLE
[BENCH t01 deepseek-v3.2-c] feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,28 @@
+"""Helper functions for text operations."""
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """
+    Return the plural form of a word based on count.
+
+    If count == 1, return word unchanged.
+    Otherwise, return plural if provided, else word + "s".
+    Handles empty string: returns empty string regardless of count.
+
+    Args:
+        word: The word to pluralize
+        count: The quantity determining singular vs plural
+        plural: Optional custom plural form (e.g., "children" for "child")
+
+    Returns:
+        The singular or plural form appropriate for the count
+    """
+    if word == "":
+        return ""
+
+    if count == 1:
+        return word
+
+    if plural is not None:
+        return plural
+
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,34 @@
+"""Unit tests for text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_singular():
+    """Test singular count returns word unchanged."""
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_regular_plural():
+    """Test plural count returns word + 's'."""
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_custom_plural():
+    """Test that custom plural overrides default."""
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count():
+    """Test zero count uses plural form."""
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string():
+    """Test empty word returns empty string regardless of count."""
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #23

## What changed

- Added `scripts/text_helpers.py` with a single function `pluralize(word: str, count: int, *, plural: str | None = None) -> str` that returns the plural form of a word based on count.
- Added `tests/test_text_helpers.py` with five pytest cases covering singular, regular plural, custom plural, zero count, and empty string scenarios.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_text_helpers.py -v
```

```
collected 5 items
tests/test_text_helpers.py::test_pluralize_singular PASSED
tests/test_text_helpers.py::test_pluralize_regular_plural PASSED
tests/test_text_helpers.py::test_pluralize_custom_plural PASSED
tests/test_text_helpers.py::test_pluralize_zero_count PASSED
tests/test_text_helpers.py::test_pluralize_empty_string PASSED

5 passed in 0.09s
```

## Acceptance criteria coverage

- Implementation matches all behaviors described in the task body (see Notes): `pluralize()` follows the spec: returns `word` when `count == 1`, returns `plural` if provided else `word + "s"`, handles empty string returning empty string regardless of count.
- All named tests pass the verification command: Five pytest cases (singular, regular plural, custom plural, zero count, empty string) all pass; the verification command `pytest tests/test_text_helpers.py -v` exits 0.
- No dependencies added unless absolutely required: Only standard library imports (`sys`, `pathlib`, `pytest` for test runner); no new dependencies in `pyproject.toml`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — not violated: only `scripts/text_helpers.py` and `tests/test_text_helpers.py` were added.
- Do NOT add third-party dependencies unless required by the task body — not violated: no new dependencies introduced.
- Do NOT refactor unrelated code in the touched files — not violated: new module and test file only.

## Notes

- The test file follows existing repo convention (`sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))`).
- Ruff linting passes with zero errors after automatic fixes.
- Code style matches nearby helpers `dict_helpers.py` and `validate_plugins.py`.

### Coverage

- AC 1 (verbatim): ✓ addressed in `scripts/text_helpers.py:pluralize()` with explicit branches for empty string, `count == 1`, `plural is not None`, and default `f"{word}s"`.
- AC 2 (verbatim): ✓ addressed via `tests/test_text_helpers.py` containing five pytest functions covering all required cases; verification command `pytest tests/test_text_helpers.py -v` passes.
- AC 3 (verbatim): ✓ addressed because code uses only `sys`, `pathlib`, `pytest` (test framework), no new third‑party dependencies; all behavior is pure Python standard library.