### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,26 @@
+"""Dictionary helper utilities."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """Get a value from a nested dict using a dotted path.
+
+    Args:
+        data: The dictionary to traverse.
+        path: Dotted path string (e.g., "a.b.c").
+        default: Value to return if path is not found or traversal fails.
+
+    Returns:
+        The value at the path, or ``default`` if the path is invalid.
+    """
+    if path == "":
+        return data
+    current: Any = data
+    for key in path.split("."):
+        if not isinstance(current, dict):
+            return default
+        if key not in current:
+            return default
+        current = current[key]
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,27 @@
+"""Tests for dict_helpers."""
+
+from scripts.dict_helpers import get_nested
+
+
+def test_get_nested_happy_path_returns_value():
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_nested_missing_key_returns_default():
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+
+def test_get_nested_non_dict_step_returns_default():
+    assert get_nested({"a": 1}, "a.b") is None
+
+
+def test_get_nested_empty_path_returns_data():
+    assert get_nested({}, "") == {}
+    assert get_nested({"a": 1}, "") == {"a": 1}
+
+
+def test_get_nested_three_plus_levels_and_does_not_mutate():
+    data = {"a": {"b": {"c": "value"}}}
+    expected = {"a": {"b": {"c": "value"}}}
+    assert get_nested(data, "a.b.c") == "value"
+    assert data == expected


### PR DESCRIPTION
## Linked card

Closes #98

## What changed

- Added `scripts/dict_helpers.py` with `get_nested(data: dict, path: str, default=None) -> Any` implementing dotted-path lookup on nested dicts.
- Added `tests/test_dict_helpers.py` with 5 pytest cases covering happy path, missing key, non-dict traversal, empty path, and 3+ level lookup with no mutation.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_dict_helpers.py -v --override-ini="addopts="
\`\`\`

Output: 5 passed in 0.02s

Full suite (excluding pre-existing todoist failure): 277 passed in 0.92s

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): Addressed in `scripts/dict_helpers.py:get_nested()` — handles empty path (returns data), dotted traversal, non-dict step returns default, missing key returns default, no mutation of input.
- AC 2 (All named tests pass): Addressed in `tests/test_dict_helpers.py` — all 5 named tests pass.
- AC 3 (No dependencies added): Addressed — uses only stdlib `typing.Any` in `scripts/dict_helpers.py`; no new dependencies.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `scripts/dict_helpers.py` and `tests/test_dict_helpers.py` created.
- Do NOT add third-party dependencies: no new dependencies introduced.
- Do NOT refactor unrelated code: no refactoring performed.

## Notes

- Pre-existing `test_todoist_client.py` failure is unrelated to this change (277 other tests pass cleanly).