### PR TITLE
feat(scripts): Add get_nested() dict path lookup

### DIFF
--- a/scripts/dict_helpers.py
+++ b/scripts/dict_helpers.py
@@ -1,0 +1,40 @@
+"""Dictionary traversal helper utilities."""
+
+from typing import Any
+
+
+def get_nested(data: dict, path: str, default: Any = None) -> Any:
+    """
+    Get a nested value from a dict using a dotted path string.
+
+    Args:
+        data: The dictionary to traverse
+        path: A dotted path string like "a.b.c"
+        default: Value to return if path is missing or non-dict encountered
+
+    Returns:
+        The value at the path, or default if path cannot be traversed
+
+    Examples:
+        >>> get_nested({"a": {"b": 1}}, "a.b")
+        1
+        >>> get_nested({"a": {"b": 1}}, "a.c", default=-1)
+        -1
+        >>> get_nested({"a": 1}, "a.b")
+        None
+        >>> get_nested({}, "")
+        {}
+    """
+    # Empty path returns the entire data
+    if path == "":
+        return data
+
+    current: Any = data
+    for part in path.split("."):
+        if not isinstance(current, dict):
+            return default
+        if part not in current:
+            return default
+        current = current[part]
+
+    return current

--- a/tests/test_dict_helpers.py
+++ b/tests/test_dict_helpers.py
@@ -1,0 +1,31 @@
+"""Tests for dict helper utilities."""
+
+from scripts.dict_helpers import get_nested
+
+
+def test_get_nested_returns_happy_path_value():
+    """Test basic nested dict lookup returns correct value."""
+    assert get_nested({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_nested_returns_default_for_missing_key():
+    """Test missing key returns specified default."""
+    assert get_nested({"a": {"b": 1}}, "a.c", default=-1) == -1
+
+
+def test_get_nested_returns_default_when_step_is_not_dict():
+    """Test that stepping into non-dict returns default."""
+    assert get_nested({"a": 1}, "a.b") is None
+
+
+def test_get_nested_empty_path_returns_entire_data():
+    """Test that empty path returns the entire dict unchanged."""
+    data = {"a": 1}
+    assert get_nested(data, "") == {"a": 1}
+    assert get_nested({}, "") == {}
+
+
+def test_get_nested_supports_three_or_more_levels():
+    """Test traversal through 3+ levels of nesting."""
+    data = {"a": {"b": {"c": {"d": "value"}}}}
+    assert get_nested(data, "a.b.c.d") == "value"


### PR DESCRIPTION
## Linked card

Closes #103

## What changed

- Added `scripts/dict_helpers.py` with `get_nested(data: dict, path: str, default=None) -> Any` function for dotted-path dictionary traversal
- Added `tests/test_dict_helpers.py` with 5 pytest test cases covering all specified behaviors

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
python3 -m pytest tests/test_dict_helpers.py -v --override-ini="addopts="
ruff check scripts/dict_helpers.py tests/test_dict_helpers.py
```

Output: 5 passed in 0.02s, All checks passed!

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in scripts/dict_helpers.py get_nested() function (lines 8-40)
- AC 2: All named tests pass the verification command — ✓ addressed in tests/test_dict_helpers.py (5 test functions, all passing)
- AC 3: No dependencies added unless absolutely required — ✓ only stdlib `typing.Any` used, no new dependencies

## Notes

- Implementation is ~32 lines (excluding docstring), well under the <40 line scope limit
- Empty path case returns `data` directly without any mutation
- All edge cases from the examples covered by tests

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body (see Notes) — ✓ addressed in scripts/dict_helpers.py get_nested() function (lines 8-40)
- AC 2 (verbatim): All named tests pass the verification command — ✓ addressed in tests/test_dict_helpers.py (5 test functions, all passing)
- AC 3 (verbatim): No dependencies added unless absolutely required — ✓ no new dependencies, only stdlib typing used