### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,39 @@
+"""Dictionary helper utilities for nested path lookups."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Retrieve a value from a nested dict using a dotted path string.
+
+    Args:
+        data: The dictionary to search.
+        path: A dotted string path like "a.b.c" to traverse.
+        default: The value to return if any step fails (default: None).
+
+    Returns:
+        The value at the path if found, otherwise the default.
+
+    Examples:
+        >>> get_nested({"a": {"b": 1}}, "a.b")
+        1
+        >>> get_nested({"a": {"b": 1}}, "a.c", default=-1)
+        -1
+        >>> get_nested({"a": 1}, "a.b")
+        None
+        >>> get_nested({}, "")
+        {}
+    """
+    if path == "":
+        return data
+
+    current_value: Any = data
+
+    for segment in path.split("."):
+        if not isinstance(current_value, dict):
+            return default
+        if segment not in current_value:
+            return default
+        current_value = current_value[segment]
+
+    return current_value

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,42 @@
+"""Unit tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+class TestGetNested:
+    """Test get_nested function."""
+
+    def test_get_nested_happy_path(self):
+        """Test basic nested lookup returns the correct value."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "a.b")
+        assert result == 1
+
+    def test_get_nested_missing_key_returns_default(self):
+        """Test missing key returns the provided default value."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "a.c", default=-1)
+        assert result == -1
+
+    def test_get_nested_non_dict_step_returns_default(self):
+        """Test stepping into a non-dict returns default."""
+        data = {"a": 1}
+        result = get_nested(data, "a.b")
+        assert result is None
+
+    def test_get_nested_empty_path_returns_data(self):
+        """Test empty path returns the entire data dict."""
+        data = {}
+        result = get_nested(data, "")
+        assert result == {}
+
+    def test_get_nested_three_level_lookup(self):
+        """Test three-level nested lookup."""
+        data = {"a": {"b": {"c": 2}}}
+        result = get_nested(data, "a.b.c")
+        assert result == 2


### PR DESCRIPTION
## Linked card

Closes #43

## What changed

- Created `scripts/dict_helpers.py` with `get_nested(data, path, default)` function
- Created `tests/test_dict_helpers.py` with 5 pytest cases covering all required behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_dict_helpers.py -v
```

```
============================= test session starts ==============================
collected 5 items
tests/test_dict_helpers.py::TestGetNested::test_get_nested_happy_path PASSED [ 20%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_missing_key_returns_default PASSED [ 40%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_non_dict_step_returns_default PASSED [ 60%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_empty_path_returns_data PASSED [ 80%]
tests/test_dict_helpers.py::TestGetNested::test_get_nested_three_level_lookup PASSED [100%]
============================== 5 passed in 0.06s ===============================
```

```bash
ruff check scripts/dict_helpers.py tests/test_dict_helpers.py
```

```
All checks passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ — `get_nested()` handles empty path, dotted traversal, non-dict steps, missing keys, and returns default appropriately
- AC 2: All named tests pass the verification command ✓ — 5 tests pass: `test_get_nested_happy_path`, `test_get_nested_missing_key_returns_default`, `test_get_nested_non_dict_step_returns_default`, `test_get_nested_empty_path_returns_data`, `test_get_nested_three_level_lookup`
- AC 3: No dependencies added unless absolutely required ✓ — only stdlib `typing.Any` used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: ✓ only `scripts/dict_helpers.py` and `tests/test_dict_helpers.py` changed
- Do NOT add third-party dependencies unless required: ✓ no new dependencies
- Do NOT refactor unrelated code in the touched files: ✓ no refactors, only new code

## Notes

None — implementation followed the approved plan exactly.

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body (see Notes) ✓ addressed in scripts/dict_helpers.py:get_nested()
- AC 2 (verbatim): All named tests pass the verification command ✓ addressed in tests/test_dict_helpers.py with 5 test functions
- AC 3 (verbatim): No dependencies added unless absolutely required ✓ addressed — stdlib only