### PR TITLE
feat(scripts): add safe_json_load() path-aware loader

### DIFF
--- a/scripts/json_helpers.py
+++ b/scripts/json_helpers.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def safe_json_load(path: str | Path, default: Any = None) -> Any:
+    """Load JSON from a file, returning default if the file doesn't exist or is invalid JSON."""
+    json_path = Path(path)
+
+    if not json_path.exists():
+        return default
+
+    try:
+        with json_path.open(encoding="utf-8") as file_obj:
+            return json.load(file_obj)
+    except (OSError, json.JSONDecodeError):
+        return default

--- a/tests/test_json_helpers.py
+++ b/tests/test_json_helpers.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.json_helpers import safe_json_load
+
+
+def test_safe_json_load_returns_default_for_missing_file(tmp_path: Path) -> None:
+    """Test that safe_json_load returns default when file doesn't exist."""
+    missing_path = tmp_path / "missing.json"
+
+    # Default is None
+    assert safe_json_load(missing_path) is None
+
+    # Custom default
+    assert safe_json_load(missing_path, default={}) == {}
+
+
+def test_safe_json_load_returns_default_for_empty_file(tmp_path: Path) -> None:
+    """Test that safe_json_load returns default when file is empty."""
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text("")
+
+    assert safe_json_load(empty_path, default=[]) == []
+
+
+def test_safe_json_load_returns_default_for_malformed_json(tmp_path: Path) -> None:
+    """Test that safe_json_load returns default when file contains invalid JSON."""
+    broken_path = tmp_path / "broken.json"
+    broken_path.write_text("{not-json")
+
+    assert safe_json_load(broken_path, default=[]) == []
+
+
+def test_safe_json_load_returns_parsed_result_for_valid_json(tmp_path: Path) -> None:
+    """Test that safe_json_load correctly parses valid JSON."""
+    good_path = tmp_path / "good.json"
+    good_path.write_text('{"name": "infiquetra", "count": 2}')
+
+    result = safe_json_load(good_path)
+    assert result == {"name": "infiquetra", "count": 2}
+
+
+def test_safe_json_load_accepts_str_path(tmp_path: Path) -> None:
+    """Test that safe_json_load accepts string paths (not just Path objects)."""
+    good_path = tmp_path / "string-path.json"
+    good_path.write_text('["a", "b"]')
+
+    result = safe_json_load(str(good_path))
+    assert result == ["a", "b"]


### PR DESCRIPTION
## Linked card

Closes #99

## What changed

- Added `scripts/json_helpers.py` with `safe_json_load(path: str | Path, default=None) -> Any` function
- Added `tests/test_json_helpers.py` with 5 tests covering missing file, empty file, malformed JSON, valid JSON, and str vs Path inputs
- Uses only Python standard library (json, pathlib, typing)

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
.venv/bin/python -m pytest tests/test_json_helpers.py -v
\`\`\`
5 passed

All ruff lint checks passed.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. ✓ Addressed in `scripts/json_helpers.py` with `safe_json_load()` function that returns default for missing files, empty files, or invalid JSON.
- AC 2: All named tests pass the verification command. ✓ All 5 tests in `tests/test_json_helpers.py` pass.
- AC 3: No dependencies added unless absolutely required. ✓ Only Python standard library modules used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Not violated - only `scripts/json_helpers.py` and `tests/test_json_helpers.py` changed
- Do NOT add third-party dependencies unless required by the task body: Not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: Not violated - new files created with focused implementation

## Notes

- Implementation follows the approved plan exactly
- Ruff lint checks pass with no warnings
- Tests use `tmp_path` fixture for isolated file creation per pytest best practices