### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,20 @@
+"""JSON loading helpers with safe fallback behavior."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from *path*, returning *default* for missing/empty/invalid files."""
+    path_obj = Path(path)
+    if not path_obj.exists():
+        return default
+    try:
+        content = path_obj.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return default
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,39 @@
+"""Unit tests for json_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+def test_safe_json_load_missing_file_returns_default(tmp_path):
+    missing = tmp_path / "missing.json"
+    assert safe_json_load(missing) is None
+    assert safe_json_load(missing, default={}) == {}
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path):
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    assert safe_json_load(empty, default=[]) == []
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path):
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not valid json", encoding="utf-8")
+    assert safe_json_load(broken, default=[]) == []
+
+
+def test_safe_json_load_valid_json_returns_parsed_result(tmp_path):
+    good = tmp_path / "good.json"
+    good.write_text('{"name": "infiquetra", "enabled": true}', encoding="utf-8")
+    assert safe_json_load(good) == {"name": "infiquetra", "enabled": True}
+
+
+def test_safe_json_load_accepts_str_and_path(tmp_path):
+    good = tmp_path / "good.json"
+    good.write_text('{"key": "value"}', encoding="utf-8")
+    assert safe_json_load(good) == safe_json_load(str(good))
+    assert safe_json_load(good) == {"key": "value"}


### PR DESCRIPTION
## Linked card

Closes #70

## What changed

- Created `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any` that returns parsed JSON for valid files and `default` for missing, empty, or malformed files
- Created `tests/test_json_helpers.py` with 5 pytest test cases covering all named behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_json_helpers.py -v
# 5 passed in 0.07s

ruff check scripts/json_helpers.py tests/test_json_helpers.py
# All checks passed!
```

Note: full `pytest` suite has a pre-existing failure in `tests/test_todoist_client.py` (TodoistClient calls `sys.exit(1)` at import when env vars are missing). This is unrelated to this change — the targeted test file passes cleanly.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — `safe_json_load` returns `default` for missing files (line 13), `default` for empty/malformed JSON via `json.JSONDecodeError` catch (lines 19-20), parsed result for valid JSON (line 18), accepts both `str` and `Path` via `Path(path)` conversion (line 12).
- AC 2: All named tests pass the verification command — 5 tests in `tests/test_json_helpers.py` all pass (`pytest tests/test_json_helpers.py -v` exits 0).
- AC 3: No dependencies added unless absolutely required — only stdlib imports (`json`, `pathlib.Path`, `typing.Any`); no `pyproject.toml` changes.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/json_helpers.py` and `tests/test_json_helpers.py` changed
- Do NOT add third-party dependencies: not violated — no new dependencies added
- Do NOT refactor unrelated code: not violated — both files are new

## Notes

Pre-existing `pytest` suite failure in `todoist_client.py` (unrelated `sys.exit(1)` at import) prevents full-suite green, but the card's targeted verification command for the new file passes cleanly.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/json_helpers.py / safe_json_load()
- All named tests pass the verification command: ✓ addressed in tests/test_json_helpers.py (5/5 passing)
- No dependencies added unless absolutely required: ✓ addressed — only stdlib imports, no pyproject.toml changes