### PR TITLE
feat(scripts): add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,39 @@
+"""Text formatting utilities for Infiquetra Claude plugins."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of *word* based on *count*.
+
+    Args:
+        word: The word to pluralize.
+        count: Determines singular (1) vs plural (all other values).
+        plural: Optional explicit plural override. When provided and
+            *count* is not 1, this value is returned instead of
+            *word* + "s".
+
+    Returns:
+        *word* unchanged when *count* == 1.
+        *plural* when provided and *count* != 1.
+        *word* + ``"s"`` otherwise.
+        Empty string when *word* is empty, regardless of *count*.
+
+    Examples:
+        >>> pluralize("cat", 1)
+        'cat'
+        >>> pluralize("cat", 2)
+        'cats'
+        >>> pluralize("child", 2, plural="children")
+        'children'
+        >>> pluralize("", 5)
+        ''
+    """
+    if word == "":
+        return ""
+
+    if count == 1:
+        return word
+
+    if plural is not None:
+        return plural
+
+    return word + "s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,35 @@
+"""Unit tests for text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+# Add repo root to path so `scripts` is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.text_helpers import pluralize
+
+
+class TestPluralize:
+    """Tests for pluralize()."""
+
+    def test_returns_singular_when_count_is_one(self) -> None:
+        """count == 1 returns the word unchanged."""
+        assert pluralize("cat", 1) == "cat"
+
+    def test_adds_s_for_regular_plural(self) -> None:
+        """Default plural appends 's'."""
+        assert pluralize("cat", 2) == "cats"
+
+    def test_uses_custom_plural_when_provided(self) -> None:
+        """Explicit plural override is returned for non-one counts."""
+        assert pluralize("child", 2, plural="children") == "children"
+
+    def test_treats_zero_as_plural(self) -> None:
+        """Zero count produces the plural form."""
+        assert pluralize("cat", 0) == "cats"
+
+    def test_returns_empty_string_regardless_of_count(self) -> None:
+        """Empty word returns empty string for any count or plural override."""
+        assert pluralize("", 5) == ""
+        assert pluralize("", 1) == ""
+        assert pluralize("", 2, plural="children") == ""


### PR DESCRIPTION
## Linked card

Closes #77

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word, count, *, plural=None)` — a standard-library-only helper that returns singular/plural forms based on count
- Created `tests/test_text_helpers.py` with pytest coverage for all five required behaviors: singular, regular plural, custom plural, zero count, and empty string

## How verified

```bash
# Targeted test file
cd ~/workspace/infiquetra/infiquetra-claude-plugins && source .venv/bin/activate
pytest tests/test_text_helpers.py -v
```

Output: `5 passed in 0.07s`

```bash
# Lint (ruff)
ruff check scripts/text_helpers.py tests/test_text_helpers.py
```
Output: All checks passed

```bash
# Type check (mypy)
mypy scripts/text_helpers.py tests/test_text_helpers.py
```
Output: Success: no issues found in 2 source files

Note: the `pytest` full suite is blocked at collection time by a pre-existing issue (`requests` not installed in .venv breaks `test_pagerduty_client.py`). The targeted test file passes cleanly.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  ✓ addressed in `scripts/text_helpers.py:pluralize()` — empty string guard, singular check, custom plural fallback, default "s" suffix
- AC 2: All named tests pass the verification command
  ✓ addressed in `tests/test_text_helpers.py` — 5 tests (singular, regular plural, custom plural, zero count, empty string) all pass via `pytest tests/test_text_helpers.py -v`
- AC 3: No dependencies added unless absolutely required
  ✓ `scripts/text_helpers.py` uses only Python built-ins (no imports). Tests use standard pytest conventions already in the repo.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` are changed
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no refactoring done

## Notes

- The full `pytest` suite fails at collection due to a pre-existing missing `requests` dependency in `.venv`, unrelated to this change.
- Import approach matches existing test convention in this repo: `sys.path.insert(0, str(Path(...).parent.parent))` before importing from `scripts/`.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in scripts/text_helpers.py lines 12-49 (pluralize function)
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_text_helpers.py — 5 tests passing via pytest
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — zero imports in implementation, zero new deps