### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,18 @@
+"""Small text formatting helpers used by scripts."""
+
+from __future__ import annotations
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return `word` pluralized by `count`.
+
+    Rules:
+    - Empty string input always returns empty string (regardless of count).
+    - count == 1 returns word unchanged.
+    - Otherwise returns `plural` if provided, else word + "s".
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,25 @@
+"""Tests for scripts.text_helpers."""
+
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_word_for_singular_count():
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_appends_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural_when_provided():
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_treats_zero_as_plural():
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_returns_empty_string_for_empty_word():
+    assert pluralize("", 1) == ""
+    assert pluralize("", 5) == ""
+    assert pluralize("", 5, plural="items") == ""


### PR DESCRIPTION
## Linked card

Closes #104

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word, count, *, plural=None)` function
- Created `tests/test_text_helpers.py` with 5 test cases covering singular, regular plural, custom plural, zero count, and empty string

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
\`\`\`

Result: 5 passed in 0.09s

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors — `pluralize()` in `scripts/text_helpers.py` handles empty string first, then `count == 1`, then non-singular with optional custom plural
- AC 2: All named tests pass — `test_pluralize_*` functions in `tests/test_text_helpers.py` all pass
- AC 3: No dependencies added — standard library only, no changes to any dependency files

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed
- Do NOT add third-party dependencies unless required: no dependencies added
- Do NOT refactor unrelated code in the touched files: both files are new, no refactoring occurred

## Notes

- Full pytest suite has a pre-existing failure in `test_todoist_client.py` due to a broken import (sys.exit(1) in the module). This is unrelated to this PR.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in scripts/text_helpers.py:pluralize()
- AC 2 (All named tests pass the verification command): ✓ addressed in tests/test_text_helpers.py - all 5 named tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - no dependencies added, stdlib only