### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,22 @@
+"""Text helpers for Infiquetra Claude Code plugins."""
+
+from __future__ import annotations
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of a word based on count.
+
+    Args:
+        word: The singular form of the word.
+        count: The count to determine singular vs plural.
+        plural: Optional custom plural form. If not provided, appends "s".
+
+    Returns:
+        The word unchanged if count is 1, otherwise the plural form.
+        Returns empty string if word is empty, regardless of count.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else word + "s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,36 @@
+"""Tests for scripts.text_helpers."""
+
+import sys
+from pathlib import Path
+
+# Add repo root to path so "scripts" is importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.text_helpers import pluralize
+
+
+class TestPluralize:
+    def test_pluralize_singular(self) -> None:
+        """count == 1 returns word unchanged."""
+        result = pluralize("cat", 1)
+        assert result == "cat"
+
+    def test_pluralize_regular_plural(self) -> None:
+        """count != 1 without custom plural appends 's'."""
+        result = pluralize("cat", 2)
+        assert result == "cats"
+
+    def test_pluralize_custom_plural(self) -> None:
+        """count != 1 with custom plural returns the custom form."""
+        result = pluralize("child", 2, plural="children")
+        assert result == "children"
+
+    def test_pluralize_zero_count(self) -> None:
+        """count == 0 returns plural form."""
+        result = pluralize("cat", 0)
+        assert result == "cats"
+
+    def test_pluralize_empty_string(self) -> None:
+        """Empty word returns empty string regardless of count."""
+        result = pluralize("", 5)
+        assert result == ""


### PR DESCRIPTION
## Linked card

Closes #44

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word, count, *, plural=None)` helper
- Created `tests/test_text_helpers.py` with 5 pytest cases covering singular, regular plural, custom plural, zero count, and empty string

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_text_helpers.py -v --override-ini="addopts=-v"
```

Output:
```
============================= test session starts ==============================
collected 5 items
tests/test_text_helpers.py::TestPluralize::test_pluralize_singular PASSED
tests/test_text_helpers.py::TestPluralize::test_pluralize_regular_plural PASSED
tests/test_text_helpers.py::TestPluralize::test_pluralize_custom_plural PASSED
tests/test_text_helpers.py::TestPluralize::test_pluralize_zero_count PASSED
tests/test_text_helpers.py::TestPluralize::test_pluralize_empty_string PASSED
============================== 5 passed in 0.08s ===============================
```

Ruff linting:
```
ruff check scripts/text_helpers.py tests/test_text_helpers.py
All checks passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in `scripts/text_helpers.py:pluralize()`
- AC 2: All named tests pass the verification command ✓ addressed in `tests/test_text_helpers.py` (5 tests passing)
- AC 3: No dependencies added unless absolutely required ✓ standard library only

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — new files only

## Notes

None — implementation follows the approved plan exactly.

### Coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in scripts/text_helpers.py:pluralize()
- AC 2: All named tests pass the verification command ✓ addressed in tests/test_text_helpers.py
- AC 3: No dependencies added unless absolutely required ✓ addressed in scripts/text_helpers.py (stdlib only)