### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,39 @@
+"""Dictionary helper utilities."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Traverse a dict using a dotted path and return the value.
+
+    Args:
+        data: The dictionary to traverse.
+        path: A dotted string like "a.b.c" indicating nested keys.
+        default: Value returned when a key is missing or traversal
+                 reaches a non-dict before the path ends.
+
+    Returns:
+        The value at the end of the path, or *default* if the path
+        cannot be fully followed.
+
+    Examples:
+        >>> get_nested({"a": {"b": 1}}, "a.b")
+        1
+        >>> get_nested({"a": {"b": 1}}, "a.c", default=-1)
+        -1
+        >>> get_nested({"a": 1}, "a.b") is None
+        True
+        >>> get_nested({}, "")
+        {}
+    """
+    if path == "":
+        return data
+
+    current: Any = data
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return default
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,41 @@
+"""Unit tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for non-package import
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from dict_helpers import get_nested
+
+
+class TestGetNested:
+    """Tests for get_nested()."""
+
+    def test_get_nested_happy_path(self) -> None:
+        """Basic dotted lookup returns the nested value."""
+        data = {"a": {"b": 1}}
+        assert get_nested(data, "a.b") == 1
+
+    def test_get_nested_missing_key_returns_default(self) -> None:
+        """Missing key at any depth returns the supplied default."""
+        data = {"a": {"b": 1}}
+        assert get_nested(data, "a.c", default=-1) == -1
+
+    def test_get_nested_non_dict_step_returns_default(self) -> None:
+        """Stepping into a non-dict returns None (default)."""
+        data = {"a": 1}
+        assert get_nested(data, "a.b") is None
+
+    def test_get_nested_empty_path_returns_data(self) -> None:
+        """Empty path returns the entire dict without copying."""
+        data = {"x": 1}
+        result = get_nested(data, "")
+        assert result is data
+
+    def test_get_nested_three_plus_levels(self) -> None:
+        """Traversal works for three or more levels of nesting."""
+        data = {"a": {"b": {"c": {"d": "found"}}}}
+        assert get_nested(data, "a.b.c.d") == "found"
+
+        # Verify no mutation occurred during traversal
+        assert data == {"a": {"b": {"c": {"d": "found"}}}}


### PR DESCRIPTION
## Linked card

Closes #82

## What changed

- Created `scripts/dict_helpers.py` with `get_nested(data: dict, path: str, default=None) -> Any` — a pure helper for dotted-path dictionary lookup.
- Created `tests/test_dict_helpers.py` with 5 pytest cases covering: happy path, missing key with default, non-dict step, empty path (returns data ref), and 3+ level nested lookup with non-mutation assertion.

## How verified

All 5 tests pass with zero ruff warnings on both files.

Verification command: `.venv/bin/pytest tests/test_dict_helpers.py -v`

Output: 5 passed in 0.12s.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): addressed — `scripts/dict_helpers.py` implements `get_nested()` with dotted path traversal, missing-key default, non-dict guard, empty-path return, and no mutation.
- AC 2 (All named tests pass): addressed — 5 tests in `tests/test_dict_helpers.py` all pass.
- AC 3 (No dependencies added): addressed — only stdlib `typing.Any` used in the helper; tests use stdlib `sys`/`pathlib` + existing pytest.

## Non-goals acknowledged

- No files modified beyond `scripts/dict_helpers.py` and `tests/test_dict_helpers.py`.
- No third-party dependencies added.
- No unrelated code refactored in touched files.

## Notes

The plan's import strategy (sys.path.insert for scripts/ directory) matches the existing test patterns in the repo (e.g., tests/test_pagerduty_client.py).

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): addressed in scripts/dict_helpers.py — get_nested() implements dotted-path lookup, missing-key default, non-dict guard, empty-path return, and no mutation.
- AC 2 (All named tests pass the verification command): addressed in tests/test_dict_helpers.py — all 5 tests pass.
- AC 3 (No dependencies added unless absolutely required): addressed — only stdlib imports used.
