### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,13 @@
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """
+    Pluralizes a word based on the count.
+
+    If the word is empty, returns an empty string.
+    If count is 1, returns the word unchanged.
+    Otherwise, returns the custom plural if provided, or the word with 's' appended.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,16 @@
+from scripts.text_helpers import pluralize
+
+def test_pluralize_singular_returns_word():
+    assert pluralize("cat", 1) == "cat"
+
+def test_pluralize_regular_plural_adds_s():
+    assert pluralize("cat", 2) == "cats"
+
+def test_pluralize_custom_plural_uses_override():
+    assert pluralize("child", 2, plural="children") == "children"
+
+def test_pluralize_zero_count_uses_plural_form():
+    assert pluralize("cat", 0) == "cats"
+
+def test_pluralize_empty_string_returns_empty_string():
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #46

## What changed

- Created `scripts/text_helpers.py` with `pluralize()` helper.
- Added `scripts/__init__.py` to make the scripts directory a package for easier test imports.
- Added `tests/test_text_helpers.py` with comprehensive test cases covering singular, plural, custom plural, zero count, and empty strings.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
PYTHONPATH=. pytest tests/test_text_helpers.py -v
```

Output:
```
tests/test_text_helpers.py::test_pluralize_singular_returns_word PASSED
tests/test_text_helpers.py::test_pluralize_regular_plural_adds_s PASSED
tests/test_text_helpers.py::test_pluralize_custom_plural_uses_override PASSED
tests/test_text_helpers.py::test_pluralize_zero_count_uses_plural_form PASSED
tests/test_text_helpers.py::test_pluralize_empty_string_returns_empty_string PASSED
============================== 5 passed in 0.06s =============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches behaviors (word=, count=1, plural override) -> verified in `scripts/text_helpers.py`.
- AC 2: All named tests pass the verification command -> verified via `pytest tests/test_text_helpers.py`.
- AC 3: No dependencies added -> verified; only standard library used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated (only scripts/ and tests/ touched).
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

Added `scripts/__init__.py` to resolve  during pytest collection.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/text_helpers.py`/
- All named tests pass the verification command: ✓ addressed in `tests/test_text_helpers.py`
- No dependencies added unless absolutely required: ✓ addressed in `scripts/text_helpers.py`