### PR TITLE
feat(scripts): add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,30 @@
+"""Dictionary helper functions for path-based lookups."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default=None) -> Any:
+    """
+    Get a value from a nested dictionary using a dotted path.
+
+    Args:
+        data: The dictionary to traverse.
+        path: A dotted string like "a.b.c" specifying the path.
+        default: Value to return if path is not found. Defaults to None.
+
+    Returns:
+        The value at the path, default if not found, or the entire data
+        if path is empty.
+    """
+    if path == "":
+        return data
+
+    current: Any = data
+    for key in path.split("."):
+        if not isinstance(current, dict):
+            return default
+        if key not in current:
+            return default
+        current = current[key]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,43 @@
+"""Unit tests for dict_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dict_helpers import get_nested
+
+
+class TestGetNested:
+    """Test get_nested function."""
+
+    def test_get_nested_returns_value_for_dotted_path(self):
+        """Test successful nested lookup."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "a.b")
+        assert result == 1
+
+    def test_get_nested_returns_default_for_missing_key(self):
+        """Test missing key returns default value."""
+        data = {"a": {"b": 1}}
+        result = get_nested(data, "a.c", default=-1)
+        assert result == -1
+
+    def test_get_nested_returns_default_when_stepping_into_non_dict(self):
+        """Test stepping into a non-dict returns default."""
+        data = {"a": 1}
+        result = get_nested(data, "a.b")
+        assert result is None
+
+    def test_get_nested_empty_path_returns_entire_data(self):
+        """Test empty path returns the entire data dict."""
+        data = {}
+        result = get_nested(data, "")
+        assert result == {}
+        assert result is data
+
+    def test_get_nested_supports_three_or_more_levels(self):
+        """Test deep nesting with 3+ levels."""
+        data = {"a": {"b": {"c": {"d": 4}}}}
+        result = get_nested(data, "a.b.c.d")
+        assert result == 4


### PR DESCRIPTION
## Linked card

Closes #97

## What changed

- Created scripts/dict_helpers.py with get_nested() function
  - Takes data dict, dotted path string, and optional default
  - Returns full data for empty path
  - Traverses nested dicts on dotted path (e.g., 'a.b.c')
  - Returns default when path step is missing or not a dict
  - No mutation of input data

- Created tests/test_dict_helpers.py with 5 pytest test cases
  - test_get_nested_returns_value_for_dotted_path
  - test_get_nested_returns_default_for_missing_key
  - test_get_nested_returns_default_when_stepping_into_non_dict
  - test_get_nested_empty_path_returns_entire_data
  - test_get_nested_supports_three_or_more_levels

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_dict_helpers.py -v
```

All 5 tests passed in 0.07s.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in scripts/dict_helpers.py get_nested() function implementation matching all examples in task body
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_dict_helpers.py with all 5 named test cases passing pytest
- AC 3 (No dependencies added unless absolutely required): ✓ no third-party dependencies added; only typing.Any from stdlib

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ only scripts/dict_helpers.py and tests/test_dict_helpers.py modified
- Do NOT add third-party dependencies unless required by the task body: ✓ no dependencies added
- Do NOT refactor unrelated code in the touched files: ✓ only get_nested() implementation and tests added, no refactoring of existing code

## Notes

- Implementation follows the exact behavior spec from issue #97:
  - Empty path returns entire data dict
  - Dotted path traversal via split('.') with type checks at each step
  - Default returned when current is not dict or key missing
- Linting (ruff) passes with no errors
- Type checking (mypy) passes with no issues