### PR TITLE
feat(scripts): add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default=None) -> Any:
+    """
+    Walks a dictionary using a dotted path and returns the deepest match.
+
+    Args:
+        data: The dictionary to traverse.
+        path: A dotted string representing the path (e.g., "a.b.c").
+        default: Value to return if any key in the path is missing or if
+                 a step in the path is not a dictionary.
+
+    Returns:
+        The value at the end of the path, or the default value.
+    """
+    if path == "":
+        return data
+
+    current = data
+    for key in path.split("."):
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,25 @@
+import pytest
+from scripts.dict_helpers import get_nested
+
+def test_get_nested_returns_value_for_existing_path():
+    """Happy path: existing nested key should return the value."""
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+def test_get_nested_returns_default_for_missing_key():
+    """Missing key should return the provided default value."""
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+def test_get_nested_returns_default_when_step_is_not_dict():
+    """Stepping into a non-dict value should return the default."""
+    assert get_nested({"a": 1}, "a.b") is None
+
+def test_get_nested_empty_path_returns_data():
+    """Empty path should return the entire input dictionary."""
+    data = {"a": 1}
+    assert get_nested(data, "") == {"a": 1}
+    # Also verify empty dict case from requirements
+    assert get_nested({}, "") == {}
+
+def test_get_nested_supports_three_or_more_levels():
+    """Deeply nested lookups (3+ levels) should work correctly."""
+    assert get_nested({"a": {"b": {"c": "value"}}}, "a.b.c") == "value"


### PR DESCRIPTION
## Linked card

Closes #65

## What changed

- Created  and implemented .
- Added  to make the scripts directory a package for testing.
- Created  with comprehensive test coverage for happy path, missing keys, non-dict traversal, empty paths, and deep nesting.

## How verified

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0
collecting ... collected 5 items

tests/test_dict_helpers.py::test_get_nested_returns_value_for_existing_path PASSED [ 20%]
tests/test_dict_helpers.py::test_get_nested_returns_default_for_missing_key PASSED [ 40%]
tests/test_dict_helpers.py::test_get_nested_returns_default_when_step_is_not_dict PASSED [ 60%]
tests/test_dict_helpers.py::test_get_nested_empty_path_returns_data PASSED [ 80%]
tests/test_dict_helpers.py::test_get_nested_supports_three_or_more_levels PASSED [100%]
WARNING: Failed to generate report: No data to report.



============================== 5 passed in 0.06s ===============================
Output:
5 passed in 0.06s

## Acceptance criteria coverage

- AC 1: Implementation of  matches all required behaviors, including dotted path traversal, default values for missing keys or non-dicts, and handling empty paths.
- AC 2: All 5 named tests in  passed successfully.
- AC 3: No third-party dependencies were added; only standard library  is used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only ,  (required for imports), and  were modified.
- Do NOT add third-party dependencies: none added.
- Do NOT refactor unrelated code: no unrelated code was touched.

## Notes

- Added  to allow ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
testpaths: tests, plugins/*/tests
plugins: cov-7.1.0
collecting ... {"error": "todoist-api-python not installed", "message": "Install with: pip install 'todoist-api-python>=3.1.0,<4.0.0'"}
collected 135 items / 1 error
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/agent/workspace/infiquetra/infiquetra-claude-plugins/plugins/todoist-manager/skills/todoist-manage/scripts/todoist_client.py", line 28, in <module>
INTERNALERROR>     from todoist_api_python.api import TodoistAPI
INTERNALERROR> ModuleNotFoundError: No module named 'todoist_api_python'
INTERNALERROR> 
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR> 
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 318, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 371, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     raise exception
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/logging.py", line 788, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/warnings.py", line 98, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/config/__init__.py", line 1409, in pytest_collection
INTERNALERROR>     return (yield)
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 382, in pytest_collection
INTERNALERROR>     session.perform_collect()
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 857, in perform_collect
INTERNALERROR>     self.items.extend(self.genitems(node))
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 1023, in genitems
INTERNALERROR>     yield from self.genitems(subnode)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 1020, in genitems
INTERNALERROR>     rep, duplicate = self._collect_one_node(node, handle_dupes)
INTERNALERROR>                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/main.py", line 883, in _collect_one_node
INTERNALERROR>     rep = collect_one_node(node)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/runner.py", line 576, in collect_one_node
INTERNALERROR>     rep: CollectReport = ihook.pytest_make_collect_report(collector=collector)
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     raise exception
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/capture.py", line 880, in pytest_make_collect_report
INTERNALERROR>     rep = yield
INTERNALERROR>           ^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/runner.py", line 400, in pytest_make_collect_report
INTERNALERROR>     call = CallInfo.from_call(
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/runner.py", line 353, in from_call
INTERNALERROR>     result: TResult | None = func()
INTERNALERROR>                              ^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/runner.py", line 398, in collect
INTERNALERROR>     return list(collector.collect())
INTERNALERROR>                 ^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/python.py", line 563, in collect
INTERNALERROR>     self._register_setup_module_fixture()
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/python.py", line 576, in _register_setup_module_fixture
INTERNALERROR>     self.obj, ("setUpModule", "setup_module")
INTERNALERROR>     ^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/python.py", line 289, in obj
INTERNALERROR>     self._obj = obj = self._getobj()
INTERNALERROR>                       ^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/python.py", line 560, in _getobj
INTERNALERROR>     return importtestmodule(self.path, self.config)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/python.py", line 507, in importtestmodule
INTERNALERROR>     mod = import_path(
INTERNALERROR>           ^^^^^^^^^^^^
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/pathlib.py", line 587, in import_path
INTERNALERROR>     importlib.import_module(module_name)
INTERNALERROR>   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
INTERNALERROR>     return _bootstrap._gcd_import(name[level:], package, level)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
INTERNALERROR>   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
INTERNALERROR>   File "/home/agent/.local/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 197, in exec_module
INTERNALERROR>     exec(co, module.__dict__)
INTERNALERROR>   File "/home/agent/workspace/infiquetra/infiquetra-claude-plugins/tests/test_todoist_client.py", line 22, in <module>
INTERNALERROR>     from todoist_client import TodoistClient
INTERNALERROR>   File "/home/agent/workspace/infiquetra/infiquetra-claude-plugins/plugins/todoist-manager/skills/todoist-manage/scripts/todoist_client.py", line 46, in <module>
INTERNALERROR>     sys.exit(1)
INTERNALERROR> SystemExit: 1

=============================== 1 error in 5.21s =============================== to import  correctly.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in 
- AC 2 (All named tests pass the verification command): ✓ addressed in 
- AC 3 (No dependencies added unless absolutely required): ✓ addressed in 