### PR TITLE
feat(blueprint-reviewer): new plugin for upstream-of-PR rubrics

### DIFF
--- a/plugins/blueprint-reviewer/.claude-plugin/plugin.json
+++ b/plugins/blueprint-reviewer/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "blueprint-reviewer",
+  "version": "0.1.0",
+  "description": "Multi-phase artifact review for the Infiquetra SDLC: blueprints, specs, and issues. Provides rubric-driven reviewers for the upstream-of-PR phases (idea, spec, issue) that complement the existing plan/PR review system in the home-lab orchestrator. Rubrics here are the canonical source of truth — the home-lab Ansible vendors them at deploy time.",
+  "author": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+  "keywords": [
+    "blueprint",
+    "spec",
+    "issue",
+    "reviewer",
+    "rubrics",
+    "sdlc",
+    "ideation",
+    "fidelity",
+    "devils-advocate",
+    "mount-olympus"
+  ]
+}

--- a/plugins/blueprint-reviewer/README.md
+++ b/plugins/blueprint-reviewer/README.md
@@ -1,0 +1,118 @@
+# blueprint-reviewer
+
+Multi-phase artifact review for the Infiquetra SDLC. Extends the
+review system upstream of PR/plan into the earlier lifecycle phases
+where mistakes are cheapest to fix.
+
+## The expanded lifecycle
+
+```
+IDEATION ─► BLUEPRINT ─► SPECIFICATION ─► ISSUE ─► PLAN ─► PR
+              repo:        spec.md         GH       (today's   (today's
+              campps-      outcome doc     issue    review)    review)
+              blueprint
+              mimir-
+              blueprint
+```
+
+Each transition is where things go wrong. This plugin contributes
+**rubrics** for the three new phases (idea, spec, issue) plus the
+**fidelity spine** that connects them. The plan and PR phases are
+already covered by reviewers in the home-lab orchestrator.
+
+## What's in this plugin
+
+### Rubrics
+
+The canonical rubric library lives under `rubrics/`. Each rubric is a
+markdown file with YAML frontmatter declaring which phase(s) it fires
+in and whether it's an always-runs core or an LLM-picked extra.
+
+| Phase | Cores (always run) | Extras (LLM-picked conditional) |
+|---|---|---|
+| **Idea** (blueprints) | problem_framing, assumption_audit, devils_advocate_blueprint, internal_consistency | alternatives_explored, prior_art_check, falsifiability, binding_constraint, stakeholder_coverage, incentive_audit |
+| **Spec** | outcome_clarity, acceptance_testability, blueprint_fidelity, devils_advocate_spec | measurement_plan, scope_unity, dependency_mapping, ramp_down_criteria |
+| **Issue** | devils_advocate_issue, spec_fidelity, acceptance_criteria_clarity | issue_sizing, context_completeness, prerequisite_mapping |
+
+### Two consumers
+
+1. **Manual review skill** (this plugin's `skills/blueprint-review/`) —
+   for ad-hoc deep-dive review of a blueprint section, spec, or issue.
+   Used during active iteration when the human is in the loop.
+
+2. **Home-lab orchestrator** (vendors rubrics from this repo) — for
+   automated PR-driven review of changes to blueprint repos
+   (`*-blueprint`), spec PRs in those repos, and issue review on
+   transition to `Backlog` on the Olympus project board.
+
+The two paths share the same rubric library so there's a single
+source of truth for "what does a good blueprint section look like?"
+and equivalent questions for specs and issues.
+
+## The fidelity spine
+
+A reviewer at every transition checks whether the artifact descends
+faithfully from its parent:
+
+| Reviewer | Phase | Question |
+|---|---|---|
+| `blueprint_fidelity` | spec | Does this spec descend from a blueprint? |
+| `spec_fidelity` | issue | Does this issue serve a spec? |
+| `plan_fidelity` | pr | Does this PR implement the plan? *(home-lab, existing)* |
+
+This is the connective tissue that catches scope drift across phases.
+
+## The devils_advocate dynasty
+
+Every phase has a phase-tuned skeptic:
+
+- `devils_advocate_blueprint` — challenge the framing
+- `devils_advocate_spec` — challenge the outcome definition
+- `devils_advocate_issue` — challenge the work definition
+- `devils_advocate` *(home-lab, existing)* — challenge the plan
+
+Each one shares the role ("argue the opposite, find the cracks") but
+with a phase-specific rubric calibrated to that artifact's failure
+modes.
+
+## Review log convention
+
+Reviews accumulate as provenance. Two patterns depending on artifact:
+
+**Section-embedded** (blueprint sections, specs):
+
+```markdown
+## Section: <name>
+
+(content here)
+
+<!-- review-log:start -->
+### Review log
+- 2026-05-01 — problem_framing v1 (8.5) — [comment](url) — "..."
+- 2026-05-08 — devils_advocate_blueprint v2 (7.0) — [comment](url) — "..."
+<!-- review-log:end -->
+```
+
+**Folder-of-reviews** (ADRs, where reviews are formal artifacts):
+
+```
+adrs/
+  adr-001-flutter-application-platform.md
+  reviews/
+    adr-001/
+      2026-05-01-devils_advocate_blueprint.md
+      2026-05-01-prior_art_check.md
+      2026-05-08-assumption_audit.md
+```
+
+## Status
+
+Phase A foundation: rubrics + plugin skeleton in place. Phase B
+(manual skill) and Phase C (automated PR review in home-lab) are
+the next layers.
+
+## See also
+
+- Lifecycle architecture: `infiquetra-sdlc/docs/lifecycle/ideation-to-pr.md`
+- Home-lab orchestrator (plan/PR phase reviewers + vendoring): `home-lab/ansible/roles/hermes_orchestrator/`
+- Sister plugin (SDLC management — board, issues, labels): `plugins/sdlc-manager/`

--- a/plugins/blueprint-reviewer/rubrics/idea/core/assumption_audit.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/core/assumption_audit.md
@@ -1,0 +1,67 @@
+---
+phases: [idea]
+applicability: always
+---
+# Assumption Audit lens
+
+Your focus: surface every assumption the blueprint makes — about
+users, infrastructure, data, regulation, organization, time, money,
+behavior — and assess which are validated vs. claimed.
+
+Unvalidated assumptions in a blueprint compound: they become
+implicit constraints in specs, hidden defaults in issues, and
+silent failures in code. Catch them here, where the cost of
+swapping an assumption is a paragraph rewrite, not a refactor.
+
+## What to look for
+
+- **User assumptions.** Does the blueprint assume users have specific
+  hardware, network conditions, language, prior knowledge, support
+  channels, or trust levels? Each one is potentially wrong.
+- **Infrastructure assumptions.** Cloud provider, region availability,
+  service-tier guarantees, third-party SLAs, backup/restore
+  capabilities. Many blueprints assume "AWS works" without checking
+  that the specific service is available in target regions.
+- **Data assumptions.** Volume, velocity, schema stability,
+  consistency model, retention requirements, regulatory class
+  (PII/PHI/PCI). Wrong here = expensive rewrite later.
+- **Behavioral assumptions.** "Users will X" claims. What's the
+  base rate? Have we seen them do similar things before?
+- **Organizational assumptions.** "We'll have a backend team
+  available," "ops will own this." Is that team's headcount /
+  buy-in actually confirmed, or aspirational?
+- **Temporal assumptions.** "By Q3" / "in 6 months" — is that based
+  on a sized estimate or a wishful target?
+- **Validation status per assumption.** For each surfaced
+  assumption: is it (a) validated by data the blueprint cites,
+  (b) testable but not yet tested, or (c) untestable / unfalsifiable?
+  The blueprint should distinguish.
+
+## Scoring
+
+- **10**: Every load-bearing assumption is named AND categorized
+  (validated / testable / untestable). Plan for testing the
+  testables exists.
+- **9**: Most assumptions named; one or two slipped in implicitly.
+- **8**: The big assumptions are out in the open; small ones are
+  embedded but readable.
+- **7**: Several material assumptions are presented as facts; needs
+  a separate "assumptions" section before specs descend.
+- **≤6**: Multiple critical assumptions hidden behind narrative
+  voice — "users want X," "the system handles Y," "compliance
+  requires Z" — without any cited basis.
+
+## REVISE criteria
+
+REVISE with: a specific assumption you found, the section/line that
+contains it, and what category you think it falls in. Example:
+"Section 4 paragraph 2 assumes users have always-on internet —
+that's a behavioral + infrastructure assumption. Validated for
+admin users (we have data); not validated for parents/families.
+Worth surfacing as a tracked assumption."
+
+## BLOCK only for
+
+- A blueprint that depends on an assumption known to be FALSE
+  (verifiable from data already in the blueprint or its source
+  documents).

--- a/plugins/blueprint-reviewer/rubrics/idea/core/devils_advocate_blueprint.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/core/devils_advocate_blueprint.md
@@ -1,0 +1,80 @@
+---
+phases: [idea]
+applicability: always
+---
+# Devil's Advocate (Blueprint phase) lens
+
+Your focus: challenge the blueprint's framing and direction. Find
+what's missing from the conversation, where premature consensus
+sneaked in, and what a hostile reader would say.
+
+The plan-phase devil's advocate (sibling rubric) challenges *plans*.
+You challenge *blueprints* — earlier, more abstract, more
+consequential. Your job is to be the voice that asks "but what if
+this whole framing is wrong?" before someone has implemented it.
+
+Default posture: contrarian-curious. Default verdict: NOT BLOCK.
+
+## What to look for
+
+- **"Looks like every other X" trap.** Does the blueprint
+  differentiate from prior art / competitors / industry norms?
+  If you swapped product names, would it apply to a dozen other
+  startups? If yes, the differentiation isn't on the page.
+- **Survivorship bias.** Does the blueprint cite winners as evidence
+  ("Spotify did X, so we should") without citing losers who tried the
+  same thing? Survivorship reasoning produces confidently wrong
+  blueprints.
+- **Premature consensus.** Is there evidence multiple options were
+  weighed, or does the blueprint read as a single confident
+  direction? If single-direction: was the team genuinely converged
+  or did one person write it and nobody pushed back?
+- **Stakes asymmetry.** What's the cost of being wrong on this
+  blueprint? Days? Weeks? Years? If it's years, the blueprint should
+  show MORE skepticism, not less.
+- **The "obvious" things.** Does the blueprint cite things as obvious
+  that aren't? "Obviously we'll use Postgres," "obviously users want
+  X" — anything that hides behind "obviously" deserves a hostile
+  read.
+- **Missing inverse.** What would the blueprint look like if you
+  argued the opposite direction? Does it survive the inversion test
+  ("would a competent team write a contrary blueprint with the same
+  data?")? If yes, the data isn't decisive.
+- **Buzzword density.** "AI-native," "cloud-first," "user-centric" —
+  empty signals. What concrete properties do these terms commit to,
+  and are they listed? Buzzwords that don't decompose into specifics
+  are red flags.
+- **Optimism leakage.** Are projections / assumptions phrased
+  optimistically without a corresponding pessimistic case? "Users
+  will adopt rapidly" needs "users may NOT adopt rapidly because..."
+  to be balanced.
+
+## Scoring
+
+- **10**: Blueprint shows its own arguments-against, names what could
+  invalidate it, weighs alternatives explicitly. Survives inversion.
+- **9**: Strong skeptical posture; one or two places where optimism
+  leaked in.
+- **8**: Reasonable for an early blueprint — has confidence but
+  hasn't shadowboxed every claim.
+- **7**: Reads single-voice; no visible counter-arguments. Should
+  add at least an "alternatives considered" section before specs
+  descend.
+- **≤6**: Blueprint reads like marketing copy — confident, vague,
+  full of "obvious" claims, no visible skepticism.
+
+## REVISE criteria
+
+REVISE with: a specific challenge to a specific section. Examples:
+- "Section 2 cites competitor X's success without engaging with
+  competitors Y and Z who tried the same thing and folded."
+- "Section 4 says 'obviously serverless' — but the blueprint's
+  workload pattern (high steady-state QPS, large persistent state)
+  is precisely what serverless costs MORE for. Argue this trade-off
+  explicitly."
+
+## BLOCK only for
+
+- Blueprint contradicts a load-bearing fact already known to the
+  team and documented (cite it). Pre-emptive lock-in based on
+  demonstrably-false premise.

--- a/plugins/blueprint-reviewer/rubrics/idea/core/internal_consistency.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/core/internal_consistency.md
@@ -1,0 +1,69 @@
+---
+phases: [idea]
+applicability: always
+---
+# Internal Consistency lens
+
+Your focus: do the blueprint's principles, claims, and decisions
+agree with EACH OTHER, or do they contradict in ways that will
+surface only when downstream specs try to descend from both?
+
+Blueprints accumulate over multiple authoring sessions, often by
+multiple authors. Contradictions creep in: a section claims
+"prioritize speed," another claims "compliance gates everything";
+a domain section says "users are admins," a use-case section
+addresses families. The earlier you catch these, the cheaper to fix.
+
+## What to look for
+
+- **Principle conflicts.** Are stated principles internally
+  consistent? If two principles point opposite directions, the
+  blueprint should explicitly resolve which trumps which (with
+  reasoning), not leave them both standing.
+- **Definition drift.** Is a key term used consistently across
+  sections? "User" might mean admin in section 2 and family in
+  section 6 — that's a drift, even if neither is wrong on its own.
+- **Scope drift.** Does an early section define a narrow scope and
+  a later section expand it without acknowledgment? Common pattern:
+  "MVP focuses on X" then chapter 8 quietly adds Y.
+- **Contradictory non-functional claims.** "We will be cost-
+  efficient AND highly available AND globally distributed AND
+  open-source" — these aren't all simultaneously achievable for
+  the budgets / team sizes most blueprints assume. Is the
+  trade-off named?
+- **Cross-section dependencies.** Does section A claim X based on
+  section B providing Y, while section B describes a system that
+  actually provides Z? Cross-references should match.
+- **Contradiction between blueprint and ADRs.** If the blueprint
+  cites ADRs (or vice-versa), do they actually align? An ADR that
+  picked tech X while the blueprint discusses architecture
+  assuming tech Y is a load-bearing inconsistency.
+- **Stale claims.** Earlier sections that haven't been updated
+  after a later section's decisions. "Section 3 (written month 1)
+  predicts X; Section 9 (written month 3) decided NOT-X but
+  Section 3 wasn't updated."
+
+## Scoring
+
+- **10**: All principles, definitions, scope, and cross-references
+  align. Trade-offs explicitly named where they could conflict.
+- **9**: Strong consistency; one minor terminology drift.
+- **8**: Reasonable consistency; a couple of unrunchecked
+  cross-references or one stale claim worth fixing.
+- **7**: Two or more material contradictions present that downstream
+  specs will trip over.
+- **≤6**: Multiple sections contradict each other on load-bearing
+  decisions. Specs descending from this will collapse.
+
+## REVISE criteria
+
+REVISE with: a specific contradiction, citing both sides. Format:
+"Section X line N says: <claim A>. Section Y line M says: <claim B>.
+These appear to contradict on <axis>. Which is intended, and should
+the other be updated?"
+
+## BLOCK only for
+
+- A contradiction so severe that no spec can be written without
+  picking a side, AND the blueprint expressly forbids picking a
+  side. (Rare.)

--- a/plugins/blueprint-reviewer/rubrics/idea/core/problem_framing.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/core/problem_framing.md
@@ -1,0 +1,63 @@
+---
+phases: [idea]
+applicability: always
+---
+# Problem Framing lens
+
+Your focus: is the stated problem the actual problem worth solving, or
+a proxy that will steer everything downstream off-course?
+
+The earlier the lifecycle, the cheaper a framing fix. By the time a
+spec is written, framing errors have ossified into outcome
+definitions; by the time issues are filed, into acceptance criteria.
+Catch them HERE.
+
+## What to look for
+
+- **Symptom vs. root.** Does the blueprint frame a symptom users
+  complain about, or the underlying mechanism producing the symptom?
+  "Users want faster checkout" is a symptom; "checkout requires 7
+  manual steps when 3 would do" is closer to root.
+- **Whose problem.** Is the user/persona named, or is the problem
+  generic ("users struggle with...")? A generic-sounding problem
+  often means no specific user has it.
+- **Counterfactual.** If this problem went unsolved for another year,
+  who specifically suffers, and how? If the answer is "nobody really,
+  it's just a thing we'd like to do" — the framing should say so.
+- **Proxy detection.** Is the problem stated in terms of a goal
+  (revenue, retention, NPS) that the team can't directly affect, or
+  in terms of a user experience the team CAN affect? Goals belong
+  in objectives; problems belong in user-affordance terms.
+- **Inherited framing.** Is this someone's else's framing carried
+  over uncritically (a competitor's positioning, an industry
+  whitepaper, a prior project's premise)? Inherited framing is
+  particularly dangerous because it's pre-validated-feeling without
+  actually being validated for THIS context.
+- **Falsification path.** What evidence would prove the framing
+  wrong? If nothing could, the framing is unfalsifiable mush.
+
+## Scoring
+
+- **10**: Framing names a specific user, a specific affordance gap,
+  and what evidence would falsify the framing. Hard to drift from.
+- **9**: Strong framing; minor specificity gap (e.g. user persona is
+  named but not characterized).
+- **8**: Reasonable framing for an early blueprint. The downstream
+  team can sharpen it during spec-writing.
+- **7**: Framing leans heavily on a proxy or symptom; will need
+  explicit redirection before specs descend cleanly.
+- **≤6**: Framing is genericized, inherited without examination, or
+  unfalsifiable. Specs descending from this will be ungrounded.
+
+## REVISE criteria
+
+REVISE with: a specific question the framing should answer ("who
+specifically experiences this problem and how often?") OR a specific
+re-framing suggestion ("frame in terms of the affordance gap, not the
+revenue impact").
+
+## BLOCK only for
+
+- Framing solves a problem the named user demonstrably does NOT
+  have (verifiable by 1 user-research datum the blueprint contains
+  or omits).

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/alternatives_explored.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/alternatives_explored.md
@@ -1,0 +1,68 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Alternatives Explored lens
+
+Your focus: did the blueprint genuinely consider real alternatives,
+or did it lock onto one direction prematurely and post-rationalize?
+
+## When you fire
+
+Picker selects you when the blueprint contains directional decisions
+(architecture choices, technology picks, business-model framing,
+go-to-market approach) without an explicit "alternatives considered"
+treatment.
+
+## What to look for
+
+- **Named alternatives, not strawmen.** Real alternatives are real
+  — actual products, real competitors, viable tech stacks. A
+  blueprint that lists "we considered doing nothing" or "we
+  considered building from scratch in assembly" as alternatives is
+  pretending to weigh options.
+- **Rejection criteria, not rejection adjectives.** "Option B was
+  too slow" is an adjective. "Option B's median request latency
+  exceeded our 200ms target by 3x" is a criterion. Real alternatives
+  analysis uses the latter.
+- **Reversibility.** Does the blueprint name which decisions are
+  reversible later vs. one-way doors? The latter deserve more
+  alternatives analysis; the former can move with less.
+- **Status quo as alternative.** Is "keep doing what we're doing
+  today" treated as a real alternative, with an honest cost-benefit
+  vs. the new direction? If the blueprint never engages with the
+  status quo's strengths, it's not weighing alternatives.
+- **Order of selection.** Was the choice made FIRST and alternatives
+  retrofitted? Tells: alternatives section is short, critique of
+  alternatives is one-sided, no reasoning for why the chosen option
+  beat them on rejection criteria.
+- **Combinatorial alternatives.** Many decisions are made jointly
+  (front-end framework × backend × deployment × monitoring). Did
+  the blueprint consider COMBINATIONS, or one decision at a time
+  in isolation?
+
+## Scoring
+
+- **10**: Named alternatives, real rejection criteria, reversibility
+  flagged, status quo engaged, combinatorial considerations visible.
+- **9**: Strong alternatives treatment; one minor gap (e.g. status
+  quo not separately addressed).
+- **8**: Adequate for early blueprint; specs can sharpen later.
+- **7**: Alternatives section feels retrofitted; criteria are
+  adjective-level not measurement-level.
+- **≤6**: Blueprint locked onto a direction with zero or strawman-
+  level alternatives.
+
+## REVISE criteria
+
+REVISE with: a specific alternative that should have been weighed
+and a measurable criterion that would have decided. "Considered Flutter
+but not React Native — both fit the cross-platform mandate; the
+reasoned trade-off (e.g. team's prior experience, native-feeling on
+iOS, build complexity) isn't shown."
+
+## BLOCK only for
+
+- Blueprint declares a one-way-door decision (e.g. data architecture
+  for a regulated industry) with NO alternatives analysis. The
+  reversibility cost is too high to skip the work.

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/binding_constraint.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/binding_constraint.md
@@ -1,0 +1,84 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Binding Constraint lens
+
+Your focus: what is the ONE constraint that gates everything else?
+If it isn't addressed, the rest of the blueprint is decoration.
+
+Theory of Constraints applied to product blueprints: every system has
+exactly one binding constraint at any given time. Energy spent on
+non-binding constraints is mostly wasted. Energy spent on the binding
+one moves the whole system. Most blueprints diffuse attention across
+many constraints; this rubric asks "which one actually matters?"
+
+## When you fire
+
+Picker selects you when the blueprint discusses multiple constraints
+(time, money, headcount, technology, regulation, market window)
+without explicitly naming which is the binding one.
+
+## What to look for
+
+- **The named binding constraint.** Does the blueprint say "X is the
+  thing we have to solve before anything else matters"? If yes,
+  evaluate whether that's right (often it is, sometimes the wrong
+  one is named).
+- **The unnamed binding constraint.** If the blueprint doesn't name
+  one, can YOU pick it from the content? It's usually the constraint
+  that, if relaxed by 50%, would unlock the most. Often it's:
+  - **Headcount** (small team can't ship multiple modules in
+    parallel)
+  - **Capital runway** (unproven model + 9 months of runway = market
+    discovery is the binding constraint, not architecture)
+  - **Customer acquisition** (product is fine but distribution is
+    the bottleneck)
+  - **Single technical risk** (one unknown that gates everything
+    else, like "can we build the AI part to required accuracy?")
+  - **Regulatory clearance** (can't ship before approval)
+  - **A specific user-trust threshold** (early adopters won't bring
+    others until X is true)
+- **Decoration check.** What % of the blueprint discusses things
+  that DON'T move the binding constraint? Architecture decisions,
+  competitive analyses, and feature lists often don't. They might
+  still be necessary, but the blueprint should acknowledge that
+  energy spent on them doesn't move the needle until the binding
+  constraint is addressed.
+- **Sequencing.** Once the binding constraint is named, does the
+  blueprint sequence work to address it FIRST? Or is it sequenced
+  by team capacity / technology dependency / political comfort?
+- **Constraint shift recognition.** The binding constraint changes
+  over time. Does the blueprint acknowledge what the SECOND
+  binding constraint is (the one that becomes binding once the
+  first is relaxed)?
+
+## Scoring
+
+- **10**: Binding constraint named, addressed first, second-order
+  constraint named, decoration acknowledged.
+- **9**: Strong; binding constraint named but second-order
+  constraint glossed.
+- **8**: Adequate; the right binding constraint is implicit in the
+  sequencing.
+- **7**: Blueprint diffuses across multiple "important" things
+  without picking the binding one.
+- **≤6**: Blueprint focuses on a non-binding constraint while the
+  real binding one goes unaddressed (e.g. obsessing over
+  architecture when the binding constraint is "we don't know if
+  customers want this").
+
+## REVISE criteria
+
+REVISE with: what you think the binding constraint is and why,
+plus what evidence would change your mind. "It looks like the
+binding constraint here is customer-acquisition cost — runway is
+24 months but CAC is unproven. Architecture pages 12-30 don't
+move that constraint. Suggest adding a discovery sub-blueprint to
+de-risk CAC before further architecture investment."
+
+## BLOCK only for
+
+- Blueprint expressly avoids identifying a binding constraint and
+  the resulting work plan is circular (each piece blocks on
+  another). Effectively non-actionable.

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/falsifiability.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/falsifiability.md
@@ -1,0 +1,65 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Falsifiability lens
+
+Your focus: what evidence would prove the blueprint's central claims
+WRONG? If the answer is "nothing could," the blueprint is structured
+to be unfalsifiable, and unfalsifiable plans waste time gracefully.
+
+## When you fire
+
+Picker selects you when the blueprint contains big directional claims
+("users will love this," "this will scale to N users," "this approach
+is more efficient") without paired falsification criteria.
+
+## What to look for
+
+- **Claim-evidence pairing.** For each load-bearing claim, what
+  evidence supports it AND what evidence would contradict it? A
+  blueprint that lists supporting evidence without listing
+  potentially-contradicting evidence is doing motivated reasoning.
+- **Predictions.** Does the blueprint make any concrete predictions
+  ("by month 6, X will happen"; "if we do A, B will result")?
+  Predictions are the unit of falsifiability. No predictions = no
+  falsifiability.
+- **Pre-registered failure conditions.** Does the blueprint say
+  "if we see X, we'll know we were wrong"? This is the strongest
+  form. Most blueprints don't have it.
+- **Survivor-bias-resistant evidence.** Is the cited evidence
+  selected because it confirms ("look, X startup did it"), or is
+  it cherry-pick-resistant (cohort analysis, base rates, paired
+  cases)?
+- **Refutability of metrics.** If success metrics are listed
+  ("retention," "conversion," "performance"), are the failure
+  thresholds defined? "Better than today" without a threshold is
+  not falsifiable — anything above today's number passes.
+- **Internal contradictions surface refutability.** Sometimes a
+  blueprint contradicts itself in ways that make ONE of the
+  contradictions falsifiable — that's actually a feature, exposed
+  by this rubric.
+
+## Scoring
+
+- **10**: Each load-bearing claim has paired evidence + counter-
+  evidence + falsification criterion. Predictions concrete.
+- **9**: Strong falsifiability; one or two claims could be sharpened.
+- **8**: Adequate; the claims that matter most are falsifiable; small
+  ones less so.
+- **7**: Blueprint has predictions but no failure thresholds.
+- **≤6**: Blueprint structured so nothing could prove it wrong.
+  "Users will love it." "It will scale." Ungrounded.
+
+## REVISE criteria
+
+REVISE with: a specific unfalsifiable claim, and a proposed
+falsification criterion. "Section 5 says 'parents will engage with
+the platform daily.' Add a falsification: 'within 90 days of MVP
+launch, if median parent session frequency is < 1/week, this claim
+is contradicted and we revisit the parent-facing scope.'"
+
+## BLOCK only for
+
+- A blueprint where ALL load-bearing claims are unfalsifiable. The
+  blueprint cannot be evaluated, only believed or not.

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/incentive_audit.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/incentive_audit.md
@@ -1,0 +1,81 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Incentive Audit lens
+
+Your focus: who benefits from this blueprint succeeding? Who pays
+the cost? Who loses if it's adopted? Misaligned incentives surface
+as adoption failure, support burden, or regulatory backlash long
+after the blueprint becomes code.
+
+Money trail + status trail + workflow-cost trail. Three independent
+lenses; if any has a stakeholder being asked to absorb cost without
+upside, that's a fragility.
+
+## When you fire
+
+Picker selects you when the blueprint touches a multi-party domain:
+two-sided marketplaces, B2B-to-end-user products, workflow systems
+with admin/end-user splits, anything where the buyer ≠ the user.
+
+## What to look for
+
+- **Buyer vs. user split.** Is the buyer the same as the user? If
+  not, the blueprint must address both — buyer cares about ROI,
+  user cares about workflow. Blueprints that optimize for the
+  buyer ignore the user's daily friction; blueprints that optimize
+  for the user produce stalled adoption because the buyer never
+  approves rollout.
+- **Work-shifting.** Does the blueprint shift work between parties?
+  ("Parents fill in their own data" — moves work from admins to
+  parents. Parents have to be incentivized to absorb that.) Every
+  work-shift needs a corresponding incentive-shift, or the system
+  fails at the shifted-to party.
+- **Status changes.** Does this blueprint create new winners or
+  losers in someone's workplace? "Self-service tool" often
+  effectively demotes the role of the people who used to do it
+  for-them. They will resist quietly.
+- **Cost incidence.** If the blueprint has costs (subscription
+  fees, transaction fees, time costs), who bears them? Cost
+  borne by the wrong party = pricing failure.
+- **Network-effect winners.** For multi-sided platforms: each
+  side's growth depends on the other; who makes the early
+  investment with no immediate return? That side is the bootstrap
+  problem.
+- **Default-vs-explicit choice.** If the blueprint default-opts
+  someone into something costly to them (data sharing, vendor
+  lock-in, deprecating their existing process), they will revolt.
+  Defaults need to be aligned with the default party's interest.
+- **Long-tail beneficiary.** Some blueprints have a named primary
+  beneficiary but a large unnamed group that ALSO benefits without
+  being asked. That's fine, but worth noting — sometimes the
+  unnamed group is actually the primary value and the explicit
+  one is secondary.
+
+## Scoring
+
+- **10**: Each stakeholder's incentive named (gain, cost, status
+  change). Mismatches surfaced and addressed.
+- **9**: Strong; one stakeholder's cost glossed.
+- **8**: Adequate; primary parties' incentives engaged.
+- **7**: Blueprint optimized from one party's view; cost-bearing
+  parties' incentives unaddressed.
+- **≤6**: Blueprint asks a stakeholder to bear material cost with
+  no visible compensating value.
+
+## REVISE criteria
+
+REVISE with: a specific incentive mismatch. "Section 7 asks camp
+directors to enter Activity-of-Daily-Living data nightly — that's
+~30 minutes of new work. The benefit is 'better safety records'
+which accrues to the parent and the regulator, not the director.
+What's the director's gain? If the answer is 'avoiding liability,'
+make that explicit in the blueprint so the spec phase designs
+the workflow to highlight liability-protection."
+
+## BLOCK only for
+
+- Blueprint design depends on a stakeholder absorbing significant
+  cost AND there's documented evidence (citation, prior data) that
+  this stakeholder class historically refuses similar costs.

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/prior_art_check.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/prior_art_check.md
@@ -1,0 +1,68 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Prior Art Check lens
+
+Your focus: has someone already solved this, partially solved it, or
+tried and failed? The blueprint should engage with prior art —
+copying, learning from, or explicitly diverging.
+
+## When you fire
+
+Picker selects you when the blueprint covers a problem-space domain
+where prior art is likely to exist (most non-trivial domains),
+especially when the blueprint reads as if the problem is novel.
+
+## What to look for
+
+- **Open-source projects in the same space.** Are there OSS
+  projects that solve some/all of the problem? If yes, the blueprint
+  should name the closest 1-3 and explain "we use / extend / replace
+  this because X."
+- **Prior commercial attempts.** Has someone tried this commercially
+  and succeeded, failed, pivoted? Each is informative. A failed
+  prior attempt is especially important — what did they learn the
+  hard way that we can copy?
+- **Published research.** For domains where research literature is
+  active (ML, distributed systems, security), is the relevant
+  literature cited or at least gestured at? "We're using algorithm X"
+  with a paper link beats inventing X from scratch.
+- **Internal prior art.** Has someone in this organization (or a
+  predecessor org) already tried something adjacent? Tribal knowledge
+  is the most valuable prior art and the easiest to forget.
+- **Standards / specs.** For data formats, protocols, security: is
+  there an RFC / industry standard the blueprint should align with?
+  Diverging from a standard is fine — claiming to invent one fresh
+  is usually NOT.
+- **Recent shifts.** Has the prior-art landscape changed recently
+  (last 12-24 months)? A blueprint that references prior art from
+  before a major paradigm shift is likely outdated.
+
+## Scoring
+
+- **10**: 3+ pieces of prior art named and engaged with — including
+  at least one failure case. Position relative to prior art is
+  explicit.
+- **9**: Strong prior art treatment; one expected reference missing
+  (recent or specialized).
+- **8**: Adequate for early blueprint; specs/architecture phases
+  can deepen.
+- **7**: One or two references but no genuine engagement (cited
+  without analysis).
+- **≤6**: Blueprint reads as if the problem is novel when prior
+  art is plentiful; "first to do this" claims unsupported.
+
+## REVISE criteria
+
+REVISE with: a specific piece of prior art the blueprint should
+engage with, and what aspect (architecture, business model, failure
+modes, validation methodology). Be specific — "they should look at
+projectX" not enough; "projectX failed because of Y; we should
+explicitly state how we avoid Y."
+
+## BLOCK only for
+
+- Blueprint claims novelty in a space with abundant prior art and
+  uses that claimed novelty as load-bearing justification (e.g.
+  for funding, scope, or technical risk acceptance).

--- a/plugins/blueprint-reviewer/rubrics/idea/extras/stakeholder_coverage.md
+++ b/plugins/blueprint-reviewer/rubrics/idea/extras/stakeholder_coverage.md
@@ -1,0 +1,74 @@
+---
+phases: [idea]
+applicability: conditional
+---
+# Stakeholder Coverage lens
+
+Your focus: whose perspective is missing from this blueprint?
+Stakeholders ignored at the blueprint stage become problem-cases
+discovered late, when their concerns are most expensive to address.
+
+## When you fire
+
+Picker selects you when the blueprint discusses a system with
+multiple stakeholder classes (end-users, admins, ops, security,
+support, finance, legal/compliance, partners, regulators) but reads
+from a single dominant perspective.
+
+## What to look for
+
+- **Stakeholder enumeration.** Does the blueprint name stakeholders?
+  At minimum: who uses the system, who operates it, who buys it,
+  who depends on its outputs, who's regulated by it.
+- **Per-stakeholder concerns.** For each named stakeholder, what
+  matters to them? End-users care about workflow speed; ops cares
+  about runbooks + alerting; security cares about audit + blast
+  radius; finance cares about unit economics; support cares about
+  diagnosability of user-reported issues.
+- **The forgotten ones.** Common omissions:
+  - **Support** — "how do support agents diagnose this?" rarely
+    appears in blueprints, then surfaces 6 months later when
+    tickets pile up.
+  - **Ops on-call** — runbook surface, observability hooks,
+    rollback procedures.
+  - **The losing user** — for any feature that creates a winner,
+    someone loses access / loses status / pays the cost. Often
+    invisible.
+  - **The user who quits.** Departing users still have data.
+    Deletion / portability / contractual compliance.
+  - **Adversarial users** — abuse, fraud, gaming.
+  - **Regulators** — even if no specific regulation applies today,
+    the blueprint domain may have one coming (privacy, AI safety,
+    accessibility).
+- **Stakeholder conflict.** When two stakeholders' concerns
+  conflict (e.g. user privacy vs. admin oversight; speed vs.
+  audit; revenue vs. trust), does the blueprint name the conflict
+  and propose a resolution, or paper over it?
+- **Specific personas, not generic.** "Users" is generic. "Camp
+  director scheduling staff" is specific. Specific personas force
+  the blueprint to engage with real workflows, not stylized ones.
+
+## Scoring
+
+- **10**: All stakeholder classes named, per-stakeholder concerns
+  surfaced, conflicts named with resolution direction.
+- **9**: Strong coverage; one minor stakeholder under-discussed.
+- **8**: Adequate; major stakeholders covered, secondary
+  stakeholders implicit.
+- **7**: Blueprint addresses 1-2 stakeholders well; others mentioned
+  but not engaged.
+- **≤6**: Single-stakeholder blueprint (usually written from the
+  primary user's perspective only). Ops, support, security, edge
+  users invisible.
+
+## REVISE criteria
+
+REVISE with: a specific missing stakeholder + a specific concern
+they'd raise. "Support is missing — when a parent reports 'my
+camper's allergy data is wrong,' what's the support workflow?
+The blueprint mentions data-entry but not data-correction-by-support."
+
+## BLOCK only for
+
+- Blueprint targets a regulated domain (healthcare, financial,
+  child-safety) and omits the regulator stakeholder entirely.

--- a/plugins/blueprint-reviewer/rubrics/issue/core/acceptance_criteria_clarity.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/core/acceptance_criteria_clarity.md
@@ -1,0 +1,70 @@
+---
+phases: [issue]
+applicability: always
+---
+# Acceptance Criteria Clarity lens
+
+Your focus: are the ACs tight enough that the agent and the PR
+reviewer would reach the SAME verdict from the AC text alone?
+
+This is the issue-level analog to spec's `acceptance_testability` —
+sharper, because issues are what an agent actually plans against,
+and what a PR reviewer actually verifies. Ambiguous ACs at issue
+phase produce R2/R3 review loops where reviewers disagree about
+whether AC X is satisfied.
+
+## What to look for
+
+- **Pass/fail unambiguous.** Each AC should have a clear
+  pass/fail test. "AC: form validates input" is not a pass/fail
+  test — what counts as validation? "AC: form displays inline
+  error message when email field is empty on submit" is.
+- **Observable artifact.** What artifact (file change, log line,
+  DB row, API response, UI screenshot, test name) constitutes
+  evidence of AC satisfaction? An AC with no nameable artifact
+  is reviewer-subjective.
+- **Reviewer-text identical.** Imagine reading just the AC text
+  with no other context. Could you, as a reviewer, write a
+  test for this? If not, the AC is not concrete enough.
+- **Negative-case bounded.** Each AC should bound what it does
+  NOT cover. "AC: input field accepts emails" — what about
+  invalid emails? International characters? Empty strings? The
+  AC should specify or the reviewer will have to invent.
+- **Quantitative ACs need methodology.** "Latency under 500ms" —
+  measured how? from where? at what percentile? on what
+  hardware? Quantitative ACs without methodology are not
+  testable, even at issue level.
+- **Test mention.** Modern issue ACs often name the test that
+  would prove satisfaction ("AC: tests/e2e/registration.test.ts
+  passes the new registration-flow scenario"). This is the
+  strongest form.
+- **AC count + balance.** Issues with 1-3 ACs are usually
+  under-spec'd; >8 ACs are usually over-bundled (multiple issues
+  in disguise). Sweet spot 4-7 for most issues.
+- **Cross-AC overlap.** Two ACs shouldn't ambiguously test the
+  same thing. Each AC adds a distinct testable property.
+
+## Scoring
+
+- **10**: Each AC has pass/fail criterion, observable artifact,
+  negative-case bound, methodology where quantitative,
+  reviewer-text-self-sufficient.
+- **9**: Strong; one AC has thin methodology.
+- **8**: Adequate; load-bearing ACs are clear, secondary ACs
+  could sharpen.
+- **7**: Multiple ACs are vague or imply subjective verdicts.
+- **≤6**: ACs are direction-without-threshold, or one-line
+  fragments that nobody could test from.
+
+## REVISE criteria
+
+REVISE with: a specific fuzzy AC + a proposed sharper version.
+"AC #2 'login feels fast' — fuzzy. Suggest: 'login p95 wall-clock
+from form-submit to authenticated-redirect is < 800ms on the
+staging environment with 50 concurrent simulated users.'"
+
+## BLOCK only for
+
+- Issue has zero ACs (work is undefined).
+- ACs reference internal contradictions (AC #1 requires X, AC #4
+  forbids X) — issue is incoherent.

--- a/plugins/blueprint-reviewer/rubrics/issue/core/devils_advocate_issue.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/core/devils_advocate_issue.md
@@ -1,0 +1,79 @@
+---
+phases: [issue]
+applicability: always
+---
+# Devil's Advocate (Issue phase) lens
+
+Your focus: challenge the issue's framing as work to be done. Find
+where the issue assumes too much, scopes too broadly, or sneaks in
+work that doesn't serve the parent spec.
+
+Issue phase is the LAST chance to catch problems cheaply. Once an
+agent picks up the issue and starts planning, costs rise quickly
+(LLM tokens, branch lifecycle, review overhead). Catch issue-level
+problems here.
+
+Default posture: skeptical-of-this-specific-piece-of-work. Default
+verdict: NOT BLOCK.
+
+## What to look for
+
+- **Smallest useful slice.** Is this the smallest CHANGE that
+  delivers value, or is it bundled with adjacent work that
+  COULD ship separately? "While we're in there, also..." is the
+  scope-creep tell.
+- **Hidden refactor.** Does the issue title describe a feature
+  but the body describes refactoring? Mixed-purpose issues
+  (feature + refactor + cleanup) produce unwieldy PRs.
+- **Wrong-level abstraction.** Is the issue at the right altitude
+  for one PR? "Add error handling" is too abstract — needs
+  scoping. "Implement the entire admin UI" is too coarse —
+  needs splitting.
+- **Premature design.** Does the issue prescribe HOW to
+  implement at a level the agent should be deciding during
+  planning? Pre-deciding implementation details often forecloses
+  better approaches the agent would otherwise find.
+- **Title-vs-body mismatch.** Sometimes the title and body
+  describe different work. The body always wins; the title was
+  probably written before the body and not updated.
+- **Implicit prerequisites.** Does the issue assume work that
+  hasn't been done? "Add the X feature" might assume Y exists,
+  when Y is also pending.
+- **Failure-mode blindness.** Does the issue body discuss what
+  happens when the change is incorrect / fails / partially
+  rolls out?
+- **Acceptance bait-and-switch.** ACs that don't match the title
+  / body — the issue says "fix bug X" but ACs say "verify Y, Z,
+  and W don't regress." That's testing scope, not change scope.
+- **Unscoped non-functional asks.** "And it should be fast" /
+  "and it should be secure" tacked on to an otherwise-bounded
+  issue without performance or security ACs. Either scope them
+  or remove them.
+
+## Scoring
+
+- **10**: Smallest useful slice, single purpose, right
+  abstraction level, leaves implementation choices open, ACs
+  align with title/body.
+- **9**: Strong; one minor scope-creep or pre-decision.
+- **8**: Adequate; the work is bounded with one or two minor
+  smells.
+- **7**: Multiple structural concerns — bundled work, premature
+  design, or fuzzy scope.
+- **≤6**: Issue is fundamentally too big, too small, or
+  describes confused work.
+
+## REVISE criteria
+
+REVISE with: a specific structural concern. "Issue title is 'Add
+allergy field to camper form' but ACs include 'verify that
+existing camper records migrate cleanly.' That's a separate
+piece of work (data migration) and probably its own issue."
+
+## BLOCK only for
+
+- Issue contradicts the parent spec's outcome direction. Already
+  caught by spec_fidelity but escalates here if missed.
+- Issue describes work whose scope is so unbounded the agent
+  cannot reasonably plan it (e.g. "improve performance" with no
+  metric, no boundary, no acceptance threshold).

--- a/plugins/blueprint-reviewer/rubrics/issue/core/spec_fidelity.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/core/spec_fidelity.md
@@ -1,0 +1,69 @@
+---
+phases: [issue]
+applicability: always
+---
+# Spec Fidelity lens
+
+Your focus: does this issue actually serve a named spec, or has it
+drifted into work the spec didn't authorize?
+
+The fidelity spine continues here. Issues that don't trace back to
+specs produce code that doesn't trace back to outcomes — work
+shipped without a way to know if it helped.
+
+## What to look for
+
+- **Named spec.** Does the issue cite its parent spec? Format
+  ideally: "Spec: [link to spec.md]" so a reader can verify
+  descent.
+- **AC ⇄ spec AC mapping.** Does each issue AC trace to a spec
+  AC (or a clear sub-component of one)? Issue ACs that don't
+  appear in any spec AC are scope creep.
+- **Outcome alignment.** Does the issue's work move the spec's
+  outcome metric, or does it move some adjacent metric? Common
+  drift: spec optimizes for X, issue optimizes for Y because Y
+  is easier to measure.
+- **Scope subset.** Is the issue a coherent subset of the spec's
+  scope, or has it expanded? Expansion is fine if EXPLICITLY
+  acknowledged ("this issue extends the spec to also cover...").
+- **Constraint inheritance.** The spec inherited constraints
+  from its parent blueprint. Does the issue inherit them too?
+  Often issues that descend from late-stage specs lose the
+  upstream constraints in transit.
+- **Definition consistency.** Does the issue use the same
+  terms-of-art the spec defined? Drift to synonyms causes
+  reviewer-vs-implementer divergence at PR time.
+- **Spec freshness.** If the spec was updated AFTER the issue
+  was filed, does the issue reflect the spec's current state?
+  Stale-against-spec issues are common.
+- **Out-of-spec hidden.** Does the issue smuggle in work that
+  the spec EXPLICITLY excluded? Specs have non-goals; issues
+  shouldn't quietly include them.
+
+## Scoring
+
+- **10**: Named spec, ACs map cleanly, outcome aligned, scope is
+  a coherent subset, constraints inherited, terms consistent,
+  fresh against spec.
+- **9**: Strong; one minor terminology drift or one AC slightly
+  expanded.
+- **8**: Adequate; primary descent clean, secondary alignments
+  could sharpen.
+- **7**: Multiple silent expansions or one un-cited constraint
+  loss.
+- **≤6**: Issue contradicts the spec without acknowledgment, or
+  descends from no named spec at all.
+
+## REVISE criteria
+
+REVISE with: a specific drift + the spec section it drifts from.
+"Issue AC #3 says 'admin sees usage chart on home screen.'
+Spec scope (section 4) is server-side data aggregation only;
+UI is explicitly out-of-scope until a follow-up spec. Either
+remove this AC or escalate to amend the spec."
+
+## BLOCK only for
+
+- Issue descends from a SPEC the team has never written. The
+  fidelity chain is broken at the issue→spec link.
+- Issue contradicts a spec AC outright.

--- a/plugins/blueprint-reviewer/rubrics/issue/extras/context_completeness.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/extras/context_completeness.md
@@ -1,0 +1,82 @@
+---
+phases: [issue]
+applicability: conditional
+---
+# Context Completeness lens
+
+Your focus: does the issue body contain enough technical pointers
+that an agent can plan WITHOUT guessing? Insufficient context
+produces planning loops that hallucinate file paths, reinvent
+existing helpers, or skip established conventions.
+
+## When you fire
+
+Picker selects you when the issue describes a code change in a
+non-trivial repo where conventions / file layout / shared
+abstractions matter (which is most non-trivial repos).
+
+## What to look for
+
+- **Named files / modules.** Does the issue identify the
+  files/modules where the change goes, or does it leave the
+  agent to grep the codebase from scratch? Specific paths
+  ("`lib/services/registration_service.dart`") prevent
+  hallucination.
+- **Cross-references.** If the change interacts with existing
+  code (calling a function, extending a class, conforming to an
+  interface), is the existing code's location pointed at?
+- **Conventions to follow.** "We pattern <X> after <Y>." For
+  any non-obvious convention this code should follow, the
+  issue should name a precedent ("see how `Service A` handles
+  it").
+- **Test expectations.** What test file does the new test go
+  in? What test framework? What style (table-driven? property-
+  based? snapshot?). Issues that don't specify test expectations
+  produce inconsistent test styles across PRs.
+- **Data model linkages.** If the change touches data models,
+  does the issue point at the model definitions, the migration
+  history, the validation rules?
+- **API contract linkages.** If the change touches API surface,
+  does the issue point at the OpenAPI / proto / typed-client
+  definition? Without a pointer, the agent might create new
+  types that diverge from existing ones.
+- **Permitted vs. forbidden additions.** Some issues need
+  explicit "you may add file X but DO NOT touch file Y" —
+  particularly when there's a tempting-but-wrong path through
+  adjacent code.
+- **External docs referenced.** If the change implements a
+  third-party API, RFC, or SDK feature, is the spec link in
+  the issue? Agents that have to hunt for external docs hit
+  rate-limits and lose context.
+- **Missing-context proxy.** Even without auditing each item:
+  if you imagine yourself as an agent picking up this issue
+  with zero prior context, can you start planning, or do you
+  need to read 5 files to even know where to start?
+
+## Scoring
+
+- **10**: Files named, cross-references provided, conventions
+  cited, test expectations specified, external docs linked.
+  Agent could plan without grepping.
+- **9**: Strong; one or two pointers thin (e.g. test framework
+  not specified).
+- **8**: Adequate; the load-bearing pointers are present.
+- **7**: Issue describes the WHAT but not the WHERE; agent
+  will need to grep significantly.
+- **≤6**: Issue is high-level prose with no technical pointers.
+  Agent will hallucinate or get lost.
+
+## REVISE criteria
+
+REVISE with: a specific missing pointer + impact. "Issue says
+'add a registration endpoint' but doesn't name where. The repo
+has registration logic split across 3 services. Add a pointer:
+'this lives in services/registration-api/, see existing
+endpoints in routes.ts for the pattern to follow.'"
+
+## BLOCK only for
+
+- Issue is so context-thin that planning is impossible. The
+  agent would need to do discovery work before planning, which
+  is more expensive than the human writing 3 lines of context
+  upfront.

--- a/plugins/blueprint-reviewer/rubrics/issue/extras/issue_sizing.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/extras/issue_sizing.md
@@ -1,0 +1,72 @@
+---
+phases: [issue]
+applicability: conditional
+---
+# Issue Sizing lens
+
+Your focus: is this issue right-sized for ONE PR? Too small =
+overhead exceeds the change; too big = unwieldy review and high
+abandonment rate.
+
+## When you fire
+
+Picker selects you when the issue's body suggests scope concerns
+(many ACs, multiple components, "and also..." patterns) or when
+the title is broad enough to imply >1 PR.
+
+## What to look for
+
+- **One-PR rule of thumb.** Can a single agent open a single PR
+  in <1 day of focused work and have a competent reviewer
+  approve it? If yes: well-sized. If no: too big.
+- **Component count.** How many distinct files/areas does this
+  issue touch? Spanning many areas usually means many concerns
+  bundled. Generic guideline: 3-8 file changes is typical;
+  >15 is usually multi-issue-in-disguise.
+- **AC count.** 4-7 ACs typical; <3 often under-specified; >8
+  usually over-bundled.
+- **Cross-component coupling.** If the issue spans frontend +
+  backend + database + ops, that's 4 disciplines. Splitting by
+  component often reduces cycle time and per-PR review cost.
+- **Refactor + feature.** Issues that mix refactoring with
+  feature work are often badly-sized. Refactor PRs and feature
+  PRs review differently; bundling them produces PRs that are
+  hard to evaluate.
+- **Test coupling.** Does the issue require establishing new
+  test infrastructure? If yes, that's often a separate issue
+  (the infra) before this one (the feature using it).
+- **Migration-shaped.** Issues that include data migration are
+  almost always too big for one PR. Migrate first, then add
+  feature; two issues, two PRs.
+- **Time-of-day to ship.** Some issues touch riskier production
+  surface (auth, billing, data writes). Right-sizing for these
+  means smaller scope so review burden is concentrated where it
+  helps most.
+
+## Scoring
+
+- **10**: One PR, single component, 4-7 ACs, <1 day focused work,
+  feature-only or refactor-only.
+- **9**: Strong sizing; one minor scope item could split.
+- **8**: Adequate; the issue is bounded, sizing is approximate.
+- **7**: Issue spans 2-3 distinct concerns; would benefit from
+  splitting but could be implemented as-is.
+- **≤6**: Issue requires multiple PRs or coordinated rollout —
+  must be split before agent picks it up.
+
+## REVISE criteria
+
+REVISE with: a specific split suggestion. "Issue covers (a) new
+endpoint, (b) DB schema migration, (c) frontend integration.
+Suggest splitting:
+- Issue 1: schema migration + tests (no API surface change)
+- Issue 2: new endpoint (using migrated schema)
+- Issue 3: frontend integration (using new endpoint)
+This reduces per-PR review burden and lets us pause between
+phases if any of them surfaces problems."
+
+## BLOCK only for
+
+- Issue is so large it's effectively a spec ("implement the
+  admin dashboard"). Hand back to spec phase to decompose, OR
+  decompose at issue phase before picking up.

--- a/plugins/blueprint-reviewer/rubrics/issue/extras/prerequisite_mapping.md
+++ b/plugins/blueprint-reviewer/rubrics/issue/extras/prerequisite_mapping.md
@@ -1,0 +1,77 @@
+---
+phases: [issue]
+applicability: conditional
+---
+# Prerequisite Mapping lens
+
+Your focus: what other issues / PRs / external work must complete
+BEFORE this issue can be planned, and what work does THIS issue
+unlock once it's done?
+
+Issue-level analog of spec's `dependency_mapping`. Issues without
+prerequisite-mapping start prematurely (agent picks up an issue,
+plans for hours, only to discover an upstream issue isn't merged
+yet) or block other issues without alerting their owners.
+
+## When you fire
+
+Picker selects you when there are >1 in-flight issues in the same
+repo, OR when the issue references components / abstractions that
+might not exist yet, OR when the issue is part of a broader
+multi-issue effort.
+
+## What to look for
+
+- **Upstream issues / PRs.** Does this issue depend on another
+  issue being closed or another PR being merged first? Each
+  upstream is a "we wait for X" risk. The dependency should be
+  named explicitly with the issue/PR number.
+- **Downstream issues.** What other issues, when this closes,
+  unblocks? Surfacing this prevents accidental delays — the
+  downstream owner can prepare while we're working.
+- **External prereqs.** Third-party action (vendor approval,
+  partner integration, cloud account provisioning, secret
+  rotation, security review). These are often un-tracked.
+- **Schema / API prereqs.** If this issue uses a data shape or
+  API contract that's still in flux (parent spec under
+  iteration, or a related issue defining the schema), wait for
+  the schema to stabilize first.
+- **Infrastructure prereqs.** New CI runner, new monitoring
+  dashboard, new secret in vault, new VPC subnet. These often
+  need ops involvement and pre-arrival.
+- **Team prereqs.** Does this issue require a specific person /
+  reviewer / specialist? If yes, are they available? Issues
+  that need a specific reviewer who's on PTO will stall.
+- **Reverse coupling.** Issue creates a prerequisite for other
+  work — "after merging this, downstream issues #X #Y need to
+  update their data fetches." This is a coordination cost.
+- **Implicit timing.** Some issues are time-sensitive (close
+  before quarter-end, before a specific feature flag flips,
+  before a customer demo). Time pressure is a prerequisite of
+  sorts.
+
+## Scoring
+
+- **10**: Upstream + downstream + external + infra + team
+  prereqs all named with concrete references (issue numbers,
+  PR numbers, dates).
+- **9**: Strong; one minor prereq glossed.
+- **8**: Adequate; primary prereqs surfaced.
+- **7**: Issue names some prereqs but misses the critical path
+  or external risks.
+- **≤6**: Issue presented as standalone when it has material
+  upstream coupling. Agent will hit a wall during planning.
+
+## REVISE criteria
+
+REVISE with: a specific missed prerequisite + impact. "This
+issue uses the new auth context shape, but issue #47 (the
+auth-migration) is still in 'In Progress.' Either explicitly
+depend on #47 closing first, or explicitly target the legacy
+auth shape to decouple."
+
+## BLOCK only for
+
+- Issue has hard upstream dependency that's unscheduled or
+  blocked itself, AND issue's timeline cannot tolerate the
+  resulting wait. Don't pick up.

--- a/plugins/blueprint-reviewer/rubrics/spec/core/acceptance_testability.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/core/acceptance_testability.md
@@ -1,0 +1,68 @@
+---
+phases: [spec]
+applicability: always
+---
+# Acceptance Testability lens
+
+Your focus: can each acceptance criterion be tested without
+subjective judgment? If two competent reviewers couldn't reach the
+same verdict from the AC text alone, the AC is fuzzy and will cause
+rework when it descends into issues.
+
+This is the strictest version of "ACs should be clear" — applied at
+spec time when fuzz can still be removed cheaply.
+
+## What to look for
+
+- **Binary verdicts.** Each AC should have a clear pass/fail.
+  "Performance is good" — not binary. "p99 latency under load
+  scenario L is < 500ms" — binary.
+- **Observable artifacts.** What artifact (log line, DB row, API
+  response, UI element, screenshot) constitutes evidence of AC
+  satisfaction? An AC with no nameable artifact is hard to test.
+- **Negative cases.** Does each AC have a corresponding "and these
+  scenarios are NOT handled by this AC" clause? Specs without
+  negative-case bounding produce scope creep at issue time.
+- **Quantitative ACs need methodology.** "Latency < 500ms" needs
+  to specify: under what load? measured from where? at what
+  percentile? over what window? Quantitative ACs without
+  methodology are not testable.
+- **Behavioral ACs need triggers.** "When user does X, the system
+  Y" — both X and Y need to be specific enough to script.
+- **Test-equivalence.** Two ACs shouldn't ambiguously test the
+  same thing or contradict each other. Each AC adds a distinct
+  testable property.
+- **AC dependencies.** Does AC #5 implicitly depend on AC #2's
+  artifact existing first? If yes, the spec should make that
+  ordering explicit.
+- **Missing AC categories.** Most specs need at least: functional
+  ACs (what works), non-functional ACs (performance, reliability,
+  security), data ACs (state at rest), operational ACs (alerts,
+  metrics, runbook hooks). Categories missing entirely is a sign.
+
+## Scoring
+
+- **10**: Every AC binary, with named observable artifact,
+  methodology where quantitative, negative-case bounding, no
+  ambiguity between ACs.
+- **9**: Strong; one AC with thin methodology.
+- **8**: Adequate; the load-bearing ACs are testable, secondary
+  ones could sharpen.
+- **7**: Multiple ACs are direction-without-threshold or have
+  un-named artifacts.
+- **≤6**: Most ACs are subjective ("user-friendly," "fast,"
+  "robust") with no path to test.
+
+## REVISE criteria
+
+REVISE with: a specific fuzzy AC + a proposed testable version.
+"AC #3 'parents can easily find their camper's allergies' — fuzzy.
+Testable: 'parent navigates from home → camper roster → camper
+detail → allergies section in ≤ 4 clicks; allergy data appears
+within 200ms of clicking; allergy data matches the data entered
+at registration time.'"
+
+## BLOCK only for
+
+- Spec has zero quantitative ACs and the parent blueprint's
+  outcome was quantitative. The descent broke.

--- a/plugins/blueprint-reviewer/rubrics/spec/core/blueprint_fidelity.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/core/blueprint_fidelity.md
@@ -1,0 +1,69 @@
+---
+phases: [spec]
+applicability: always
+---
+# Blueprint Fidelity lens
+
+Your focus: does this spec descend cleanly from a named blueprint
+section, or does it contradict / drift from blueprint decisions?
+
+The fidelity spine: every artifact downstream should be traceable
+to its parent. Specs that quietly contradict their blueprint
+produce specs-vs-blueprint divergence that costs the most to
+reconcile.
+
+## What to look for
+
+- **Named source.** Does the spec cite its parent blueprint
+  section(s)? Format ideally: "Source: [Section X.Y of
+  blueprint-Z](link)" so a reader can verify the descent.
+- **Decision alignment.** If the blueprint made directional
+  decisions (tech stack, architecture pattern, business model,
+  user workflow), does the spec align with them? Drift is fine
+  if NAMED ("blueprint says X; this spec proposes Y because
+  ..."). Silent drift is the failure mode.
+- **Scope alignment.** Is the spec's scope a coherent subset of
+  the blueprint's scope, or does it expand beyond? Expansion is
+  fine if named.
+- **Constraint inheritance.** The blueprint surfaces constraints
+  (regulatory, technical, organizational). Does the spec inherit
+  them, ignore them, or argue against them?
+- **Terminology consistency.** Spec uses the same terms-of-art
+  the blueprint defined? Or has it drifted to synonyms (which
+  produce ambiguity at issue time)?
+- **Out-of-scope correspondence.** The blueprint's "non-goals"
+  and "out of scope" sections should be respected by the spec.
+  If the spec quietly includes a blueprint non-goal, that's a
+  fidelity violation.
+- **Update freshness.** If the blueprint was updated AFTER this
+  spec was started, does the spec reflect the new blueprint
+  state? Stale-against-blueprint specs are common when blueprint
+  evolves rapidly.
+
+## Scoring
+
+- **10**: Named source, decisions aligned, scope coherent,
+  constraints inherited, terms consistent, fresh against latest
+  blueprint version.
+- **9**: Strong; one minor terminology drift or one un-cited
+  inherited constraint.
+- **8**: Adequate; primary descent is clean, secondary
+  alignments could sharpen.
+- **7**: Multiple silent drifts from blueprint — expansions of
+  scope, inconsistent terminology, glossed constraints.
+- **≤6**: Spec contradicts the blueprint without acknowledgment,
+  or descends from no named blueprint at all.
+
+## REVISE criteria
+
+REVISE with: a specific drift + the blueprint section it drifts
+from. "Spec proposes synchronous API; blueprint Section 4 says
+'all I/O paths must be async by default for scalability.' Either
+follow that, or argue for the exception explicitly."
+
+## BLOCK only for
+
+- Spec contradicts a blueprint ADR (Architecture Decision Record)
+  without going through the ADR-supersession process. ADRs are
+  the formal commitments; bypassing them is a fidelity failure
+  at the level that requires a hard stop.

--- a/plugins/blueprint-reviewer/rubrics/spec/core/devils_advocate_spec.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/core/devils_advocate_spec.md
@@ -1,0 +1,79 @@
+---
+phases: [spec]
+applicability: always
+---
+# Devil's Advocate (Spec phase) lens
+
+Your focus: challenge the spec's outcome and approach. Find what's
+hand-waved, where success is being defined to be conveniently
+achievable, and where the spec is a feature in search of a user.
+
+Spec phase is later than blueprint phase, so the framing-level
+skepticism is less useful here — but spec-level traps are different
+and equally important.
+
+Default posture: contrarian-curious about THIS spec specifically.
+Default verdict: NOT BLOCK.
+
+## What to look for
+
+- **Defining success to be easy.** Does the spec set an outcome
+  threshold that's already met today? "Latency < 1 second" when
+  current is 800ms — outcome shipping is automatic, the spec
+  measures nothing. Move the threshold or change the metric.
+- **Cheapest-defeat scan.** What's the cheapest way to defeat
+  this spec? If a 1-line code change makes it obsolete, the spec
+  is over-engineered. If users can route around the spec by
+  doing things outside the system, the spec is over-trusting.
+- **Feature-in-search-of-user.** Specs sometimes capture an
+  engineer's enthusiasm for a technology rather than a user's
+  need. Tells: spec discusses tech choices in detail but the
+  user-side is sketchy; user research absent or anecdotal.
+- **Hidden-cost ack.** What does this spec COST when shipped?
+  Operational burden, support load, training, migration, data
+  cleanup, third-party fees, latency overhead. Are these listed?
+- **Worse-version-still-counts.** What's the WORST version of
+  this spec that still satisfies the ACs? If the worst version
+  is fine (functionally degraded but still hits ACs), the ACs
+  are too weak. If the worst version is unacceptable, ACs need
+  to be tightened.
+- **Spec under stress.** What happens to this spec when traffic
+  is 10x? When the third party is down? When data is malformed?
+  When concurrent users collide? Specs that don't engage with
+  stress conditions ship as bugs at scale.
+- **Predecessor-failure recall.** Have we (or anyone) tried
+  something like this before and had it fail? If yes, what's
+  different about this attempt? "Last time, we tried X and it
+  flopped because Y; this time we mitigate Y by Z."
+- **Premature commitment.** Does the spec commit to specific
+  technologies / vendors / shapes before user-research or
+  prototype evidence supports the commitment?
+
+## Scoring
+
+- **10**: Spec engages with each failure mode, sets difficult
+  thresholds, names hidden costs, cites predecessor failures,
+  scales gracefully.
+- **9**: Strong; one or two stress conditions glossed.
+- **8**: Adequate; primary risks engaged, edge risks glossed.
+- **7**: Spec reads optimistically — no failure modes named,
+  no predecessor lessons cited.
+- **≤6**: Spec is a feature wishlist, or commits prematurely to
+  a direction without supporting evidence.
+
+## REVISE criteria
+
+REVISE with: a specific cheap-defeat or specific failure mode +
+what the spec needs to address. Example: "Section 4's outcome
+('reduce admin time') is satisfied if admins simply skip the
+new feature — the metric is feature-engagement-conditional. Add
+an unconditional metric."
+
+## BLOCK only for
+
+- Spec premise contradicts a parent-blueprint outcome decision
+  (already covered by blueprint_fidelity, escalates here only when
+  fidelity check missed it).
+- Spec proposes irreversible action (data migration, vendor
+  contract, public commitment) on premises the spec itself
+  acknowledges are unvalidated.

--- a/plugins/blueprint-reviewer/rubrics/spec/core/outcome_clarity.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/core/outcome_clarity.md
@@ -1,0 +1,67 @@
+---
+phases: [spec]
+applicability: always
+---
+# Outcome Clarity lens
+
+Your focus: is the spec's desired outcome stated as something
+measurable, with a clear "we hit it" condition? Or is it stated
+in terms of activity ("we'll build X") that doesn't tell you
+whether shipping helped?
+
+Specs that conflate output (built X) with outcome (X improved a
+metric) silently absorb energy without delivering value. Catch the
+conflation at spec time, when the cost is a sentence rewrite.
+
+## What to look for
+
+- **Output vs. outcome.** Output: "we'll ship the new dashboard."
+  Outcome: "admins find the activity they need within 30 seconds
+  on the new dashboard, vs. 90 seconds today." Specs should lean
+  outcome.
+- **Measurability.** Is the outcome stated with units? "Faster"
+  is not measurable. "Median time-to-first-meaningful-paint <
+  500ms on a Camp Director workflow" is.
+- **Direction + threshold.** A measurable outcome has both: which
+  way is good (lower latency, higher conversion) AND a threshold
+  ("under 500ms," "above 30%"). Direction without threshold means
+  any movement counts as success.
+- **Outcome window.** Over what time window does the outcome hold?
+  Day 1 post-launch? 90-day cohort? Steady state? Different
+  windows imply different validation strategies.
+- **Counterfactual reasoning.** Could the outcome be hit by
+  accident (e.g. seasonality, unrelated changes)? If yes, the
+  spec needs an isolation strategy (A/B, holdout, attribution).
+- **Unintended consequences ack.** Does the spec acknowledge
+  outcomes that COULD GET WORSE if it succeeds? "Faster checkout
+  may reduce returns by reducing buyer's-remorse window — is
+  that fine?" A spec that only lists upside is incomplete.
+- **One outcome per spec.** Multi-outcome specs are usually multi-
+  spec disguised as one. (See `scope_unity` extras for deeper.)
+
+## Scoring
+
+- **10**: Single outcome, measurable, threshold + direction +
+  window + isolation strategy + unintended-consequences ack.
+- **9**: Strong; one element thin (e.g. window unspecified).
+- **8**: Adequate for a small spec; can sharpen at issue
+  decomposition time.
+- **7**: Outcome is direction-without-threshold or output-stated
+  pretending to be outcome.
+- **≤6**: Spec describes activity (what we'll build) without
+  describing what success looks like in terms anyone could
+  verify.
+
+## REVISE criteria
+
+REVISE with: a specific weak outcome statement and a proposed
+sharper version. "Section 2 says 'reduce admin frustration' —
+unmeasurable. Suggest: 'within the camp-roster-building workflow,
+median click-count from new-camper-form to roster-saved drops
+from 23 today to 12 by 90 days post-launch.'"
+
+## BLOCK only for
+
+- Spec describes an outcome that contradicts the parent
+  blueprint's stated outcome direction (e.g. blueprint optimizes
+  for safety; spec optimizes for speed at safety's expense).

--- a/plugins/blueprint-reviewer/rubrics/spec/extras/dependency_mapping.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/extras/dependency_mapping.md
@@ -1,0 +1,72 @@
+---
+phases: [spec]
+applicability: conditional
+---
+# Dependency Mapping lens
+
+Your focus: what does this spec DEPEND ON, and what does it BLOCK?
+Specs that don't surface their dependency graph produce surprise
+serializations and parallel work that can't actually start.
+
+## When you fire
+
+Picker selects you when the spec is non-trivial (multi-AC,
+multi-area) and the surrounding ecosystem has multiple in-flight
+specs or known-pending work.
+
+## What to look for
+
+- **Upstream dependencies (depends-on).** What other specs, ADRs,
+  infrastructure, or external work must be DONE before this spec
+  can start? Each one is a "we wait for X" risk. Common
+  upstreams: data model decisions, third-party API
+  availability, ADR resolutions, capacity provisioning, security
+  review.
+- **Downstream dependencies (blocks).** What downstream specs or
+  rollouts depend on THIS spec finishing? Each one is a "delay
+  here cascades to..." risk.
+- **Lateral dependencies (coupled).** What other in-flight specs
+  share interfaces, data models, or user flows? Lateral
+  dependencies often mean "we coordinate launches" or "we share
+  a code area" — which serializes work even when the specs are
+  formally independent.
+- **External dependencies.** Third-party services, vendors,
+  partner contracts, regulatory approvals. These are the ones
+  most likely to slip and least controllable.
+- **Critical path identification.** Of the upstream dependencies,
+  which is on the critical path (longest chain that must finish
+  before this spec can start)? The spec should name it.
+- **Reverse-direction coupling.** Sometimes a spec creates an
+  upstream dependency for OTHER work — e.g. "this spec changes
+  the schema; downstream specs A and B will need to update."
+  This is a coordination cost the spec should surface.
+- **Hidden dependencies.** Things teams forget: developer
+  environment changes, CI/CD pipeline updates, monitoring
+  dashboards, runbook updates, documentation, training.
+
+## Scoring
+
+- **10**: Upstream + downstream + lateral named, external
+  dependencies flagged, critical path identified, hidden
+  dependencies enumerated.
+- **9**: Strong; one or two minor dependencies missed.
+- **8**: Adequate; the load-bearing dependencies are surfaced.
+- **7**: Spec names some dependencies but misses the critical
+  path or external risks.
+- **≤6**: Spec presented as standalone when it has material
+  upstream/downstream coupling.
+
+## REVISE criteria
+
+REVISE with: a specific missed dependency + impact. "This spec
+assumes user-auth context is available, but the
+identity-service-migration spec is in flight and will change the
+auth context shape. Either coordinate with that spec or scope
+this one to use the legacy auth shape during a transition window."
+
+## BLOCK only for
+
+- Spec depends on an upstream that is itself blocked or
+  unscheduled, AND the spec's outcome window doesn't tolerate
+  the implied delay. This is a serialization that the spec
+  hasn't acknowledged.

--- a/plugins/blueprint-reviewer/rubrics/spec/extras/measurement_plan.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/extras/measurement_plan.md
@@ -1,0 +1,73 @@
+---
+phases: [spec]
+applicability: conditional
+---
+# Measurement Plan lens
+
+Your focus: how will we KNOW this spec helped after it ships? Is the
+telemetry/analytics plan defined so the outcome is observable in
+production, or are we shipping into the dark?
+
+## When you fire
+
+Picker selects you when the spec defines a measurable outcome (it
+should — see `outcome_clarity` core) but doesn't visibly engage
+with how that outcome will be measured post-ship.
+
+## What to look for
+
+- **Metric definition.** Each outcome metric should be defined
+  precisely: source (log? DB? client SDK?), aggregation (mean?
+  p99? cohort?), exclusions (test traffic, internal users), time
+  window. "Conversion rate" without a definition is a metric
+  family, not a metric.
+- **Instrumentation gap.** Does the relevant data already exist
+  in production logs / events / DB, or does shipping this spec
+  REQUIRE new instrumentation to be observable? If new
+  instrumentation: is it a sub-task of this spec or an
+  unscheduled prerequisite?
+- **Baseline.** What's the metric's value TODAY? Without a
+  baseline, "30% improvement" has no anchor. The spec should
+  cite a baseline value with its measurement date.
+- **Confounders.** What could cause the metric to move that ISN'T
+  this spec? Seasonal traffic, pricing change, marketing push,
+  another team's feature. The measurement plan should account
+  for confounders (A/B test, holdout, time-series control).
+- **Read frequency.** When and how often will someone look at the
+  metric? Day-1 review? Week-1? 30/60/90? Quarterly? The
+  measurement plan that says nothing about frequency means
+  nobody will look.
+- **Negative-result handling.** What's the plan if the metric
+  doesn't move (or moves wrong)? Iterate-and-retry? Roll back?
+  Declare success-by-different-metric? Specs that don't engage
+  with negative results don't actually have measurement plans.
+- **Cost of measurement.** Is the data-pipeline / dashboard work
+  itself sized? "We'll add a Mixpanel event" is ~1 day; "we'll
+  build a real-time funnel dashboard" is ~weeks.
+- **Owner.** Who reads the metric and decides what to do? An
+  unnamed owner = no decision = wasted measurement.
+
+## Scoring
+
+- **10**: Metric defined, baseline cited, confounders addressed,
+  read frequency + owner named, negative-result plan exists.
+- **9**: Strong; one element light (e.g. confounders glossed).
+- **8**: Adequate; metric definition + baseline are clear, plan
+  for reading is implicit.
+- **7**: Metric named, no baseline OR no read frequency.
+- **≤6**: Spec proposes a metric without supporting plan to
+  observe it after ship. We will be unable to tell if it worked.
+
+## REVISE criteria
+
+REVISE with: a specific gap. "Metric is 'admin time-on-task' but
+no baseline value cited and no instrumentation exists today.
+Either cite the baseline or scope the instrumentation work as
+part of this spec — otherwise post-ship we'll have neither."
+
+## BLOCK only for
+
+- Spec's irreversible action (e.g. permanent data migration)
+  cannot be evaluated for success because no measurement plan
+  exists. We'd ship blind without a way to know we made things
+  worse.

--- a/plugins/blueprint-reviewer/rubrics/spec/extras/ramp_down_criteria.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/extras/ramp_down_criteria.md
@@ -1,0 +1,76 @@
+---
+phases: [spec]
+applicability: conditional
+---
+# Ramp-Down Criteria lens
+
+Your focus: when does this spec STOP? When do we declare it done,
+when do we declare it failed and roll back, and when do we
+declare it inconclusive and move on?
+
+Most specs have a "we ship it" criterion (the ACs) but not a "we
+KILL it" criterion. Specs without kill criteria run forever — they
+absorb low-grade attention months after their evidence stopped
+warranting it.
+
+## When you fire
+
+Picker selects you when the spec proposes an experiment, an
+MVP/pilot, an A/B test, a phased rollout, or any work where the
+right outcome might be "stop investing" rather than "ship it."
+
+## What to look for
+
+- **Time-bounded review.** Does the spec say "we re-evaluate at
+  T+30 / T+90 / T+6mo"? Without a review checkpoint, the work
+  has no decision moment.
+- **Success threshold for promotion.** What metric value moves
+  this from pilot to full rollout? Spec'd thresholds prevent
+  scope-creep ("just one more iteration" forever).
+- **Failure threshold for rollback.** What metric value triggers
+  rollback? Specs that name only the success threshold default
+  to "keep going" no matter how bad the data is.
+- **Inconclusive threshold + plan.** Sometimes the data is
+  ambiguous — neither clearly successful nor clearly failed.
+  The spec should name what "inconclusive" looks like and what
+  to do (run longer? change the design? abandon?).
+- **Kill cost estimation.** What does it cost to kill this spec
+  AT each phase? Code revert? Data migration reversal?
+  User-facing rollback comms? Vendor contract penalties? Higher
+  kill costs argue for more conservative early phasing.
+- **Sunk cost vigilance.** Does the spec acknowledge that
+  ramp-down decisions should be made on FORWARD value, not on
+  past investment? "We've spent 3 months on this, we have to
+  ship" is sunk-cost reasoning. Strong specs explicitly counter
+  this.
+- **Owner of the kill decision.** Who decides? An unnamed kill-
+  decider means no kill happens — it's nobody's job to call it.
+- **Defaults.** What's the default if nobody actively decides at
+  the review checkpoint? Default-continue is the failure mode;
+  default-pause-until-explicit-go is healthier.
+
+## Scoring
+
+- **10**: Review checkpoints, success / failure / inconclusive
+  thresholds, kill cost, named decider, default-pause behavior.
+- **9**: Strong; one threshold under-specified.
+- **8**: Adequate; major thresholds named but kill cost or
+  decider implicit.
+- **7**: Success threshold named, no failure or inconclusive
+  threshold.
+- **≤6**: Spec has no ramp-down concept; once shipped, it
+  continues unless someone independently decides to kill it.
+
+## REVISE criteria
+
+REVISE with: a specific missing criterion. "Pilot has a success
+threshold (>50% adoption by W4) but no failure threshold. Suggest:
+'if adoption < 15% by W6 OR support tickets > 2× control by W4,
+we roll back the pilot and re-evaluate the parent spec.'"
+
+## BLOCK only for
+
+- Spec proposes an irreversible commitment (vendor contract,
+  public communication, data destruction) with no kill-criteria
+  for the decision being correct. The spec is asking us to
+  commit blind.

--- a/plugins/blueprint-reviewer/rubrics/spec/extras/scope_unity.md
+++ b/plugins/blueprint-reviewer/rubrics/spec/extras/scope_unity.md
@@ -1,0 +1,69 @@
+---
+phases: [spec]
+applicability: conditional
+---
+# Scope Unity lens
+
+Your focus: is this ONE spec, or several specs in a trenchcoat?
+Multi-outcome specs decompose poorly into issues, force premature
+prioritization debates, and make success/failure verdicts incoherent.
+
+## When you fire
+
+Picker selects you when the spec contains multiple acceptance
+criteria that don't share a single outcome direction, or when the
+spec's title hints at multiple things ("Onboarding & Roster
+Management & Billing").
+
+## What to look for
+
+- **Single outcome direction.** Does the whole spec point at ONE
+  outcome that all ACs serve, or does it contain ACs that serve
+  unrelated outcomes? "Reduce admin time" + "increase parent
+  engagement" — different outcomes. Two specs.
+- **AC dependency cluster.** Are the ACs all interdependent, or
+  could subsets be implemented independently with no relation to
+  each other? Independently-shippable AC subsets = multiple
+  specs.
+- **Ship cadence.** If you had to ship just half the spec, would
+  the half deliver value? If yes, that half is a coherent
+  sub-spec. If no, the spec is genuinely unified.
+- **Single user-flow.** Specs that span >1 user workflow are
+  usually >1 spec. "User onboards AND admin reviews AND billing
+  charges" = three flows, three specs.
+- **Estimate split.** Is the spec sized as a single estimate, or
+  is the estimate "it depends — could be small or large
+  depending on which parts we prioritize"? The latter is a
+  multi-spec.
+- **Title smell test.** Conjunctions in the title ("&", "and",
+  "with", "plus") are red flags. Singular-noun titles ("Roster
+  Management") usually indicate a unified spec.
+- **Contributor split.** Does the spec touch areas that
+  realistically need different specialists (frontend vs.
+  backend vs. data vs. ops)? Multi-specialist specs survive but
+  often improve when split — different specialists need
+  different ACs.
+
+## Scoring
+
+- **10**: Single outcome, tight AC cluster, single user flow,
+  singular title, estimate is unitary.
+- **9**: Strong unity; one AC could arguably be its own spec.
+- **8**: Adequate; spec is dominantly one thing with some
+  adjacent acks.
+- **7**: 2 distinct outcomes packed in; should split.
+- **≤6**: 3+ outcomes; spec is effectively a mini-blueprint and
+  should be decomposed.
+
+## REVISE criteria
+
+REVISE with: a specific cleavage line. "ACs 1-4 serve outcome
+A (admin time reduction); ACs 5-7 serve outcome B (parent
+engagement). Suggest splitting into two specs so each has its
+own measurement plan and can be prioritized independently."
+
+## BLOCK only for
+
+- Spec spans 4+ outcomes with no plan for decomposition. The
+  scope is so broad that no single team can own it and no
+  single review can cover it.


### PR DESCRIPTION
## Summary

Adds a new plugin `blueprint-reviewer` covering review rubrics for the
upstream-of-PR lifecycle phases (ideation/blueprint, specification,
issue). Complements the home-lab orchestrator's existing plan/PR
review system.

24 rubric files organized by phase + tier:

- **idea/**  — 4 cores + 6 extras for blueprint section + ADR review
- **spec/**  — 4 cores + 4 extras for implementation-spec review
- **issue/** — 3 cores + 3 extras for GitHub-issue review

Two cross-cutting concepts:

- **Fidelity spine:** \`blueprint_fidelity\` (in spec phase),
  \`spec_fidelity\` (in issue phase) check artifact descent.
- **Devils_advocate dynasty:** phase-tuned skeptics
  (\`devils_advocate_blueprint\`/\`spec\`/\`issue\`).

This is Phase A foundation only — rubric library + plugin scaffold.
Companion changes:
- home-lab vendors these rubrics + extends \`reviewer_picker.py\` to
  walk both legacy flat + new phase-nested layouts (separate PR)
- infiquetra-sdlc memorializes the lifecycle architecture (separate PR)

Phase B (manual review skill driving these rubrics) + Phase C
(orchestrator PR-webhook handlers for blueprint repos) come in
follow-up commits.

## Test plan

- [ ] Verify \`plugin.json\` parses (validate against Claude Code
      plugin schema)
- [ ] Lint all rubric frontmatter (YAML valid, phases array
      non-empty, applicability is a known value)
- [ ] Spot-check rubric prose matches the format of existing
      home-lab rubrics (devils_advocate.md, api_contract.md, etc)
- [ ] Verify the home-lab vendoring script copies all 24 rubrics
      cleanly when run against this branch