### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,29 @@
+"""Small text formatting helpers used by scripts."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the plural form of a word based on count.
+
+    Args:
+        word: The word to pluralize.
+        count: The count determining singular/plural form.
+        plural: Optional custom plural form.
+
+    Returns:
+        The word unchanged if count is 1, otherwise the plural form.
+
+    Examples:
+        >>> pluralize("cat", 1)
+        'cat'
+        >>> pluralize("cat", 2)
+        'cats'
+        >>> pluralize("child", 2, plural="children")
+        'children'
+        >>> pluralize("", 5)
+        ''
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,30 @@
+"""Tests for scripts.text_helpers."""
+
+import sys
+from pathlib import Path
+
+# Add repo root to path so scripts module can be imported
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_word_for_singular_count():
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural_when_provided():
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_treats_zero_as_plural():
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_returns_empty_string_regardless_of_count():
+    assert pluralize("", 5) == ""
+    assert pluralize("", 1) == ""


### PR DESCRIPTION
## Linked card

Closes #88

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word: str, count: int, *, plural: str | None = None) -> str` function
- Added `tests/test_text_helpers.py` with 5 pytest test cases

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v --override-ini="addopts="
ruff check scripts/text_helpers.py tests/test_text_helpers.py
```

Output: 5 tests passed in 0.02s, All checks passed!

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/text_helpers.py` lines 8-29 — handles empty string (returns empty), singular count (returns word unchanged), and non-singular counts (returns custom plural or word + 's')
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_text_helpers.py` — 5 tests covering singular, regular plural, custom plural, zero count, and empty string — all pass
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — uses only Python standard library (no imports beyond `sys` and `pathlib` for test path setup)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` created
- Do NOT add third-party dependencies unless required by the task body: not violated — no external dependencies, only stdlib
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no refactoring needed

## Notes

None — implementation follows the approved plan exactly.