### PR TITLE
feat(scripts): add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """
+    Safely loads a JSON file. Returns default if the file does not exist,
+    is empty, or contains invalid JSON.
+
+    Args:
+        path: Path to the JSON file (str or Path object).
+        default: Value to return if loading fails. Defaults to None.
+
+    Returns:
+        The parsed JSON data or the default value.
+    """
+    json_path = Path(path)
+
+    if not json_path.exists():
+        return default
+
+    try:
+        content = json_path.read_text()
+        if not content:
+            return default
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,33 @@
+from scripts.json_helpers import safe_json_load
+
+
+def test_safe_json_load_returns_default_for_missing_file(tmp_path):
+    missing_path = tmp_path / "missing.json"
+    assert safe_json_load(missing_path) is None
+    assert safe_json_load(missing_path, default={}) == {}
+
+
+def test_safe_json_load_returns_default_for_empty_file(tmp_path):
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text("")
+    assert safe_json_load(empty_path, default=[]) == []
+
+
+def test_safe_json_load_returns_default_for_malformed_json(tmp_path):
+    broken_path = tmp_path / "broken.json"
+    broken_path.write_text("{not valid json")
+    assert safe_json_load(broken_path, default=[]) == []
+
+
+def test_safe_json_load_returns_parsed_valid_json(tmp_path):
+    good_path = tmp_path / "good.json"
+    data = {"name": "infiquetra", "count": 2}
+    good_path.write_text('{"name": "infiquetra", "count": 2}')
+    assert safe_json_load(good_path) == data
+
+
+def test_safe_json_load_accepts_str_path(tmp_path):
+    good_path = tmp_path / "good.json"
+    data = {"name": "infiquetra", "count": 2}
+    good_path.write_text('{"name": "infiquetra", "count": 2}')
+    assert safe_json_load(str(good_path)) == data


### PR DESCRIPTION
## Linked card

Closes #81

## What changed

- Created `scripts/json_helpers.py` providing `safe_json_load(path, default=None)` which handles missing files, empty files, and malformed JSON by returning the default value.
- Created `tests/test_json_helpers.py` containing unit tests covering all specified failure and success cases, including support for both `str` and `Path` inputs.

## How verified

```bash
pytest tests/test_json_helpers.py -v
```
Output: 5 passed in 0.10s

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. Verified by 5 unit tests covering missing, empty, malformed, and valid JSON, as well as path type flexibility.
- AC 2: All named tests pass the verification command. Verified by `pytest tests/test_json_helpers.py -v` exiting with 0 and all tests passing.
- AC 3: No dependencies added unless absolutely required. Implementation uses only Python standard library (`json`, `pathlib`, `typing`).

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: only `scripts/json_helpers.py` and `tests/test_json_helpers.py` were modified.
- Do NOT add third-party dependencies unless required by the task body: no new dependencies added.
- Do NOT refactor unrelated code in the touched files: only new files were created.

## Notes

Consistency with codebase: Used `ruff` for linting and `pytest` for testing as per project conventions.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/json_helpers.py
- All named tests pass the verification command: ✓ addressed in tests/test_json_helpers.py
- No dependencies added unless absolutely required: ✓ addressed in scripts/json_helpers.py
