### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,38 @@
+"""Dictionary helper functions for path-based lookups."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default=None) -> Any:
+    """
+    Get a value from a nested dictionary using a dotted path.
+
+    Args:
+        data: The dictionary to search.
+        path: A dotted path like "a.b.c".
+        default: The value to return if the path is not found.
+
+    Returns:
+        The value at the path, or default if not found.
+        Returns data unchanged if path is empty.
+
+    Examples:
+        >>> get_nested({"a": {"b": 1}}, "a.b")
+        1
+        >>> get_nested({"a": {"b": 1}}, "a.c", default=-1)
+        -1
+        >>> get_nested({"a": 1}, "a.b")
+        None
+        >>> get_nested({}, "")
+        {}
+    """
+    if path == "":
+        return data
+
+    current: Any = data
+    for key in path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,47 @@
+"""Unit tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+def test_get_nested_returns_value_for_happy_path():
+    """Test that get_nested returns the value for a valid path."""
+    data = {"a": {"b": 1}}
+    result = get_nested(data, "a.b")
+    assert result == 1
+
+
+def test_get_nested_returns_default_for_missing_key():
+    """Test that get_nested returns default when key is missing."""
+    data = {"a": {"b": 1}}
+    result = get_nested(data, "a.c", default=-1)
+    assert result == -1
+
+
+def test_get_nested_returns_default_when_stepping_into_non_dict():
+    """Test that get_nested returns default when traversing into a non-dict value."""
+    data = {"a": 1}
+    result = get_nested(data, "a.b")
+    assert result is None
+
+
+def test_get_nested_returns_data_for_empty_path():
+    """Test that get_nested returns data unchanged for empty path."""
+    data = {}
+    result = get_nested(data, "")
+    assert result == {}
+    assert result is data
+
+
+def test_get_nested_supports_three_or_more_levels():
+    """Test that get_nested supports deeply nested paths (3+ levels)."""
+    data = {"a": {"b": {"c": "value"}}}
+    result = get_nested(data, "a.b.c")
+    assert result == "value"
+    # Verify no mutation occurred
+    assert data == {"a": {"b": {"c": "value"}}}


### PR DESCRIPTION
## Linked card

Closes #59

## What changed

- Created `scripts/dict_helpers.py` with the `get_nested()` helper function
- Created `tests/test_dict_helpers.py` with 5 named pytest test cases
- `get_nested(data: dict, path: str, default=None) -> Any` traverses dotted paths like "a.b.c"
- Returns `default` when path segment is missing or when traversing into a non-dict value
- Empty path returns original data unchanged (no mutation)

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_dict_helpers.py -v -o addopts="" --override-ini="addopts="
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
collecting ... collected 5 items

tests/test_dict_helpers.py::test_get_nested_returns_value_for_happy_path PASSED [ 20%]
tests/test_dict_helpers.py::test_get_nested_returns_default_for_missing_key PASSED [ 40%]
tests/test_dict_helpers.py::test_get_nested_returns_default_when_stepping_into_non_dict PASSED [ 60%]
tests/test_dict_helpers.py::test_get_nested_returns_data_for_empty_path PASSED [ 80%]
tests/test_dict_helpers.py::test_get_nested_supports_three_or_more_levels PASSED [100%]

============================== 5 passed in 0.02s ===============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body → ✓ addressed in `scripts/dict_helpers.py` function `get_nested(data, path, default=None)`
  - Dotted path traversal: `path.split(".")` iterates through segments
  - Returns default on missing key: `key not in current` returns `default`
  - Returns default when stepping into non-dict: `not isinstance(current, dict)` returns `default`
  - Empty path returns data: `if path == "": return data`
  - No mutation: cursor-based traversal without modifying input
  
- AC 2: All named tests pass the verification command → ✓ addressed in `tests/test_dict_helpers.py`
  - `test_get_nested_returns_value_for_happy_path`
  - `test_get_nested_returns_default_for_missing_key`
  - `test_get_nested_returns_default_when_stepping_into_non_dict`
  - `test_get_nested_returns_data_for_empty_path`
  - `test_get_nested_supports_three_or_more_levels`
  
- AC 3: No dependencies added unless absolutely required → ✓ satisfied
  - Uses only `typing.Any` from standard library
  - No pyproject.toml, requirements.txt, or lockfile changes

## Non-goals acknowledged

- Did NOT modify files beyond `scripts/dict_helpers.py` and `tests/test_dict_helpers.py`
- Did NOT add third-party dependencies
- Did NOT refactor unrelated code in touched files

## Notes

- Implementation follows the exact plan with no deviations
- Verified `get_nested({}, "") == {}` and `get_nested(data, "") is data` in empty path test
- Ran `ruff check` on both files — all checks passed