### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,25 @@
+"""JSON helper utilities."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default=None) -> Any:
+    """Load and parse a JSON file, returning a default on failure.
+
+    Args:
+        path: Path to the JSON file. Accepts str or Path.
+        default: Value to return if the file is missing, empty, or unparseable.
+
+    Returns:
+        The parsed JSON content, or ``default`` if the file is missing or invalid.
+    """
+    json_path = Path(path)
+    if not json_path.exists():
+        return default
+    try:
+        return json.loads(json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,39 @@
+"""Tests for json_helpers."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from json_helpers import safe_json_load
+
+
+def test_safe_json_load_missing_file_returns_default(tmp_path):
+    missing = tmp_path / "missing.json"
+    assert safe_json_load(missing) is None
+    assert safe_json_load(missing, default={}) == {}
+
+
+def test_safe_json_load_empty_file_returns_default(tmp_path):
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    assert safe_json_load(empty, default=[]) == []
+
+
+def test_safe_json_load_malformed_json_returns_default(tmp_path):
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not valid json", encoding="utf-8")
+    assert safe_json_load(broken, default=[]) == []
+
+
+def test_safe_json_load_valid_json_returns_parsed_result(tmp_path):
+    good = tmp_path / "good.json"
+    good.write_text('{"name": "infiquetra", "count": 2}', encoding="utf-8")
+    assert safe_json_load(good) == {"name": "infiquetra", "count": 2}
+
+
+def test_safe_json_load_accepts_path_and_str_arguments(tmp_path):
+    path_arg = tmp_path / "list.json"
+    path_arg.write_text("[1, 2, 3]", encoding="utf-8")
+    assert safe_json_load(path_arg) == [1, 2, 3]
+    assert safe_json_load(str(path_arg)) == [1, 2, 3]


### PR DESCRIPTION
## Linked card

Closes #95

## What changed

- Created `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any`
- Created `tests/test_json_helpers.py` with 5 test cases covering all required behaviors
- No third-party dependencies added — uses only Python standard library

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_json_helpers.py -v
\`\`\`

Output: 5 passed in 0.15s

Linting: ruff check + mypy on both files — zero issues

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/json_helpers.py` — missing file returns default, empty/malformed JSON returns default, valid JSON returns parsed result, accepts both str and Path
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_json_helpers.py` — all 5 named tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — only stdlib imports (json, pathlib.Path, typing.Any)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `scripts/json_helpers.py` and `tests/test_json_helpers.py` created
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — files are new with only the requested content

## Notes

- The repo had no `.venv/` set up for pytest/mypy; created a local venv to run verification commands, but the lockfile was not committed
- Coverage section maps each AC to a specific file/function/test