### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""JSON helper functions for Infiquetra Claude Code plugins."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """
+    Safely load JSON from a file, returning a default value on any error.
+
+    Args:
+        path: File path as string or Path object
+        default: Value to return if file is missing, empty, or invalid JSON
+
+    Returns:
+        Parsed JSON object or default value
+    """
+    file_path = Path(path)
+
+    # Return default if file doesn't exist
+    if not file_path.exists():
+        return default
+
+    # Return default if file is empty
+    if file_path.stat().st_size == 0:
+        return default
+
+    # Try to parse JSON, return default on any error
+    try:
+        return json.loads(file_path.read_text())
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,64 @@
+"""Unit tests for json_helpers.py."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for import
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+def test_missing_file_returns_none(tmp_path):
+    """Test that missing file returns None."""
+    missing_file = tmp_path / "missing.json"
+    result = safe_json_load(missing_file)
+    assert result is None
+
+
+def test_missing_file_returns_default(tmp_path):
+    """Test that missing file returns provided default."""
+    missing_file = tmp_path / "missing.json"
+    result = safe_json_load(missing_file, default={})
+    assert result == {}
+
+
+def test_empty_file_returns_default(tmp_path):
+    """Test that empty file returns provided default."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("")
+    result = safe_json_load(empty_file, default=[])
+    assert result == []
+
+
+def test_malformed_json_returns_default(tmp_path):
+    """Test that malformed JSON returns provided default."""
+    malformed_file = tmp_path / "malformed.json"
+    malformed_file.write_text('{"invalid": json}')
+    result = safe_json_load(malformed_file, default={"error": True})
+    assert result == {"error": True}
+
+
+def test_valid_json_returns_parsed(tmp_path):
+    """Test that valid JSON returns parsed object."""
+    valid_file = tmp_path / "valid.json"
+    test_data = {"key": "value", "number": 42}
+    valid_file.write_text(json.dumps(test_data))
+    result = safe_json_load(valid_file)
+    assert result == test_data
+
+
+def test_path_and_str_inputs_work(tmp_path):
+    """Test that both Path and str inputs work."""
+    test_file = tmp_path / "test.json"
+    test_data = {"test": "data"}
+    test_file.write_text(json.dumps(test_data))
+    
+    # Test with str path
+    result_str = safe_json_load(str(test_file))
+    assert result_str == test_data
+    
+    # Test with Path object
+    result_path = safe_json_load(test_file)
+    assert result_path == test_data


### PR DESCRIPTION
## Linked card

Closes #48

## What changed

- Added `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any` function
- Added `tests/test_json_helpers.py` with comprehensive test coverage for all required cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_json_helpers.py -v
```
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
collecting ... collected 6 items

tests/test_json_helpers.py::test_missing_file_returns_none PASSED        [ 16%]
tests/test_json_helpers.py::test_missing_file_returns_default PASSED     [ 33%]
tests/test_json_helpers.py::test_empty_file_returns_default PASSED       [ 50%]
tests/test_json_helpers.py::test_malformed_json_returns_default PASSED   [ 66%]
tests/test_json_helpers.py::test_valid_json_returns_parsed PASSED        [ 83%]
tests/test_json_helpers.py::test_path_and_str_inputs_work PASSED         [100%]

============================== 6 passed in 0.04s ===============================
```

## Acceptance criteria coverage

- AC 1: ✓ addressed in scripts/json_helpers.py (safe_json_load function implementation)
- AC 2: ✓ addressed in tests/test_json_helpers.py (all named test cases pass)
- AC 3: ✓ addressed (no dependencies added - uses only standard library)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated  
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

- Implementation follows the repository's existing script style seen in scripts/validate_plugins.py
- Uses pathlib.Path for modern, type-safe file operations
- Function handles all specified error cases gracefully without raising exceptions
- Both str and Path inputs are supported through Path() normalization

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in scripts/json_helpers.py
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_json_helpers.py
- AC 3 (No dependencies added unless absolutely required): ✓ addressed (uses only json, pathlib, typing from standard library)