### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,19 @@
+"""Text helper utilities for scripts."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return pluralized form of word based on count.
+
+    Args:
+        word: The word to pluralize.
+        count: The count determining pluralization.
+        plural: Optional custom plural form. If not provided, appends 's'.
+
+    Returns:
+        The word unchanged if count is 1, otherwise the plural form.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,37 @@
+"""Tests for scripts.text_helpers module."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for imports
+sys.path.insert(
+    0,
+    str(Path(__file__).parent.parent / "scripts"),
+)
+
+from text_helpers import pluralize
+
+
+def test_pluralize_returns_singular_when_count_is_one() -> None:
+    """Asserts that pluralize returns word unchanged when count is exactly 1."""
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural() -> None:
+    """Asserts that pluralize appends 's' when count is not 1 and no custom plural provided."""
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural_when_provided() -> None:
+    """Asserts that pluralize uses custom plural when provided."""
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form() -> None:
+    """Asserts that pluralize returns plural form for zero count."""
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string_returns_empty_string() -> None:
+    """Asserts that pluralize returns empty string regardless of count for empty input."""
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #73

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word, count, *, plural=None)` function
- Created `tests/test_text_helpers.py` with 5 pytest tests covering all behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
# All 5 tests pass
pytest
# 272 tests pass (1 pre-existing todoist_client failure unrelated to this change)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. ✓ addressed in `scripts/text_helpers.py` - pluralize() handles empty string, count==1, and plural forms with custom option
- AC 2: All named tests pass the verification command. ✓ addressed in `tests/test_text_helpers.py` - 5 pytest tests all pass
- AC 3: No dependencies added unless absolutely required. ✓ not violated - stdlib only, no pyproject.toml changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated - only scripts/text_helpers.py and tests/test_text_helpers.py changed
- Do NOT add third-party dependencies: not violated - stdlib only
- Do NOT refactor unrelated code: not violated - new files only

## Notes

- Implementation follows Python conventions (PEP8, type hints with )
- Uses `sys.path.insert` for test imports (pattern used in existing tests)
- mypy passes with no issues
- ruff check passes with no warnings