### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,24 @@
+"""JSON helper utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from *path* and return the parsed object.
+
+    If *path* does not exist, is empty, or contains invalid JSON,
+    return *default* instead of raising.
+    """
+    json_path = Path(path)
+    if not json_path.exists():
+        return default
+
+    try:
+        content = json_path.read_text(encoding="utf-8")
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,51 @@
+"""Unit tests for json_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load
+
+
+def test_safe_json_load_missing_file_returns_default(tmp_path):
+    missing_path = tmp_path / "missing.json"
+
+    assert safe_json_load(missing_path) is None
+    assert safe_json_load(missing_path, default={}) == {}
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path):
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text("", encoding="utf-8")
+
+    assert safe_json_load(empty_path, default=[]) == []
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path):
+    broken_path = tmp_path / "broken.json"
+    broken_path.write_text("{", encoding="utf-8")
+
+    assert safe_json_load(broken_path, default=[]) == []
+
+
+def test_safe_json_load_valid_json_returns_parsed_result(tmp_path):
+    valid_path = tmp_path / "valid.json"
+    valid_path.write_text(
+        '{"name": "infiquetra", "enabled": true}',
+        encoding="utf-8",
+    )
+
+    result = safe_json_load(valid_path)
+    assert result == {"name": "infiquetra", "enabled": True}
+
+
+def test_safe_json_load_accepts_path_and_str_arguments(tmp_path):
+    valid_path = tmp_path / "valid.json"
+    valid_path.write_text(
+        '{"name": "infiquetra", "enabled": true}',
+        encoding="utf-8",
+    )
+
+    assert safe_json_load(valid_path) == {"name": "infiquetra", "enabled": True}
+    assert safe_json_load(str(valid_path)) == {"name": "infiquetra", "enabled": True}


### PR DESCRIPTION
## Linked card

Closes #71

## What changed

- `scripts/json_helpers.py` (new): Added `safe_json_load(path: str | Path, default=None) -> Any` helper. Converts input to `Path`, returns `default` for missing/empty/malformed JSON, otherwise returns parsed JSON object.
- `tests/test_json_helpers.py` (new): Five pytest test functions covering missing file, empty file, malformed JSON, valid JSON, and Path-vs-str arguments.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
.venv/bin/pytest tests/test_json_helpers.py -v
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0
collected 5 items

tests/test_json_helpers.py::test_safe_json_load_missing_file_returns_default PASSED [ 20%]
tests/test_json_helpers.py::test_safe_json_load_empty_file_returns_default PASSED [ 40%]
tests/test_json_helpers.py::test_safe_json_load_malformed_json_returns_default PASSED [ 60%]
tests/test_json_helpers.py::test_safe_json_load_valid_json_returns_parsed_result PASSED [ 80%]
tests/test_json_helpers.py::test_safe_json_load_accepts_path_and_str_arguments PASSED [100%]

============================== 5 passed in 0.07s ===============================
```

`ruff check scripts/json_helpers.py tests/test_json_helpers.py` -> All checks passed!
`mypy scripts/json_helpers.py tests/test_json_helpers.py` -> Success: no issues found in 2 source files

## Acceptance criteria coverage

- **AC 1** (Implementation matches all behaviors described in the task body): Covered by `scripts/json_helpers.py`. `safe_json_load` converts `str` and `Path`, returns `default` for missing/empty files and malformed JSON (`JSONDecodeError`), returns parsed object for valid JSON.
- **AC 2** (All named tests pass the verification command): Covered by `tests/test_json_helpers.py`. All five named test functions pass with `pytest tests/test_json_helpers.py -v`.
- **AC 3** (No dependencies added unless absolutely required): Covered -- uses only `json`, `pathlib`, and `typing` from the standard library. No changes to `pyproject.toml` or lock files.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Confirmed -- only `scripts/json_helpers.py` and `tests/test_json_helpers.py` were modified.
- Do NOT add third-party dependencies unless required by the task body: Confirmed -- no dependencies added.
- Do NOT refactor unrelated code in the touched files: Confirmed -- both files are new and focused.

## Notes

None.

### Coverage

- Implementation matches all behaviors described in the task body: addressed in `scripts/json_helpers.py`
- All named tests pass the verification command: addressed in `tests/test_json_helpers.py`
- No dependencies added unless absolutely required: addressed -- zero new dependencies
