### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,12 @@
+"""Text formatting helpers."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of a word for a count."""
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    if plural is not None:
+        return plural
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,21 @@
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_word_for_singular_count() -> None:
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural() -> None:
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural() -> None:
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form() -> None:
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string_returns_empty_string() -> None:
+    assert pluralize("", 5) == ""


### PR DESCRIPTION
## Linked card

Closes #90

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word: str, count: int, *, plural: str | None = None) -> str`
- Created `tests/test_text_helpers.py` with 5 pytest cases covering all required behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```

Output: 5 passed in 0.09s

```bash
ruff check scripts/text_helpers.py tests/test_text_helpers.py
```

Output: All checks passed!

Note: Full suite (`pytest`) hits a pre-existing INTERNALERROR in `tests/test_todoist_client.py` due to missing `todoist-api-python` dependency — unrelated to this change.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): pluralize handles singular (count==1), regular plural (+s), custom plural, zero count, and empty string — verified by 5 focused tests
- AC 2 (All named tests pass the verification command): `pytest tests/test_text_helpers.py -v` exits 0 with 5 passed
- AC 3 (No dependencies added unless absolutely required): No new dependencies; scripts/text_helpers.py uses only stdlib, tests use existing pytest

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new deps
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

- Pre-existing INTERNALERROR in full pytest suite is from `test_todoist_client.py` (missing `todoist-api-python`), unrelated to this PR.

### Coverage

- AC 1: ✓ addressed in `scripts/text_helpers.py` / `pluralize()` (lines 5-12)
- AC 2: ✓ addressed in `tests/test_text_helpers.py` — 5 tests all pass
- AC 3: ✓ addressed — no dependency changes in pyproject.toml or lockfiles