### PR TITLE
feat(scripts): add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,18 @@
+"""Small text helper utilities for scripts."""
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """
+    Pluralize a word based on a count.
+
+    - If word is empty, returns empty string.
+    - If count is 1, returns the singular word.
+    - If count is not 1 and a custom plural is provided, returns custom plural.
+    - Otherwise, returns the word with 's' appended.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    if plural is not None:
+        return plural
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,17 @@
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_singular_for_count_one():
+    assert pluralize("cat", 1) == "cat"
+
+def test_pluralize_adds_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+def test_pluralize_uses_custom_plural_when_provided():
+    assert pluralize("child", 2, plural="children") == "children"
+
+def test_pluralize_zero_count_uses_plural_form():
+    assert pluralize("cat", 0) == "cats"
+
+def test_pluralize_empty_string_stays_empty():
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #74

## What changed

- Added `scripts/text_helpers.py` containing a `pluralize()` utility function.
- Added `tests/test_text_helpers.py` with comprehensive pytest coverage for:
  - Singular counts (count=1)
  - Regular pluralization (count != 1, default)
  - Custom pluralization (count != 1, custom plural provided)
  - Zero counts (count=0)
  - Empty string input

## How verified

```bash
PYTHONPATH=. pytest tests/test_text_helpers.py -v
```
Output:
5 passed in 0.11s

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body: ✓ addressed in scripts/text_helpers.py (pluralize function)
- AC 2: All named tests pass the verification command: ✓ addressed in tests/test_text_helpers.py (5 tests passed)
- AC 3: No dependencies added unless absolutely required: ✓ addressed (standard library only)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated
- Do NOT add third-party dependencies: not violated
- Do NOT refactor unrelated code: not violated

## Notes

No deviations from plan.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/text_helpers.py:pluralize
- All named tests pass the verification command: ✓ addressed in tests/test_text_helpers.py
- No dependencies added unless absolutely required: ✓ addressed by using only standard library and existing pytest dev-dependencies