### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,24 @@
+"""JSON loading helpers with graceful fallback on missing or invalid files."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from *path*, returning *default* on any failure.
+
+    Returns *default* when the file is missing, empty, or contains
+    malformed JSON. Returns the parsed object for valid JSON files.
+    Accepts both ``str`` and ``Path`` arguments.
+    """
+    p = Path(path)
+    if not p.exists():
+        return default
+    text = p.read_text()
+    if not text.strip():
+        return default
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,50 @@
+"""Tests for json_helpers.safe_json_load."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for non-package imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+def test_safe_json_load_missing_file_returns_none(tmp_path: Path) -> None:
+    """Missing file returns None when default is omitted."""
+    assert safe_json_load(tmp_path / "does_not_exist.json") is None
+
+
+def test_safe_json_load_missing_file_returns_default(tmp_path: Path) -> None:
+    """Missing file returns the provided default object."""
+    assert safe_json_load(tmp_path / "does_not_exist.json", default={}) == {}
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path: Path) -> None:
+    """Empty file returns the provided default."""
+    f = tmp_path / "empty.json"
+    f.write_text("")
+    assert safe_json_load(f, default=[]) == []
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path: Path) -> None:
+    """Malformed JSON returns the provided default."""
+    f = tmp_path / "broken.json"
+    f.write_text("{invalid json")
+    assert safe_json_load(f, default=[]) == []
+
+
+def test_safe_json_load_valid_json_returns_parsed_object(tmp_path: Path) -> None:
+    """Valid JSON returns the parsed Python object."""
+    f = tmp_path / "good.json"
+    f.write_text(json.dumps({"key": "value"}))
+    assert safe_json_load(f) == {"key": "value"}
+
+
+def test_safe_json_load_accepts_path_and_str(tmp_path: Path) -> None:
+    """Both Path and str arguments work against the same file."""
+    f = tmp_path / "good.json"
+    f.write_text(json.dumps([1, 2, 3]))
+    expected = [1, 2, 3]
+    assert safe_json_load(f) == expected
+    assert safe_json_load(str(f)) == expected


### PR DESCRIPTION
## Linked card

Closes #35

## What changed

- Added `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any` — a single focused helper that loads JSON from a file path, returning `default` when the file is missing, empty, or contains malformed JSON.
- Added `tests/test_json_helpers.py` with 6 pytest test functions covering all named scenarios.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_json_helpers.py -v
```

Output: 6 passed in 0.07s

```bash
ruff check scripts/json_helpers.py tests/test_json_helpers.py
```

Output: All checks passed!

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — `safe_json_load()` in `scripts/json_helpers.py` handles missing file, empty file, malformed JSON, valid JSON, and both `str`/`Path` inputs.
- AC 2: All named tests pass the verification command — 6/6 pytest cases pass.
- AC 3: No dependencies added unless absolutely required — only stdlib imports (`json`, `pathlib.Path`, `typing.Any`) plus existing pytest.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/json_helpers.py` and `tests/test_json_helpers.py` in diff.
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new dependencies.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new with focused content only.

## Notes

The `pyright` reportMissingImports error on `json_helpers` import in the test file is expected — the repo convention uses `sys.path.insert` for non-package script imports (same pattern in `test_slack_client.py`, `test_marketplace_client.py`). The import resolves correctly at pytest runtime.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/json_helpers.py` function `safe_json_load` + `tests/test_json_helpers.py` all 6 test functions
- All named tests pass the verification command: ✓ addressed in `tests/test_json_helpers.py` — 6/6 passed
- No dependencies added unless absolutely required: ✓ addressed in `scripts/json_helpers.py` — only stdlib imports