### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,31 @@
+"""Text helper functions for Infiquetra Claude Plugins."""
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """
+    Pluralize a word based on count.
+
+    Args:
+        word: The singular form of the word
+        count: The number of items
+        plural: Optional custom plural form
+
+    Returns:
+        The appropriate form of the word based on count
+
+    Examples:
+        >>> pluralize("cat", 1)
+        'cat'
+        >>> pluralize("cat", 2)
+        'cats'
+        >>> pluralize("child", 2, plural="children")
+        'children'
+        >>> pluralize("", 5)
+        ''
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    if plural is not None:
+        return plural
+    return word + "s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,40 @@
+"""Tests for text_helpers.py."""
+
+
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_singular_for_count_one():
+    """Test that pluralize returns singular form when count is 1."""
+    assert pluralize("cat", 1) == "cat"
+    assert pluralize("dog", 1) == "dog"
+    assert pluralize("", 1) == ""
+
+
+def test_pluralize_appends_s_for_regular_plural():
+    """Test that pluralize appends 's' for regular plural forms."""
+    assert pluralize("cat", 2) == "cats"
+    assert pluralize("dog", 5) == "dogs"
+    assert pluralize("box", 0) == "boxs"
+
+
+def test_pluralize_uses_custom_plural_when_provided():
+    """Test that pluralize uses custom plural when provided."""
+    assert pluralize("child", 2, plural="children") == "children"
+    assert pluralize("person", 0, plural="people") == "people"
+    assert pluralize("mouse", 1, plural="mice") == "mouse"  # count=1 takes precedence
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    """Test that pluralize uses plural form for zero count."""
+    assert pluralize("cat", 0) == "cats"
+    assert pluralize("dog", 0) == "dogs"
+    assert pluralize("", 0) == ""
+
+
+def test_pluralize_empty_string_returns_empty_string():
+    """Test that pluralize returns empty string for empty input."""
+    assert pluralize("", 0) == ""
+    assert pluralize("", 1) == ""
+    assert pluralize("", 5) == ""
+    assert pluralize("", 100, plural="something") == ""


### PR DESCRIPTION
## Linked card

Closes #30

## What changed

- Created `scripts/text_helpers.py` with the `pluralize(word: str, count: int, *, plural: str | None = None) -> str` function
- Created `tests/test_text_helpers.py` with comprehensive test cases covering singular, regular plural, custom plural, zero count, and empty string scenarios

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```
Output: 5 passed

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v --cov=scripts --cov-report=term
```
Output: 5 passed, scripts/text_helpers.py: 100% coverage

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in scripts/text_helpers.py (function implementation) and tests/test_text_helpers.py (test cases)
- AC 2: All named tests pass the verification command ✓ addressed in tests/test_text_helpers.py (all 5 test cases pass)
- AC 3: No dependencies added unless absolutely required ✓ addressed in scripts/text_helpers.py (uses only standard library, no imports)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated (only modified scripts/text_helpers.py and tests/test_text_helpers.py)
- Do NOT add third-party dependencies unless required by the task body: not violated (no dependencies added)
- Do NOT refactor unrelated code in the touched files: not violated (both files are new, no refactoring of existing code)

## Notes

- Implementation follows the exact specification: empty string returns empty string regardless of count, count==1 returns word unchanged, otherwise returns custom plural if provided else word + 's'
- All tests pass with 100% coverage of the new module
- Code follows project standards: passes ruff linting, uses proper type hints, follows docstring conventions

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body ✓ addressed in scripts/text_helpers.py and tests/test_text_helpers.py
- AC 2 (verbatim): All named tests pass the verification command ✓ addressed in tests/test_text_helpers.py
- AC 3 (verbatim): No dependencies added unless absolutely required ✓ addressed in scripts/text_helpers.py