### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,26 @@
+"""Dictionary helper utilities."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Walk a dotted path through a nested dictionary.
+
+    Args:
+        data: The dictionary to traverse.
+        path: Dotted string of keys, e.g. "a.b.c".
+        default: Value to return when a key is missing or a step is not a dict.
+
+    Returns:
+        The value at the deepest key, or ``default`` when traversal fails.
+        An empty ``path`` returns ``data`` itself without mutation or copying.
+    """
+    if path == "":
+        return data
+
+    current = data
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return default
+        current = current[part]
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,29 @@
+"""Tests for dict helper utilities."""
+
+from scripts.dict_helpers import get_nested
+
+
+def test_get_nested_happy_path():
+    """Test that a dotted path returns the nested value."""
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_nested_missing_key_returns_default():
+    """Test that a missing key returns the provided default."""
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+
+def test_get_nested_non_dict_step_returns_default():
+    """Test that stepping into a non-dict returns the default."""
+    assert get_nested({"a": 1}, "a.b") is None
+
+
+def test_get_nested_empty_path_returns_data():
+    """Test that an empty path returns the input dict without copying."""
+    data = {}
+    assert get_nested(data, "") is data
+
+
+def test_get_nested_three_or_more_levels():
+    """Test that deeply nested lookups work for 3+ levels."""
+    assert get_nested({"a": {"b": {"c": {"d": 4}}}}, "a.b.c.d") == 4


### PR DESCRIPTION
## Linked card

Closes #78

## What changed

- `scripts/dict_helpers.py`: New helper module with `get_nested(data, path, default=None)` that walks dotted dictionary paths without mutating `data`.
- `tests/test_dict_helpers.py`: Five pytest cases covering happy path, missing key, non-dict step, empty path, and nested 3+ levels.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_dict_helpers.py -v -o addopts=""
```

Output:
```
tests/test_dict_helpers.py::test_get_nested_happy_path PASSED
tests/test_dict_helpers.py::test_get_nested_missing_key_returns_default PASSED
tests/test_dict_helpers.py::test_get_nested_non_dict_step_returns_default PASSED
tests/test_dict_helpers.py::test_get_nested_empty_path_returns_data PASSED
tests/test_dict_helpers.py::test_get_nested_three_or_more_levels PASSED
============================== 5 passed in 0.02s ===============================
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — `get_nested()` handles dotted paths, missing keys, non-dict intermediates, and empty paths; it does not mutate `data`.
- AC 2: All named tests pass the verification command — `tests/test_dict_helpers.py` passes with all five required cases.
- AC 3: No dependencies added unless absolutely required — only the Python standard library (`typing.Any`) is used; pytest was already a dev dependency.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated; only `scripts/dict_helpers.py` and `tests/test_dict_helpers.py` were created.
- Do NOT add third-party dependencies unless required by the task body: not violated; no new dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated; both files are new and contain only the requested helper and tests.

## Notes

- None; plan and repo state matched exactly.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/dict_helpers.py::get_nested`
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_dict_helpers.py`
- AC 3 (No dependencies added unless absolutely required): ✓ addressed; no new dependencies added