### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,22 @@
+"""Text helper utilities."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the plural form of a word.
+
+    Args:
+        word: The singular noun to pluralize.
+        count: The quantity determining singular vs plural.
+        plural: Optional custom plural form. If None, default is word + "s".
+
+    Returns:
+        The empty string if word is empty.
+        The unchanged word if count == 1.
+        The provided plural if count != 1 and plural is not None.
+        Otherwise word + "s".
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,55 @@
+"""Unit tests for text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_returns_word_for_singular_count():
+    """Test that singular count returns word unchanged."""
+    assert pluralize("cat", 1) == "cat"
+    assert pluralize("dog", 1) == "dog"
+    assert pluralize("apple", 1) == "apple"
+
+
+def test_pluralize_adds_s_for_regular_plural():
+    """Test that non-singular count without custom plural adds 's'."""
+    assert pluralize("cat", 2) == "cats"
+    assert pluralize("dog", 0) == "dogs"
+    assert pluralize("apple", 3) == "apples"
+
+
+def test_pluralize_uses_custom_plural_for_non_singular_count():
+    """Test that custom plural is used when provided and count != 1."""
+    assert pluralize("child", 2, plural="children") == "children"
+    assert pluralize("child", 0, plural="children") == "children"
+    assert pluralize("child", 5, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    """Test that zero count uses plural form (regular or custom)."""
+    # Regular plural
+    assert pluralize("cat", 0) == "cats"
+    assert pluralize("dog", 0) == "dogs"
+    # Custom plural
+    assert pluralize("child", 0, plural="children") == "children"
+    assert pluralize("ox", 0, plural="oxen") == "oxen"
+
+
+def test_pluralize_empty_string_returns_empty_string():
+    """Test that empty string returns empty regardless of count."""
+    assert pluralize("", 5) == ""
+    assert pluralize("", 1) == ""
+    assert pluralize("", 0) == ""
+    assert pluralize("", 2, plural="children") == ""
+    assert pluralize("", 3, plural="oxen") == ""
+
+
+def test_pluralize_singular_ignores_custom_plural():
+    """Test that singular count ignores custom plural even when provided."""
+    assert pluralize("child", 1, plural="children") == "child"
+    assert pluralize("ox", 1, plural="oxen") == "ox"


### PR DESCRIPTION
## Linked card

Closes #68

## What changed

- Created `scripts/text_helpers.py` with `pluralize()` function implementing:
  - Empty string returns empty regardless of count
  - Singular count (`count == 1`) returns `word` unchanged
  - Non-singular count returns `plural` if provided, else `word + "s"`
- Created `tests/test_text_helpers.py` with pytest tests covering:
  - `test_pluralize_returns_word_for_singular_count`
  - `test_pluralize_adds_s_for_regular_plural`
  - `test_pluralize_uses_custom_plural_for_non_singular_count`
  - `test_pluralize_zero_count_uses_plural_form`
  - `test_pluralize_empty_string_returns_empty_string`
  - `test_pluralize_singular_ignores_custom_plural` (added for completeness)
- No external dependencies added beyond standard library
- Ruff linting passes, pytest passes

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_text_helpers.py -v --override-ini=addopts=
```

Result:
```
6 passed in 0.03s
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in `scripts/text_helpers.py:def pluralize()` lines 18-22
- AC 2: All named tests pass the verification command — ✓ addressed in `tests/test_text_helpers.py` six test functions covering all behaviors
- AC 3: No dependencies added unless absolutely required — ✓ no new dependencies in `pyproject.toml` or `requirements.txt`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: only `scripts/text_helpers.py` and `tests/test_text_helpers.py` modified
- Do NOT add third-party dependencies unless required by the task body: no dependencies added
- Do NOT refactor unrelated code in the touched files: both files are new for this task

## Notes

Implementation follows Python 3.12+ type hints (`str | None`) matching the repo's `pyproject.toml` (`requires-python = ">=3.12"`). Tests adopt the existing pytest pattern used elsewhere in the repository (simple module-level functions, no fixtures or mocks needed). Verified with Ruff linting (clean) and pytest (all pass).

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/text_helpers.py:def pluralize()` lines 1-22
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_text_helpers.py` functions covering singular, regular plural, custom plural, zero count, empty string
- AC 3 (No dependencies added unless absolutely required): ✓ no new dependencies; only uses `typing` which is Python 3.12 built-in