### PR TITLE
feat(scripts): Add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,35 @@
+"""Safe JSON loading utility."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load and parse a JSON file, returning a default on failure.
+
+    Args:
+        path: Path to the JSON file (str or Path).
+        default: Value to return if the file is missing, empty, or invalid.
+
+    Returns:
+        The parsed JSON object, or *default* on failure.
+
+    Examples:
+        >>> safe_json_load("does_not_exist.json") is None
+        True
+        >>> safe_json_load("does_not_exist.json", default={})
+        {}
+        >>> safe_json_load(Path("broken.json"), default=[])
+        []
+        >>> safe_json_load("good.json")
+        {'name': 'infiquetra', 'enabled': True}
+    """
+    json_path = Path(path)
+    if not json_path.exists():
+        return default
+    try:
+        text = json_path.read_text(encoding="utf-8")
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,41 @@
+"""Tests for json_helpers utility."""
+
+from pathlib import Path
+
+from scripts.json_helpers import safe_json_load
+
+
+def test_safe_json_load_returns_default_for_missing_file(tmp_path: Path) -> None:
+    """Missing file returns None by default, or the explicit default."""
+    assert safe_json_load(tmp_path / "missing.json") is None
+    assert safe_json_load(tmp_path / "missing.json", default={}) == {}
+
+
+def test_safe_json_load_returns_default_for_empty_file(tmp_path: Path) -> None:
+    """Empty file returns the specified default."""
+    p = tmp_path / "empty.json"
+    p.write_text("", encoding="utf-8")
+    assert safe_json_load(p, default=[]) == []
+
+
+def test_safe_json_load_returns_default_for_malformed_json(tmp_path: Path) -> None:
+    """Malformed JSON returns the specified default."""
+    p = tmp_path / "broken.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert safe_json_load(p, default=[]) == []
+
+
+def test_safe_json_load_returns_parsed_valid_json(tmp_path: Path) -> None:
+    """Valid JSON is parsed and returned."""
+    p = tmp_path / "good.json"
+    p.write_text('{"name": "infiquetra", "enabled": true}', encoding="utf-8")
+    result = safe_json_load(p)
+    assert result == {"name": "infiquetra", "enabled": True}
+
+
+def test_safe_json_load_accepts_str_and_path_arguments(tmp_path: Path) -> None:
+    """Both str and Path arguments produce the same result."""
+    p = tmp_path / "data.json"
+    p.write_text('{"key": "value"}', encoding="utf-8")
+    assert safe_json_load(p) == {"key": "value"}
+    assert safe_json_load(str(p)) == {"key": "value"}


### PR DESCRIPTION
## Linked card

Closes #89

## What changed

- Added `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any`
  - Returns `default` when the file doesn't exist
  - Returns `default` when the file is empty or contains malformed JSON
  - Returns the parsed JSON object on success
  - Accepts both `str` and `Path` arguments
- Added `tests/test_json_helpers.py` with 5 pytest tests covering all specified behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins && source venv/bin/activate && pytest tests/test_json_helpers.py -v --no-cov
```

```
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_missing_file PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_empty_file PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_default_for_malformed_json PASSED
tests/test_json_helpers.py::test_safe_json_load_returns_parsed_valid_json PASSED
tests/test_json_helpers.py::test_safe_json_load_accepts_str_and_path_arguments PASSED

5 passed in 0.03s
```

Also verified: `ruff check` passes on both files, `mypy` passes on `scripts/json_helpers.py`.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — covered by `scripts/json_helpers.py` lines 1-35, all 4 behaviors (missing, empty, malformed, valid) implemented
- AC 2: All named tests pass the verification command — all 5 tests pass as shown above
- AC 3: No dependencies added unless absolutely required — implementation uses only stdlib (`json`, `pathlib.Path`, `typing.Any`)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: only `scripts/json_helpers.py` and `tests/test_json_helpers.py` are modified
- Do NOT add third-party dependencies: confirmed — stdlib only
- Do NOT refactor unrelated code in the touched files: both files are new, no refactoring done

## Notes

No deviations from the plan.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/json_helpers.py`
- All named tests pass the verification command: ✓ addressed in `tests/test_json_helpers.py` (5 tests all passing)
- No dependencies added unless absolutely required: ✓ addressed — stdlib only (json, pathlib, typing)