### PR TITLE
feat(scripts): add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """
+    Safely load a JSON file.
+
+    Returns default if the file does not exist, is empty, or contains invalid JSON.
+    Accepts both string and Path objects as input.
+    """
+    path = Path(path)
+
+    if not path.exists():
+        return default
+
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+        if not content:
+            return default
+        return json.loads(content)
+    except (json.JSONDecodeError, OSError):
+        return default

--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -12,7 +12,7 @@ def safe_json_load(path: str | Path, default: Any = None) -> Any:
     """
     path = Path(path)
 
-    if not path.exists():
+    if not path.is_file():
         return default
 
     try:
@@ -20,5 +20,5 @@ def safe_json_load(path: str | Path, default: Any = None) -> Any:
         if not content:
             return default
         return json.loads(content)
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError:
         return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -3,9 +3,10 @@ import json
 from scripts.json_helpers import safe_json_load
 
 
-def test_safe_json_load_returns_default_for_missing_file():
+def test_safe_json_load_returns_default_for_missing_file(tmp_path):
     """AC 1.1: Missing file returns default value instead of raising."""
-    result = safe_json_load("non_existent_file.json", default={"status": "missing"})
+    missing_file = tmp_path / "does_not_exist.json"
+    result = safe_json_load(missing_file, default={"status": "missing"})
     assert result == {"status": "missing"}
 
 

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,50 @@
+import json
+
+from scripts.json_helpers import safe_json_load
+
+
+def test_safe_json_load_returns_default_for_missing_file():
+    """AC 1.1: Missing file returns default value instead of raising."""
+    result = safe_json_load("non_existent_file.json", default={"status": "missing"})
+    assert result == {"status": "missing"}
+
+
+def test_safe_json_load_returns_default_for_empty_file(tmp_path):
+    """AC 1.2: Empty file returns default value."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("")
+
+    result = safe_json_load(empty_file, default=[])
+    assert result == []
+
+
+def test_safe_json_load_returns_default_for_malformed_json(tmp_path):
+    """AC 1.3: Malformed JSON returns default value."""
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{'invalid': json}")
+
+    result = safe_json_load(bad_file, default=None)
+    assert result is None
+
+
+def test_safe_json_load_returns_parsed_object_for_valid_json(tmp_path):
+    """AC 1.4: Valid JSON returns the parsed object."""
+    data = {"key": "value", "list": [1, 2, 3]}
+    good_file = tmp_path / "good.json"
+    good_file.write_text(json.dumps(data))
+
+    result = safe_json_load(good_file)
+    assert result == data
+
+
+def test_safe_json_load_accepts_str_and_path_inputs(tmp_path):
+    """AC 1.5: Accepts both str and Path types for the path argument."""
+    data = {"data": 42}
+    test_file = tmp_path / "test.json"
+    test_file.write_text(json.dumps(data))
+
+    # Test with string path
+    assert safe_json_load(str(test_file)) == data
+
+    # Test with Path object
+    assert safe_json_load(test_file) == data


### PR DESCRIPTION
## Linked card

Closes #31

## What changed

- Added `safe_json_load` helper to `scripts/json_helpers.py` that handles missing, empty, or malformed JSON files gracefully.
- Added comprehensive unit tests in `tests/test_json_helpers.py` covering all requirements.

## How verified

Ran pytest with PYTHONPATH set to project root:
```bash
PYTHONPATH=. ./venv/bin/pytest tests/test_json_helpers.py -v
```

Output digest:
```
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_missing_file PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_empty_file PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_malformed_json PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_parsed_object_for_valid_json PASSED
tests/test_json_helpers.py::test_safe_json_load_accepts_str_and_path_inputs PASSED
============================== 5 passed in 0.09s ===============================
```

## Acceptance criteria coverage

- AC 1: ✓ implementation matches all behaviors described in the task body (missing file, empty file, malformed JSON, valid JSON, Path vs str).
- AC 2: ✓ all named tests pass with `pytest`.
- AC 3: ✓ no external dependencies added; uses standard library `json`, `pathlib`, and `typing`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: ✓ only `scripts/json_helpers.py` and `tests/test_json_helpers.py` were touched.
- Do NOT add third-party dependencies: ✓ only standard library used.
- Do NOT refactor unrelated code: ✓ focus remained on adding the new helper and tests.

## Notes

- Used `encoding='utf-8'` and `strip()` on content to handle potential whitespace-only files.
- Added `PYTHONPATH=.` to the verification command as `scripts` is not registered as a package in `pyproject.toml`.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ addressed in scripts/json_helpers.py
- All named tests pass the verification command: ✓ addressed in tests/test_json_helpers.py
- No dependencies added unless absolutely required: ✓ addressed in scripts/json_helpers.py