### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,31 @@
+"""JSON file loading helpers with safe fallback behavior."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """
+    Safely load JSON from a file, returning default on any error.
+
+    Args:
+        path: Path to the JSON file (str or Path).
+        default: Value to return if file doesn't exist, is empty, or contains invalid JSON.
+
+    Returns:
+        Parsed JSON object if successful, otherwise the default value.
+    """
+    path = Path(path)
+
+    if not path.exists():
+        return default
+
+    content = path.read_text().strip()
+    if not content:
+        return default
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,74 @@
+"""Unit tests for json_helpers.py."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+class TestSafeJsonLoad:
+    """Test safe_json_load function."""
+
+    def test_missing_file_returns_none_default(self, tmp_path: Path) -> None:
+        """Test that missing file returns None when default is omitted."""
+        result = safe_json_load(str(tmp_path / "nonexistent.json"))
+        assert result is None
+
+    def test_missing_file_returns_custom_default(self, tmp_path: Path) -> None:
+        """Test that missing file returns custom default."""
+        result = safe_json_load(str(tmp_path / "nonexistent.json"), default={})
+        assert result == {}
+
+    def test_empty_file_returns_default(self, tmp_path: Path) -> None:
+        """Test that empty file returns the provided default."""
+        empty_file = tmp_path / "empty.json"
+        empty_file.write_text("")
+        result = safe_json_load(str(empty_file), default=[])
+        assert result == []
+
+    def test_empty_file_with_whitespace_returns_default(self, tmp_path: Path) -> None:
+        """Test that file with only whitespace returns default."""
+        empty_file = tmp_path / "whitespace.json"
+        empty_file.write_text("   \n  \t  ")
+        result = safe_json_load(str(empty_file), default={})
+        assert result == {}
+
+    def test_malformed_json_returns_default(self, tmp_path: Path) -> None:
+        """Test that malformed JSON returns the provided default."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{invalid json")
+        result = safe_json_load(str(bad_file), default="fallback")
+        assert result == "fallback"
+
+    def test_valid_json_returns_parsed_object(self, tmp_path: Path) -> None:
+        """Test that valid JSON returns the parsed object."""
+        good_file = tmp_path / "good.json"
+        test_obj = {"name": "test", "value": 42}
+        good_file.write_text(json.dumps(test_obj))
+        result = safe_json_load(str(good_file))
+        assert result == test_obj
+
+    def test_str_path_argument(self, tmp_path: Path) -> None:
+        """Test that str path argument works correctly."""
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"key": "value"}')
+        result = safe_json_load(str(test_file))
+        assert result == {"key": "value"}
+
+    def test_path_argument(self, tmp_path: Path) -> None:
+        """Test that Path argument works correctly."""
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"key": "value"}')
+        result = safe_json_load(test_file)
+        assert result == {"key": "value"}
+
+    def test_path_vs_str_same_result(self, tmp_path: Path) -> None:
+        """Test that Path and str arguments produce the same result."""
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"x": 1}')
+        result_str = safe_json_load(str(test_file))
+        result_path = safe_json_load(test_file)
+        assert result_str == result_path


### PR DESCRIPTION
## Linked card

Closes #49

## What changed

- Added new helper function  in 
- Added comprehensive pytest tests in  with 9 test cases

## How verified

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0
collecting ... collected 9 items

tests/test_json_helpers.py::TestSafeJsonLoad::test_missing_file_returns_none_default PASSED [ 11%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_missing_file_returns_custom_default PASSED [ 22%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_empty_file_returns_default PASSED [ 33%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_empty_file_with_whitespace_returns_default PASSED [ 44%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_malformed_json_returns_default PASSED [ 55%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_valid_json_returns_parsed_object PASSED [ 66%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_str_path_argument PASSED [ 77%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_path_argument PASSED  [ 88%]
tests/test_json_helpers.py::TestSafeJsonLoad::test_path_vs_str_same_result PASSED [100%]
WARNING: Failed to generate report: No data to report.



============================== 9 passed in 0.08s ===============================

Test output:


## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Implementation includes all behaviors - returns default for missing files, empty files, malformed JSON, and returns parsed result for valid JSON. Both str and Path arguments are supported.

- AC 2 (All named tests pass the verification command): All 9 tests in  pass with pytest.

- AC 3 (No dependencies added unless absolutely required): No new dependencies. Implementation uses only Python standard library modules (, , ).

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Not violated - only  and  were modified.

- Do NOT add third-party dependencies unless required by the task body: Not violated - no dependencies added.

- Do NOT refactor unrelated code in the touched files: Not violated - only new files created with the required functionality.

## Notes

Followed CLAUDE.md conventions for Python plugins:
- Snake case for file names ()
- PEP 8 compliant
- Type hints on public functions
- pytest fixtures used for testing