### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,32 @@
+"""JSON helper utilities for safe file loading."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """
+    Safely load JSON from a file, returning a default on errors.
+
+    If the file does not exist, is empty, or contains invalid JSON,
+    returns `default` instead of raising. For valid JSON files,
+    returns the parsed object.
+
+    Args:
+        path: File path as string or Path object.
+        default: Value to return on missing/empty/invalid JSON.
+                 Defaults to None.
+
+    Returns:
+        The parsed JSON object, or `default` on any load error.
+    """
+    json_path = Path(path)
+
+    if not json_path.exists():
+        return default
+
+    try:
+        return json.loads(json_path.read_text())
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,44 @@
+"""Unit tests for json_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from json_helpers import safe_json_load  # noqa: E402
+
+
+def test_safe_json_load_missing_file_returns_default(tmp_path):
+    """Missing file returns the default value."""
+    missing_path = tmp_path / "missing.json"
+    assert safe_json_load(missing_path) is None
+    assert safe_json_load(missing_path, default={}) == {}
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path):
+    """Empty file returns the default value."""
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text("")
+    assert safe_json_load(empty_path, default=[]) == []
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path):
+    """Malformed JSON returns the default value."""
+    broken_path = tmp_path / "broken.json"
+    broken_path.write_text("{not-json")
+    assert safe_json_load(broken_path, default=[]) == []
+
+
+def test_safe_json_load_valid_json_returns_parsed_result(tmp_path):
+    """Valid JSON returns the parsed object."""
+    good_path = tmp_path / "good.json"
+    good_path.write_text('{"name": "infiquetra", "enabled": true, "count": 2}')
+    assert safe_json_load(good_path) == {"name": "infiquetra", "enabled": True, "count": 2}
+
+
+def test_safe_json_load_accepts_path_and_str(tmp_path):
+    """Both Path and str arguments work."""
+    path_arg = tmp_path / "list.json"
+    path_arg.write_text("[1, 2, 3]")
+    assert safe_json_load(path_arg) == [1, 2, 3]
+    assert safe_json_load(str(path_arg)) == [1, 2, 3]


### PR DESCRIPTION
## Linked card

Closes #87

## What changed

- Created `scripts/json_helpers.py` with `safe_json_load()` function
- Created `tests/test_json_helpers.py` with 5 test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_json_helpers.py -v
# Output: 5 passed in 0.13s
ruff check scripts/json_helpers.py tests/test_json_helpers.py
# Output: All checks passed!
mypy scripts/json_helpers.py tests/test_json_helpers.py
# Output: Success: no issues found in 2 source files
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  - Missing file returns default: `json_path.exists()` check returns early
  - Empty/invalid JSON returns default: catches `json.JSONDecodeError`
  - Valid JSON returns parsed result: successful parse path
  - Accepts str | Path: converts via `Path(path)` once

- AC 2: All named tests pass the verification command
  - `test_safe_json_load_missing_file_returns_default`
  - `test_safe_json_load_empty_file_returns_default`
  - `test_safe_json_load_malformed_json_returns_default`
  - `test_safe_json_load_valid_json_returns_parsed_result`
  - `test_safe_json_load_accepts_path_and_str`

- AC 3: No dependencies added unless absolutely required
  - Uses only stdlib: `json`, `pathlib.Path`, `typing.Any`
  - No pyproject.toml or lockfile changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated (only `scripts/json_helpers.py` and `tests/test_json_helpers.py` created)
- Do NOT add third-party dependencies unless required by the task body: not violated (stdlib only)
- Do NOT refactor unrelated code in the touched files: not violated (new files)

## Notes

Test file uses `sys.path.insert(0, ...)` pattern matching the existing test style in `tests/test_slack_client.py` to import from the non-package `scripts/` directory.

### Coverage

- [x] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/json_helpers.py` (lines 8-32, `safe_json_load` function)
- [x] All named tests pass the verification command: ✓ addressed in `tests/test_json_helpers.py` (5 test functions, all passing)
- [x] No dependencies added unless absolutely required: ✓ addressed by using only stdlib imports (`json`, `pathlib.Path`, `typing.Any`)