### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,25 @@
+"""Dict path lookup helpers."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Walk a dotted path into a nested dict, returning the deepest match.
+
+    Args:
+        data: The dict to traverse.
+        path: Dot-separated key path, e.g. ``"a.b.c"``.
+        default: Value returned when a key is missing or a step is not a dict.
+
+    Returns:
+        The value at the end of the path, or *default* if traversal fails.
+    """
+    if path == "":
+        return data
+
+    current: Any = data
+    for key in path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,36 @@
+"""Tests for scripts/dict_helpers.get_nested."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+def test_get_nested_happy_path() -> None:
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_nested_missing_key_returns_default() -> None:
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+
+def test_get_nested_non_dict_step_returns_default() -> None:
+    assert get_nested({"a": 1}, "a.b") is None
+
+
+def test_get_nested_empty_path_returns_data() -> None:
+    data: dict = {}
+    assert get_nested(data, "") == {}
+    assert get_nested(data, "") is data
+
+
+def test_get_nested_three_plus_levels() -> None:
+    assert get_nested({"a": {"b": {"c": {"d": "value"}}}}, "a.b.c.d") == "value"
+
+
+def test_get_nested_does_not_mutate_data() -> None:
+    data = {"a": {"b": 1}}
+    get_nested(data, "a.b")
+    assert data == {"a": {"b": 1}}


### PR DESCRIPTION
## Linked card

Closes #85

## What changed

- Created `scripts/dict_helpers.py` with `get_nested(data: dict, path: str, default=None) -> Any`
- Created `tests/test_dict_helpers.py` with 6 pytest test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_dict_helpers.py -v -o "addopts="
```

Output: 6 passed in 0.02s

```bash
ruff check scripts/dict_helpers.py tests/test_dict_helpers.py
```

Output: All checks passed!

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): `get_nested` handles dotted path traversal, missing key → default, non-dict step → default, empty path → return data, no mutation. Verified by implementation + tests.
- AC 2 (All named tests pass the verification command): 6 pytest tests pass: happy path, missing key, non-dict step, empty path, 3+ levels, no mutation.
- AC 3 (No dependencies added unless absolutely required): Only stdlib `typing.Any` used; no new packages added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `scripts/dict_helpers.py` and `tests/test_dict_helpers.py` changed.
- Do NOT add third-party dependencies: none added.
- Do NOT refactor unrelated code in the touched files: no unrelated changes.

## Notes

- `pyproject.toml` configures `addopts = "--cov=plugins --cov-report=term-missing"` which requires `pytest-cov`. Tests were run with `-o "addopts="` override; the standard `pytest` command also works once `pytest-cov` is installed.
- Plan called for 5 test functions; an additional `test_get_nested_does_not_mutate_data` was added to explicitly verify the "Do not mutate data" requirement from the card.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/dict_helpers.py` / `get_nested()` (lines 7-25)
- All named tests pass the verification command: ✓ addressed in `tests/test_dict_helpers.py` (6 tests, all passing)
- No dependencies added unless absolutely required: ✓ addressed — only stdlib `typing.Any` imported; no package changes