### PR TITLE
feat(scripts): add pluralize() text helper (#37)

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,35 @@
+"""Text helper functions for Infiquetra Claude Plugins."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the plural or singular form of a word based on its count.
+
+    Args:
+        word: The base word to pluralize
+        count: The number of items (1 = singular, otherwise plural)
+        plural: Optional custom plural form (e.g., "children" for "child")
+
+    Returns:
+        The singular form if count is 1, or the plural form if count != 1.
+        Returns empty string if word is empty, regardless of count.
+
+    Examples:
+        >>> pluralize("cat", 1)
+        'cat'
+        >>> pluralize("cat", 2)
+        'cats'
+        >>> pluralize("child", 2, plural="children")
+        'children'
+        >>> pluralize("", 5)
+        ''
+    """
+    if word == "":
+        return ""
+
+    if count == 1:
+        return word
+
+    if plural is not None:
+        return plural
+
+    return word + "s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,41 @@
+"""Tests for text_helpers module."""
+# ruff: noqa: E402
+
+import sys
+from pathlib import Path
+
+# Add the scripts directory to the path so we can import text_helpers
+scripts_path = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(scripts_path))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_singular():
+    """Test that count of 1 returns the singular form."""
+    result = pluralize("cat", 1)
+    assert result == "cat"
+
+
+def test_pluralize_regular_plural():
+    """Test that count of 2 returns the regular plural form (word + s)."""
+    result = pluralize("cat", 2)
+    assert result == "cats"
+
+
+def test_pluralize_custom_plural():
+    """Test that custom plural form is used when provided."""
+    result = pluralize("child", 2, plural="children")
+    assert result == "children"
+
+
+def test_pluralize_zero_count():
+    """Test that count of 0 returns the plural form."""
+    result = pluralize("cat", 0)
+    assert result == "cats"
+
+
+def test_pluralize_empty_string():
+    """Test that empty string returns empty string regardless of count."""
+    result = pluralize("", 5)
+    assert result == ""


### PR DESCRIPTION
## Linked card

Closes #37

## What changed

- Added scripts/text_helpers.py with pluralize() helper function
- Added tests/test_text_helpers.py with 5 pytest test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
.venv/bin/pytest tests/test_text_helpers.py -v
```

All 5 tests passed.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in scripts/text_helpers.py - the pluralize() function implements all required behaviors including empty string handling, singular form for count=1, custom plural override, and default pluralization with +s suffix
- AC 2 (All named tests pass): ✓ addressed in tests/test_text_helpers.py - the tests cover all 5 named scenarios (singular, regular plural, custom plural, zero count, empty string) and all pass
- AC 3 (No dependencies added): ✓ - the implementation uses only Python standard library, no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only scripts/text_helpers.py and tests/test_text_helpers.py were modified
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - only new files were added, no refactoring of existing code
