### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """
+    Walks a dictionary using a dotted path string and returns the deepest match.
+    Returns the default value if any step in the path is missing or not a dictionary.
+    """
+    if not path:
+        return data
+    
+    current = data
+    for key in path.split("."):
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return default
+            
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+from scripts.dict_helpers import get_nested
+
+def test_get_nested_happy_path():
+    data = {"a": {"b": 1}}
+    assert get_nested(data, "a.b") == 1
+
+def test_get_nested_missing_key_returns_default():
+    data = {"a": {"b": 1}}
+    assert get_nested(data, "a.c", default=-1) == -1
+    assert get_nested(data, "a.c") is None
+
+def test_get_nested_non_dict_intermediate_returns_default():
+    data = {"a": 1}
+    assert get_nested(data, "a.b") is None
+    assert get_nested(data, "a.b", default="fallback") == "fallback"
+
+def test_get_nested_empty_path_returns_original_data():
+    data = {"a": 1}
+    assert get_nested(data, "") == data
+    
+    empty_data = {}
+    assert get_nested(empty_data, "") == empty_data
+
+def test_get_nested_three_plus_levels():
+    data = {"a": {"b": {"c": {"d": 4}}}}
+    assert get_nested(data, "a.b.c.d") == 4
+    assert get_nested(data, "a.b.c") == {"d": 4}
+    assert get_nested(data, "a.b.z", default="missing") == "missing"


### PR DESCRIPTION
## Linked card

Closes #63

## What changed

- Added `scripts/dict_helpers.py` with `get_nested()` function for walking dictionary paths using dotted string notation
- Added `tests/test_dict_helpers.py` with comprehensive test coverage for all required behaviors:
  - Happy path traversal (`test_get_nested_happy_path`)
  - Missing key handling with default values (`test_get_nested_missing_key_returns_default`)
  - Non-dict intermediate handling (`test_get_nested_non_dict_intermediate_returns_default`)
  - Empty path returning original data (`test_get_nested_empty_path_returns_original_data`)
  - Deep nesting (3+ levels) (`test_get_nested_three_plus_levels`)

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_dict_helpers.py -v
```

Output:
```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/agent/workspace/infiquetra/infiquetra-claude-plugins
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0
collecting ... collected 5 items

tests/test_dict_helpers.py::test_get_nested_happy_path PASSED            [ 20%]
tests/test_dict_helpers.py::test_get_nested_missing_key_returns_default PASSED [ 40%]
tests/test_dict_helpers.py::test_get_nested_non_dict_intermediate_returns_default PASSED [ 60%]
tests/test_dict_helpers.py::test_get_nested_empty_path_returns_original_data PASSED [ 80%]
tests/test_dict_helpers.py::test_get_nested_three_plus_levels PASSED     [100%]

============================== 5 passed in 0.10s ===============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - ✓ addressed in `scripts/dict_helpers.py` function `get_nested()` and `tests/test_dict_helpers.py`
- AC 2: All named tests pass the verification command - ✓ addressed in `tests/test_dict_helpers.py` with all 5 tests passing
- AC 3: No dependencies added unless absolutely required - ✓ no new dependencies added, only standard library used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only created the two expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - no existing code was modified

## Notes

The implementation follows Python best practices with proper type hints and adheres to the repository's coding standards. The function handles all edge cases as specified in the requirements and examples.

### Coverage

- AC 1 (verbatim): ✓ addressed in scripts/dict_helpers.py and tests/test_dict_helpers.py
- AC 2 (verbatim): ✓ addressed in tests/test_dict_helpers.py with all tests passing
- AC 3 (verbatim): ✓ addressed with no new dependencies added