### PR TITLE
feat(blueprint-reviewer): Phase B — manual review skills + slash commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -202,7 +202,7 @@
       "name": "marketplace-lister",
       "source": "./plugins/marketplace-lister",
       "version": "3.0.0",
-      "description": "Identify items from photos and generate multi-platform listings for Facebook Marketplace, Mercari, and eBay — with full eBay API integration for programmatic publish, status checks, fulfillment, and monthly limit tracking",
+      "description": "Identify items from photos and generate multi-platform listings for Facebook Marketplace, Mercari, and eBay with full eBay API integration.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"
@@ -276,7 +276,7 @@
       "name": "team-execution",
       "source": "./plugins/team-execution",
       "version": "1.5.0",
-      "description": "Two-phase plan execution with automatic multi-reviewer consensus. Auto-suggests on non-trivial plans (3+ steps/files), responds to natural language triggers, and includes /team-setup wizard for tmux + Claude settings.",
+      "description": "Two-phase plan execution with multi-reviewer consensus. Auto-suggests on non-trivial plans, plus /team-setup wizard for tmux + Claude settings.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"

--- a/plugins/blueprint-reviewer/.claude-plugin/plugin.json
+++ b/plugins/blueprint-reviewer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "blueprint-reviewer",
   "version": "0.1.0",
-  "description": "Multi-phase artifact review for the Infiquetra SDLC: blueprints, specs, and issues. Provides rubric-driven reviewers for the upstream-of-PR phases (idea, spec, issue) that complement the existing plan/PR review system in the home-lab orchestrator. Rubrics here are the canonical source of truth — the home-lab Ansible vendors them at deploy time.",
+  "description": "Rubric-driven review for upstream-of-PR Infiquetra SDLC phases: blueprint sections, ADRs, specs, and GitHub issues. Complements home-lab orchestrator's plan/PR review.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"

--- a/plugins/blueprint-reviewer/CHANGELOG.md
+++ b/plugins/blueprint-reviewer/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog — blueprint-reviewer
+
+## [0.1.0] — 2026-05-01
+
+### Added
+
+Initial release of the blueprint-reviewer plugin for Infiquetra's
+upstream-of-PR review system.
+
+**Phase A — rubric library** (24 markdown rubrics, organized by phase
+and applicability tier):
+
+- `rubrics/idea/` — 4 cores + 6 extras for blueprint sections + ADRs
+- `rubrics/spec/` — 4 cores + 4 extras for implementation specs
+- `rubrics/issue/` — 3 cores + 3 extras for GitHub issues
+
+Each rubric carries YAML frontmatter declaring the phase(s) it fires
+in and whether it's a core (always-runs) or LLM-picked conditional
+extra.
+
+Cross-cutting patterns:
+
+- **Fidelity spine** — `blueprint_fidelity` (spec phase),
+  `spec_fidelity` (issue phase) check artifact descent
+- **Devils_advocate dynasty** — phase-tuned skeptics:
+  `devils_advocate_blueprint`, `devils_advocate_spec`,
+  `devils_advocate_issue`
+
+**Phase B — manual-driven review skills**:
+
+- `skills/blueprint-review/SKILL.md` — review blueprint sections + ADRs
+- `skills/spec-review/SKILL.md` — review specs
+- `skills/issue-review/SKILL.md` — review GitHub issues
+- `commands/{blueprint,spec,issue}-review.md` — slash command entry points
+- `scripts/lifecycle_review.py` — helper CLI with 8 subcommands
+  (rubrics list/read, log append-section, ADR peer-review folder ops)
+
+**Companion automation in home-lab orchestrator** (Phase C, not part of
+this plugin) vendors these rubrics via
+`home-lab/scripts/vendor_blueprint_rubrics.sh` and runs them
+automatically on PR open against `*-blueprint` repos and on
+issue-to-Backlog transitions on the Olympus project board. Both
+manual + automated paths share the same rubric library so findings
+are consistent.
+
+### Conventions
+
+- Section-embedded review log (blueprint sections, specs):
+  `<!-- review-log:start --> ... <!-- review-log:end -->` markers
+- Folder-of-peer-reviews (ADRs):
+  `adrs/reviews/<adr-id>/<date>-<reviewer>.md`
+
+See `docs/lifecycle/ideation-to-pr.md` in the `infiquetra-sdlc`
+repository for the full lifecycle architecture.

--- a/plugins/blueprint-reviewer/commands/blueprint-review.md
+++ b/plugins/blueprint-reviewer/commands/blueprint-review.md
@@ -1,0 +1,90 @@
+---
+name: blueprint-review
+description: Review a blueprint section or ADR using the idea-phase rubric library
+---
+
+Run a multi-reviewer review of a blueprint section or ADR. Findings
+get appended to the section's review log (or to the ADR's
+peer-review folder).
+
+## Usage
+
+```
+/blueprint-review [path-or-id] [--reviewers <slug,slug,...>] [--cores-only] [--dry-run]
+```
+
+## Arguments
+
+- `path-or-id` — Path to a blueprint section file (e.g.
+  `discovery/blueprint/04-market-analysis.md`), an ADR id (e.g.
+  `adr-003`), or a section number (e.g. `section 4`). If omitted,
+  the skill will ask.
+- `--reviewers <slug,slug,...>` — Run only the named reviewers (skip
+  the picker). Useful for targeted re-review.
+- `--cores-only` — Run only the always-applicability cores; skip
+  conditional extras.
+- `--dry-run` — List which reviewers WOULD run, without scoring.
+
+## Examples
+
+```
+/blueprint-review
+/blueprint-review discovery/blueprint/04-market-analysis.md
+/blueprint-review adr-003
+/blueprint-review section 7 --cores-only
+/blueprint-review adr-001 --reviewers prior_art_check,falsifiability
+```
+
+## What This Does
+
+1. Loads the artifact (blueprint section or ADR) — auto-detects type.
+2. Reads existing review-log entries to avoid repeating findings.
+3. Runs the always-applicability **idea-phase cores**:
+   `problem_framing`, `assumption_audit`, `devils_advocate_blueprint`,
+   `internal_consistency`.
+4. Picks 0–4 conditional extras based on artifact content (or uses
+   user-specified `--reviewers` list).
+5. Produces a summary table + per-reviewer findings with citations.
+6. Appends each finding to the review log:
+   - Blueprint sections → `<!-- review-log:start --> ... <!-- review-log:end -->` markers
+   - ADRs → `adrs/reviews/<adr-id>/<date>-<reviewer>.md` files
+7. Surfaces action items the user should address.
+
+## Script Command
+
+The skill invokes:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics list-cores --phase idea
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics read --phase idea --slug <slug>
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  log append-section <file> --reviewer <slug> --score <N> --headline <headline>
+# OR for ADRs:
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  adr-review write <adr-path> --reviewer <slug> --score <N> --content-file <findings>
+```
+
+## Instructions
+
+When the user invokes `/blueprint-review`:
+
+1. If no path provided, ask which artifact.
+2. Use the `blueprint-review` skill to drive the review procedure.
+3. Output the summary table BEFORE per-reviewer details so the user
+   can scan quickly.
+4. Always end with action items + a list of files modified in the
+   review log.
+
+This is **advisory review** — do not auto-apply suggestions, do not
+modify the artifact itself, do not commit. The human decides what
+to act on.
+
+## When NOT to use
+
+- For PR review against the working repo (use the orchestrator's
+  PR-review path or `/pr-review` if you have it)
+- For the plan-phase agent review (the orchestrator handles that)
+- For artifacts that aren't in the idea phase (use `/spec-review`
+  for specs, `/issue-review` for GitHub issues)

--- a/plugins/blueprint-reviewer/commands/issue-review.md
+++ b/plugins/blueprint-reviewer/commands/issue-review.md
@@ -1,0 +1,94 @@
+---
+name: issue-review
+description: Review a GitHub issue using the issue-phase rubric library
+---
+
+Run a multi-reviewer review of a GitHub issue. Findings get posted
+as a single consolidated comment on the issue.
+
+## Usage
+
+```
+/issue-review <issue> [--reviewers <slug,slug,...>] [--cores-only] [--dry-run] [--no-post]
+```
+
+## Arguments
+
+- `issue` — GitHub issue reference. Accepted shapes:
+  - `owner/repo#42`
+  - Full GitHub URL
+  - Issue number (in current repo context)
+- `--reviewers <slug,slug,...>` — Run only named reviewers.
+- `--cores-only` — Skip conditional extras.
+- `--dry-run` — List reviewers WITHOUT scoring or posting.
+- `--no-post` — Score + format the comment, but don't post it
+  (useful for previewing).
+
+## Examples
+
+```
+/issue-review infiquetra/campps-mvp#42
+/issue-review infiquetra/mimir#418 --cores-only
+/issue-review #15 --reviewers spec_fidelity,acceptance_criteria_clarity
+/issue-review owner/repo#9 --dry-run
+```
+
+## What This Does
+
+1. Fetches the issue (`gh issue view`).
+2. Finds + reads the parent spec (if cited in the issue body) so
+   `spec_fidelity` can check actual descent.
+3. Reads existing comments so prior reviews don't get repeated.
+4. Runs the always-applicability **issue-phase cores**:
+   `devils_advocate_issue`, `spec_fidelity`,
+   `acceptance_criteria_clarity`.
+5. Picks 0–3 conditional extras based on issue content.
+6. Produces a summary table + per-reviewer findings.
+7. Posts a single consolidated comment to the issue.
+8. Surfaces action items + suggests next step (move to Ready, or
+   address REVISE items).
+
+## Script Command
+
+The skill invokes:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics list-cores --phase issue
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics read --phase issue --slug <slug>
+gh issue view <owner>/<repo>#<num> --json title,body,labels,state,assignees
+gh issue view <owner>/<repo>#<num> --comments
+gh issue comment <owner>/<repo>#<num> --body-file /tmp/review-comment.md
+```
+
+## Instructions
+
+When the user invokes `/issue-review`:
+
+1. Parse the issue reference.
+2. Use the `issue-review` skill to drive the procedure.
+3. **Critical:** find and read the parent spec — if not named in the
+   issue, that's already a `spec_fidelity` finding.
+4. **Always post a single consolidated comment** — don't post one
+   comment per reviewer. The summary table + details should be
+   one well-formatted markdown blob.
+5. End the agent's response with the comment URL + action items.
+
+This is **advisory review**. Specifically:
+
+- **Do NOT** move the issue to Ready.
+- **Do NOT** apply suggested AC changes.
+- **Do NOT** add labels.
+- **Do NOT** edit the issue body.
+
+Findings are posted; the human decides whether to address them and
+when to promote.
+
+## Difference from automated PR-driven review
+
+This command is the **manual** path. The **automated** path (Phase C,
+future) will trigger when an issue moves to **Backlog** on the
+Olympus project board, run the same rubrics, and post the same
+comment shape. The two paths share the rubric library so findings
+are consistent between them.

--- a/plugins/blueprint-reviewer/commands/spec-review.md
+++ b/plugins/blueprint-reviewer/commands/spec-review.md
@@ -1,0 +1,85 @@
+---
+name: spec-review
+description: Review a specification using the spec-phase rubric library
+---
+
+Run a multi-reviewer review of an implementation spec. Findings get
+appended to the spec's section-embedded review log.
+
+## Usage
+
+```
+/spec-review [path] [--reviewers <slug,slug,...>] [--cores-only] [--dry-run]
+```
+
+## Arguments
+
+- `path` — Path to a spec file (e.g.
+  `campps-blueprint/specs/registration/spec.md`). If omitted, the
+  skill will ask.
+- `--reviewers <slug,slug,...>` — Run only named reviewers.
+- `--cores-only` — Skip conditional extras.
+- `--dry-run` — List which reviewers WOULD run, without scoring.
+
+## Examples
+
+```
+/spec-review
+/spec-review specs/testing/testing-strategy.md
+/spec-review specs/registration/spec.md --cores-only
+/spec-review specs/onboarding/spec.md --reviewers blueprint_fidelity,outcome_clarity
+```
+
+## What This Does
+
+1. Loads the spec.
+2. Loads the parent blueprint section (if cited) so
+   `blueprint_fidelity` can check actual descent.
+3. Reads existing review-log entries to avoid repeating findings.
+4. Runs the always-applicability **spec-phase cores**:
+   `outcome_clarity`, `acceptance_testability`, `blueprint_fidelity`,
+   `devils_advocate_spec`.
+5. Picks 0–4 conditional extras based on spec content.
+6. Produces a summary table + per-reviewer findings.
+7. Appends each finding to the spec's review log markers.
+8. Surfaces action items.
+
+## Script Command
+
+The skill invokes:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics list-cores --phase spec
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  rubrics read --phase spec --slug <slug>
+python3 ~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py \
+  log append-section <spec-file> --reviewer <slug> --score <N> --headline <headline>
+```
+
+## Instructions
+
+When the user invokes `/spec-review`:
+
+1. If no path provided, ask.
+2. Use the `spec-review` skill to drive the procedure.
+3. **Critical:** find and read the parent blueprint section. If
+   missing, that's a `blueprint_fidelity` finding — note it
+   explicitly.
+4. Output summary table first, details after.
+5. End with action items + review-log changes.
+
+This is **advisory review** — don't auto-apply, don't modify the
+spec, don't commit. Human decides.
+
+## Cross-phase note
+
+If `blueprint_fidelity` finds a contradiction with the parent
+blueprint, the right answer is rarely "fix the spec alone." It's
+either:
+
+1. Update the spec to comply, OR
+2. Update the blueprint (with its own review cycle), OR
+3. Add an ADR-supersession step.
+
+Surface the trade-off; don't silently pick option 1.

--- a/plugins/blueprint-reviewer/scripts/lifecycle_review.py
+++ b/plugins/blueprint-reviewer/scripts/lifecycle_review.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Lifecycle Review — helper CLI for the blueprint-reviewer plugin.
+
+Deterministic operations on rubrics + review logs. The agent (Claude
+Code, in skill context) does the reasoning; this script handles the
+file-shaped concerns (parse rubric frontmatter, append review-log
+markers, write peer-review files for ADRs).
+
+Subcommands:
+
+  rubrics list-cores --phase <idea|spec|issue>
+      List always-applicability rubrics for a phase.
+
+  rubrics list-extras --phase <idea|spec|issue>
+      List conditional-applicability rubrics for a phase.
+
+  rubrics read --phase <phase> --slug <slug>
+      Print one rubric's content (skill loads this and applies it).
+
+  log append-section <file> --reviewer <slug> --score <N> [--pr-url <url>] --headline <one-liner>
+      Append an entry inside <!-- review-log:start --> markers in
+      <file>. Creates the markers if missing.
+
+  log read-section <file>
+      Print existing review-log entries for <file>, or a stub if none.
+
+  adr-review init <adr-path>
+      Create the adrs/reviews/<adr-id>/ folder for peer reviews.
+
+  adr-review write <adr-path> --reviewer <slug> --score <N> --content-file <file>
+      Write adrs/reviews/<adr-id>/<date>-<reviewer>.md with frontmatter
+      + content from --content-file.
+
+  adr-review list <adr-path>
+      List existing peer-review files for an ADR.
+
+By convention, the script lives at:
+  <plugin-cache>/scripts/lifecycle_review.py
+
+And the rubrics live at:
+  <plugin-cache>/rubrics/<phase>/{core,extras}/<slug>.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ─── Paths ────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PLUGIN_DIR = SCRIPT_DIR.parent
+RUBRICS_DIR = PLUGIN_DIR / "rubrics"
+
+# Review-log marker convention.
+REVIEW_LOG_START = "<!-- review-log:start -->"
+REVIEW_LOG_END = "<!-- review-log:end -->"
+
+# Frontmatter regex (same shape as the orchestrator's reviewer_picker).
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+# ─── Rubric library ───────────────────────────────────────────────────────
+
+
+@dataclass
+class Rubric:
+    slug: str
+    phase: str
+    tier: str  # "core" or "extras"
+    path: Path
+    applicability: str
+    phases: list[str]
+
+
+def _parse_yaml_simple(block: str) -> dict:
+    """Tiny subset of YAML — handles our rubric frontmatter shape only.
+
+    Avoids adding a yaml dependency to a script users invoke ad-hoc.
+    Supports:
+      key: value
+      key: [a, b, c]    (inline list)
+      key: "value"
+    """
+    out: dict = {}
+    for line in block.splitlines():
+        line = line.rstrip()
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        m = re.match(r"^(\w+):\s*(.*)$", line)
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if not val:
+            continue
+        if val.startswith("[") and val.endswith("]"):
+            inner = val[1:-1].strip()
+            items = [s.strip().strip("\"'") for s in inner.split(",") if s.strip()]
+            out[key] = items
+        elif (val.startswith('"') and val.endswith('"')) or (val.startswith("'") and val.endswith("'")):
+            out[key] = val[1:-1]
+        else:
+            out[key] = val
+    return out
+
+
+def load_rubric(path: Path) -> Rubric:
+    text = path.read_text()
+    fm = {}
+    m = _FRONTMATTER_RE.match(text)
+    if m:
+        fm = _parse_yaml_simple(m.group(1))
+    phases = fm.get("phases") or ["unknown"]
+    if not isinstance(phases, list):
+        phases = [str(phases)]
+    applicability = fm.get("applicability", "unknown")
+    # Phase + tier from path: rubrics/<phase>/<tier>/<slug>.md
+    parts = path.relative_to(RUBRICS_DIR).parts
+    phase = parts[0] if len(parts) >= 1 else "unknown"
+    tier = parts[1] if len(parts) >= 2 else "unknown"
+    return Rubric(
+        slug=path.stem,
+        phase=phase,
+        tier=tier,
+        path=path,
+        applicability=str(applicability),
+        phases=phases,
+    )
+
+
+def rubrics_for_phase(phase: str, tier: str) -> list[Rubric]:
+    d = RUBRICS_DIR / phase / tier
+    if not d.exists():
+        return []
+    return sorted(
+        (load_rubric(p) for p in d.glob("*.md")),
+        key=lambda r: r.slug,
+    )
+
+
+def find_rubric(phase: str, slug: str) -> Optional[Rubric]:
+    """Find a rubric by slug across both core and extras tiers."""
+    for tier in ("core", "extras"):
+        path = RUBRICS_DIR / phase / tier / f"{slug}.md"
+        if path.exists():
+            return load_rubric(path)
+    return None
+
+
+# ─── CLI: rubrics ─────────────────────────────────────────────────────────
+
+
+def cmd_rubrics_list_cores(args: argparse.Namespace) -> int:
+    rubrics = rubrics_for_phase(args.phase, "core")
+    if args.json:
+        print(json.dumps([r.slug for r in rubrics]))
+    else:
+        for r in rubrics:
+            print(r.slug)
+    return 0
+
+
+def cmd_rubrics_list_extras(args: argparse.Namespace) -> int:
+    rubrics = rubrics_for_phase(args.phase, "extras")
+    if args.json:
+        print(json.dumps([r.slug for r in rubrics]))
+    else:
+        for r in rubrics:
+            print(r.slug)
+    return 0
+
+
+def cmd_rubrics_read(args: argparse.Namespace) -> int:
+    rubric = find_rubric(args.phase, args.slug)
+    if rubric is None:
+        print(
+            f"ERROR: no rubric for phase={args.phase} slug={args.slug}",
+            file=sys.stderr,
+        )
+        return 1
+    print(rubric.path.read_text(), end="")
+    return 0
+
+
+# ─── CLI: log (section-embedded) ──────────────────────────────────────────
+
+
+def _format_log_entry(
+    *,
+    date: str,
+    slug: str,
+    score: float,
+    pr_url: Optional[str],
+    headline: str,
+) -> str:
+    """Format a single review-log entry line.
+
+    Pattern matches the convention documented in:
+      infiquetra-sdlc/docs/lifecycle/ideation-to-pr.md
+    """
+    score_str = f"({score:.1f})"
+    if pr_url:
+        link = f" — [comment]({pr_url})"
+    else:
+        link = ""
+    return f"- {date} — {slug} {score_str}{link} — \"{headline}\""
+
+
+def _ensure_markers(text: str) -> str:
+    """Ensure the review-log markers exist at the end of the file.
+
+    If absent, append a fresh block. If present, leave content untouched.
+    """
+    if REVIEW_LOG_START in text and REVIEW_LOG_END in text:
+        return text
+    sep = "" if text.endswith("\n") else "\n"
+    block = (
+        f"\n{REVIEW_LOG_START}\n"
+        "### Review log\n"
+        f"{REVIEW_LOG_END}\n"
+    )
+    return text + sep + block
+
+
+def cmd_log_append_section(args: argparse.Namespace) -> int:
+    target = Path(args.file)
+    if not target.exists():
+        print(f"ERROR: file not found: {target}", file=sys.stderr)
+        return 1
+    text = target.read_text()
+    text = _ensure_markers(text)
+    date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    entry = _format_log_entry(
+        date=date,
+        slug=args.reviewer,
+        score=args.score,
+        pr_url=args.pr_url,
+        headline=args.headline,
+    )
+    # Insert entry just before END marker.
+    new = text.replace(
+        REVIEW_LOG_END,
+        f"{entry}\n{REVIEW_LOG_END}",
+        1,
+    )
+    target.write_text(new)
+    print(f"Appended to {target}: {entry}")
+    return 0
+
+
+def cmd_log_read_section(args: argparse.Namespace) -> int:
+    target = Path(args.file)
+    if not target.exists():
+        print(f"ERROR: file not found: {target}", file=sys.stderr)
+        return 1
+    text = target.read_text()
+    if REVIEW_LOG_START not in text:
+        print("(no review log yet)")
+        return 0
+    start = text.index(REVIEW_LOG_START)
+    end = text.index(REVIEW_LOG_END) + len(REVIEW_LOG_END) if REVIEW_LOG_END in text else len(text)
+    print(text[start:end])
+    return 0
+
+
+# ─── CLI: adr-review (folder-of-peer-reviews) ─────────────────────────────
+
+
+def _adr_id(adr_path: Path) -> str:
+    """Extract the ADR id from a path like 'adrs/adr-001-flutter-foo.md'.
+
+    Returns 'adr-001' (or the bare stem if not adr-NNN-shaped).
+    """
+    stem = adr_path.stem
+    m = re.match(r"^(adr-\d+)", stem, re.IGNORECASE)
+    if m:
+        return m.group(1).lower()
+    return stem
+
+
+def _adr_reviews_dir(adr_path: Path) -> Path:
+    """Return the canonical reviews/<adr-id>/ folder for a given ADR file."""
+    return adr_path.parent / "reviews" / _adr_id(adr_path)
+
+
+def cmd_adr_review_init(args: argparse.Namespace) -> int:
+    adr_path = Path(args.adr_path)
+    if not adr_path.exists():
+        print(f"ERROR: adr file not found: {adr_path}", file=sys.stderr)
+        return 1
+    reviews_dir = _adr_reviews_dir(adr_path)
+    reviews_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Created (or exists): {reviews_dir}")
+    return 0
+
+
+def cmd_adr_review_write(args: argparse.Namespace) -> int:
+    adr_path = Path(args.adr_path)
+    if not adr_path.exists():
+        print(f"ERROR: adr file not found: {adr_path}", file=sys.stderr)
+        return 1
+    content_path = Path(args.content_file)
+    if not content_path.exists():
+        print(f"ERROR: content file not found: {content_path}", file=sys.stderr)
+        return 1
+    reviews_dir = _adr_reviews_dir(adr_path)
+    reviews_dir.mkdir(parents=True, exist_ok=True)
+    date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    out_path = reviews_dir / f"{date}-{args.reviewer}.md"
+    if out_path.exists():
+        # Don't clobber existing reviews — append a counter suffix.
+        for i in range(2, 100):
+            candidate = reviews_dir / f"{date}-{args.reviewer}-v{i}.md"
+            if not candidate.exists():
+                out_path = candidate
+                break
+    body = content_path.read_text()
+    frontmatter = (
+        "---\n"
+        f"reviewer: {args.reviewer}\n"
+        f"score: {args.score:.1f}\n"
+        f"date: {date}\n"
+        f"adr: {_adr_id(adr_path)}\n"
+        f"phase: {args.phase or 'idea'}\n"
+        f"verdict: {args.verdict or 'PROCEED'}\n"
+        "---\n\n"
+    )
+    out_path.write_text(frontmatter + body if not body.startswith("---") else body)
+    print(f"Wrote: {out_path}")
+    return 0
+
+
+def cmd_adr_review_list(args: argparse.Namespace) -> int:
+    adr_path = Path(args.adr_path)
+    reviews_dir = _adr_reviews_dir(adr_path)
+    if not reviews_dir.exists():
+        print(f"(no reviews folder yet for {_adr_id(adr_path)})")
+        return 0
+    for f in sorted(reviews_dir.glob("*.md")):
+        print(f.name)
+    return 0
+
+
+# ─── CLI dispatch ─────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="lifecycle_review", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # rubrics
+    p_rub = sub.add_parser("rubrics", help="Rubric library operations")
+    sub_rub = p_rub.add_subparsers(dest="subcmd", required=True)
+
+    p_rlc = sub_rub.add_parser("list-cores", help="List always-applicability rubrics for a phase")
+    p_rlc.add_argument("--phase", required=True, choices=["idea", "spec", "issue"])
+    p_rlc.add_argument("--json", action="store_true", help="Emit JSON list of slugs")
+    p_rlc.set_defaults(func=cmd_rubrics_list_cores)
+
+    p_rle = sub_rub.add_parser("list-extras", help="List conditional-applicability rubrics for a phase")
+    p_rle.add_argument("--phase", required=True, choices=["idea", "spec", "issue"])
+    p_rle.add_argument("--json", action="store_true", help="Emit JSON list of slugs")
+    p_rle.set_defaults(func=cmd_rubrics_list_extras)
+
+    p_rr = sub_rub.add_parser("read", help="Print one rubric's content")
+    p_rr.add_argument("--phase", required=True, choices=["idea", "spec", "issue"])
+    p_rr.add_argument("--slug", required=True)
+    p_rr.set_defaults(func=cmd_rubrics_read)
+
+    # log
+    p_log = sub.add_parser("log", help="Section-embedded review log")
+    sub_log = p_log.add_subparsers(dest="subcmd", required=True)
+
+    p_la = sub_log.add_parser("append-section", help="Append an entry inside review-log markers")
+    p_la.add_argument("file")
+    p_la.add_argument("--reviewer", required=True)
+    p_la.add_argument("--score", required=True, type=float)
+    p_la.add_argument("--pr-url")
+    p_la.add_argument("--headline", required=True, help="One-line summary of the finding")
+    p_la.add_argument("--date", help="Override date (default: today UTC)")
+    p_la.set_defaults(func=cmd_log_append_section)
+
+    p_lr = sub_log.add_parser("read-section", help="Read existing review-log entries from a file")
+    p_lr.add_argument("file")
+    p_lr.set_defaults(func=cmd_log_read_section)
+
+    # adr-review
+    p_adr = sub.add_parser("adr-review", help="ADR peer-review folder operations")
+    sub_adr = p_adr.add_subparsers(dest="subcmd", required=True)
+
+    p_ai = sub_adr.add_parser("init", help="Create reviews/<adr-id>/ folder")
+    p_ai.add_argument("adr_path")
+    p_ai.set_defaults(func=cmd_adr_review_init)
+
+    p_aw = sub_adr.add_parser("write", help="Write a peer-review markdown file for an ADR")
+    p_aw.add_argument("adr_path")
+    p_aw.add_argument("--reviewer", required=True)
+    p_aw.add_argument("--score", required=True, type=float)
+    p_aw.add_argument("--content-file", required=True, help="Path to file with the review body markdown")
+    p_aw.add_argument("--date", help="Override date (default: today UTC)")
+    p_aw.add_argument("--phase", help="Phase (default: idea)")
+    p_aw.add_argument("--verdict", help="PROCEED|REVISE|BLOCK (default: PROCEED)")
+    p_aw.set_defaults(func=cmd_adr_review_write)
+
+    p_al = sub_adr.add_parser("list", help="List peer-review files for an ADR")
+    p_al.add_argument("adr_path")
+    p_al.set_defaults(func=cmd_adr_review_list)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/blueprint-reviewer/skills/blueprint-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/blueprint-review/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: blueprint-review
+description: |
+  Review a blueprint section or ADR using the idea-phase rubric library.
+  Runs always-applicability core reviewers (problem_framing, assumption_audit,
+  devils_advocate_blueprint, internal_consistency) and LLM-picked conditional
+  extras. Findings appended to the review log: section-embedded markers for
+  blueprint sections, peer-review folder for ADRs.
+when_to_use: |
+  Use this skill when the user wants to:
+
+  Direct invocation:
+  - "review this blueprint section"
+  - "review section 4 of campps-blueprint"
+  - "review adr-001"
+  - "review the executive-summary section"
+  - "/blueprint-review path/to/file.md"
+
+  Active iteration:
+  - "I just rewrote the market-analysis section, can you review it?"
+  - "what would devils_advocate_blueprint say about this draft?"
+  - "what assumptions am I making in this technology-architecture section?"
+
+  Pre-commit / pre-PR:
+  - "before I commit, run a quick review on this blueprint change"
+  - "this ADR is ready for review — can you run the rubrics?"
+
+  Targeted reviewer:
+  - "run only problem_framing on section 5"
+  - "I want devils_advocate_blueprint and prior_art_check on this draft"
+
+  Surveying scope:
+  - "what reviewers fire on the idea phase?"
+  - "what's in the binding_constraint rubric?"
+---
+
+# Blueprint Review
+
+Run the idea-phase reviewer panel against a blueprint section or ADR,
+producing scored findings with file:line citations and appending them
+to the review log so provenance accumulates over time.
+
+## Script Location
+
+```
+~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py
+```
+
+(During development, also at:
+`~/workspace/infiquetra/infiquetra-claude-plugins/plugins/blueprint-reviewer/scripts/lifecycle_review.py`)
+
+## Procedure
+
+### 1. Identify the artifact
+
+If the user pointed at a specific file, use it. Otherwise ask:
+"which blueprint section or ADR should I review?" and accept either:
+
+- A filesystem path (e.g. `discovery/blueprint/04-market-analysis.md`)
+- An ADR id (e.g. `adr-003`) — search adjacent `adrs/` directories
+  for `adr-003-*.md`
+- A section number (e.g. `section 4`) — search for `04-*.md` under
+  `discovery/blueprint/`
+
+Determine artifact type:
+
+- File under `adrs/` and matches `adr-NNN-*.md` → **ADR** (use peer-
+  review folder convention)
+- File under `discovery/blueprint/` or any blueprint section → **section**
+  (use embedded review-log markers)
+
+### 2. Read the artifact
+
+Use the Read tool. If the section has existing review-log entries
+(check for `<!-- review-log:start -->` markers), READ THEM TOO — the
+review history is part of the context. Don't repeat findings that
+were already raised + addressed in earlier reviews.
+
+For ADRs: also list existing peer-reviews:
+
+```bash
+python3 <SCRIPT> adr-review list <adr-path>
+```
+
+### 3. Determine which reviewers run
+
+**Always:** all idea-phase cores. Get the list:
+
+```bash
+python3 <SCRIPT> rubrics list-cores --phase idea
+```
+
+Today returns: `problem_framing`, `assumption_audit`,
+`devils_advocate_blueprint`, `internal_consistency`.
+
+**Conditionally:** pick 0-4 extras from the available list:
+
+```bash
+python3 <SCRIPT> rubrics list-extras --phase idea
+```
+
+You (the agent) pick. Read the artifact content, consider what kind
+of decisions/claims it makes, and pick the extras whose questions
+actually apply. Do not pick everything. Do not pick none if there are
+clearly applicable ones.
+
+Picking heuristics:
+
+- Artifact contains directional decisions (tech, business model,
+  go-to-market) without an explicit alternatives section →
+  `alternatives_explored`
+- Artifact reads as if the problem-space is novel → `prior_art_check`
+- Artifact makes big predictions without falsification criteria →
+  `falsifiability`
+- Artifact discusses multiple constraints without naming a binding one →
+  `binding_constraint`
+- Artifact addresses 1 stakeholder when others clearly matter →
+  `stakeholder_coverage`
+- Artifact involves multi-party value flow → `incentive_audit`
+
+If user specified specific reviewers, use only those (skip the picker).
+
+### 4. Run each selected reviewer
+
+For each reviewer:
+
+```bash
+python3 <SCRIPT> rubrics read --phase idea --slug <slug>
+```
+
+The output is the rubric. Apply it to the artifact:
+
+1. Read the rubric's "What to look for" section
+2. Walk through each item; cite specific lines/sections from the
+   artifact
+3. Score per the rubric's "Scoring" anchors (10 / 9 / 8 / 7 / ≤6)
+4. Determine verdict: PROCEED (no required action), REVISE (specific
+   changes named), or BLOCK (hard-stop reasons in rubric's "BLOCK
+   only for")
+5. Produce a structured finding:
+
+```
+Reviewer: <slug>
+Score: X.X
+Verdict: PROCEED | REVISE | BLOCK
+Headline: <one-line summary suitable for review log>
+Findings:
+- <section/line>: <claim>
+- <section/line>: <claim>
+Required changes (if REVISE/BLOCK):
+- <specific addition or fix>
+```
+
+### 5. Aggregate + present to user
+
+Print a summary table FIRST, then per-reviewer details. Example:
+
+```
+## Review summary — discovery/blueprint/04-market-analysis.md
+
+| Reviewer | Score | Verdict | Headline |
+|---|---|---|---|
+| problem_framing | 8.5 | PROCEED | framing solid; one assumption needs naming |
+| assumption_audit | 7.0 | REVISE | 3 untracked assumptions in §4.2 |
+| devils_advocate_blueprint | 8.0 | PROCEED | strong skepticism, but missing failure-mode for cohort-X |
+| internal_consistency | 9.0 | PROCEED | clean |
+| prior_art_check (extra) | 7.5 | REVISE | competitor Y's failure should be engaged |
+
+## Detailed findings
+
+### problem_framing (8.5, PROCEED)
+
+...details with citations...
+
+### assumption_audit (7.0, REVISE)
+
+...details with citations...
+```
+
+### 6. Append to review log
+
+For each reviewer that produced a finding, append to the review log.
+
+**For blueprint sections:**
+
+```bash
+python3 <SCRIPT> log append-section <file> \
+  --reviewer <slug> \
+  --score <score> \
+  --pr-url <url-if-any> \
+  --headline "<one-line summary>"
+```
+
+**For ADRs:**
+
+Write findings to a temp file first, then:
+
+```bash
+python3 <SCRIPT> adr-review write <adr-path> \
+  --reviewer <slug> \
+  --score <score> \
+  --content-file <tmp-file> \
+  --verdict <PROCEED|REVISE|BLOCK>
+```
+
+If invoked as part of a PR review (the user provided a PR URL or the
+review is happening via a PR comment), pass `--pr-url`. Otherwise
+omit and the entry will just have the headline + score.
+
+### 7. Surface what's actionable
+
+End your response with:
+
+- **Action items** — REVISE/BLOCK findings that the user should
+  address
+- **Optional improvements** — PROCEED-with-nit findings (low priority)
+- **What changed in the review log** — list of files updated
+
+If user asked to skip the log update ("just review, don't write
+anything"), omit step 6.
+
+## Important: human-in-the-loop
+
+This is an advisory review. **Do not move the artifact**, do not
+auto-apply suggested changes, do not commit anything. Surface findings
++ append to review log; the human decides what to act on.
+
+If the user wants you to APPLY a specific finding's REVISE suggestion,
+that's a separate request — don't bundle apply with review.
+
+## Targeted invocations
+
+**Specific reviewers only:**
+```
+/blueprint-review path/to/section.md --reviewers problem_framing,prior_art_check
+```
+Skip the picker; run only the named reviewers.
+
+**Cores only (skip extras):**
+```
+/blueprint-review path/to/section.md --cores-only
+```
+
+**Dry run (read rubrics, identify which would fire, but don't run them):**
+```
+/blueprint-review path/to/section.md --dry-run
+```
+List the reviewers that would fire + their headlines (no scoring).
+
+## Score-band notes (idea phase calibration)
+
+Idea-phase scores are NOT held to the 9.0 PROCEED floor that PR review
+uses. Blueprints are inherently fuzzier:
+
+- **8.0+** is healthy. Most well-formed blueprint sections will be in
+  the 7.5–9.0 range.
+- **<7.0** is a real concern; the reviewer's findings should be
+  considered before downstream specs descend.
+- **<6.0** suggests the section needs significant rework before it
+  can be a basis for spec.
+
+These are advisory anchors; the human integrates findings according
+to their judgment.

--- a/plugins/blueprint-reviewer/skills/issue-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/issue-review/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: issue-review
+description: |
+  Review a GitHub issue using the issue-phase rubric library. Runs core
+  reviewers (devils_advocate_issue, spec_fidelity, acceptance_criteria_clarity)
+  and LLM-picked conditional extras. Findings posted as a single issue
+  comment with summary table + per-reviewer details.
+when_to_use: |
+  Use this skill when the user wants to:
+
+  Direct invocation:
+  - "review issue infiquetra/campps-mvp#42"
+  - "review this issue: <github URL>"
+  - "/issue-review infiquetra/mimir#418"
+
+  Pre-Ready / pre-card-pickup:
+  - "before I move this to Ready, review it"
+  - "is this issue agent-ready?"
+  - "are the ACs tight enough?"
+
+  Targeted reviewer:
+  - "is this issue right-sized?"
+  - "does this issue have enough technical context?"
+  - "does this descend from spec X?"
+
+  Surveying:
+  - "what reviewers fire on the issue phase?"
+---
+
+# Issue Review
+
+Run the issue-phase reviewer panel against a GitHub issue, producing
+scored findings and posting them as a single issue comment with summary.
+
+## Script Location
+
+```
+~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py
+```
+
+(During development, also at:
+`~/workspace/infiquetra/infiquetra-claude-plugins/plugins/blueprint-reviewer/scripts/lifecycle_review.py`)
+
+## Procedure
+
+### 1. Identify the issue
+
+If the user pointed at a `<owner>/<repo>#<num>` or a GitHub issue URL,
+parse it. Otherwise ask: "which issue should I review?"
+
+Fetch the issue body + metadata:
+
+```bash
+gh issue view <owner>/<repo>#<num> --json title,body,labels,state,assignees,projectItems
+```
+
+If `gh` returns "issue is closed," ask the user whether to proceed
+(closed issues are usually NOT worth reviewing unless reopening
+them is on the table).
+
+### 2. Find and read the parent spec
+
+The issue should descend from a spec. Look for:
+
+- A `Spec:` link in the issue body (typical convention)
+- A reference to a `*-blueprint` repo's `specs/<area>/<spec>.md`
+- A milestone or label that maps to a known spec
+
+If the spec is named, READ IT — `spec_fidelity` checks descent. If
+no spec is named, that's already a `spec_fidelity` finding.
+
+For repos in the working set (e.g. `infiquetra/campps-mvp`), the
+parent spec typically lives in the corresponding blueprint repo
+(e.g. `infiquetra/campps-blueprint/specs/...`).
+
+### 3. Read existing comments
+
+Before reviewing, read any prior comments on the issue:
+
+```bash
+gh issue view <owner>/<repo>#<num> --comments
+```
+
+If a previous review-comment exists (the comment will have a summary
+table), don't repeat findings already raised — call out which
+findings persist and which are new.
+
+### 4. Determine which reviewers run
+
+**Always:** all issue-phase cores:
+
+```bash
+python3 <SCRIPT> rubrics list-cores --phase issue
+```
+
+Today returns: `devils_advocate_issue`, `spec_fidelity`,
+`acceptance_criteria_clarity`.
+
+**Conditionally:** pick 0-3 extras:
+
+```bash
+python3 <SCRIPT> rubrics list-extras --phase issue
+```
+
+Picking heuristics:
+
+- Issue body suggests scope concerns (multiple components, "and
+  also" patterns, conjunctive title) → `issue_sizing`
+- Issue describes a code change in a non-trivial repo without
+  pointing at specific files / modules / conventions →
+  `context_completeness`
+- Repo has multiple in-flight issues that share interfaces / data
+  models → `prerequisite_mapping`
+
+### 5. Run each selected reviewer
+
+For each reviewer:
+
+```bash
+python3 <SCRIPT> rubrics read --phase issue --slug <slug>
+```
+
+Apply the rubric to the issue. Score, verdict, findings.
+
+Notes specific to issue-phase reviewers:
+
+- **devils_advocate_issue** asks the structural questions: smallest
+  useful slice? Right abstraction level? Hidden refactor sneaking
+  into a feature?
+- **spec_fidelity** checks AC ⇄ spec AC mapping. Flag every issue
+  AC that doesn't trace to a spec AC.
+- **acceptance_criteria_clarity** is the most concrete of the three.
+  Imagine reading just the AC text — would two reviewers reach the
+  same verdict? If not, fuzzy.
+
+### 6. Aggregate + post a single comment to the issue
+
+Format the entire review as a single GitHub comment with summary
+table and per-reviewer details. **Don't post multiple comments** —
+one consolidated comment is better for issue-page readability.
+
+Comment template:
+
+```markdown
+## Issue review — <date> UTC
+
+| Reviewer | Score | Verdict | Headline |
+|---|---|---|---|
+| devils_advocate_issue | 8.0 | PROCEED | well-scoped; one minor scope smell |
+| spec_fidelity | 9.0 | PROCEED | clean descent from spec X |
+| acceptance_criteria_clarity | 7.5 | REVISE | AC #2 lacks methodology |
+| issue_sizing (extra) | 8.5 | PROCEED | one PR; balanced ACs |
+
+## Required changes
+
+- **acceptance_criteria_clarity (REVISE):** AC #2 says "p99 < 200ms" —
+  needs methodology: under what load? from where? on what hardware?
+
+## Optional improvements
+
+- **devils_advocate_issue (PROCEED-with-nit):** consider whether the
+  refactor of `helper.dart` could be extracted to a separate issue
+  if it grows.
+
+---
+
+🤖 *Posted by `/issue-review` — see [blueprint-reviewer plugin](https://github.com/infiquetra/infiquetra-claude-plugins/tree/main/plugins/blueprint-reviewer) for rubric details.*
+```
+
+Post via:
+
+```bash
+gh issue comment <owner>/<repo>#<num> --body-file /tmp/review-comment.md
+```
+
+### 7. Surface to the user
+
+After posting:
+
+- Print the comment URL
+- List action items (REVISE/BLOCK findings)
+- Suggest next step: "If satisfied, move to Ready. Otherwise, address
+  the REVISE items above."
+
+## Important: human-in-the-loop, advisory only
+
+Issue review is **advisory**:
+
+- **Do NOT** move the issue to Ready automatically.
+- **Do NOT** apply suggested changes.
+- **Do NOT** add labels (unless explicitly asked).
+
+Findings are posted; the human decides whether to address them and
+when to promote the issue to Ready.
+
+## Targeted invocations
+
+```
+/issue-review owner/repo#42 --reviewers spec_fidelity,acceptance_criteria_clarity
+/issue-review owner/repo#42 --cores-only
+/issue-review owner/repo#42 --dry-run        # surface findings, don't post
+/issue-review owner/repo#42 --no-post        # print findings, don't post comment
+```
+
+## Difference from automated PR-driven review
+
+This skill is the **manual** path — invoked by the user directly.
+
+The **automated** path (Phase C, future) will trigger when an issue
+moves to the **Backlog** column on the Olympus project board, run
+the same rubrics, and post the same comment. The skill and the
+orchestrator share the rubric library so findings are consistent.
+
+If the user asks "what's the difference between running this manually
+vs. auto?", the answer is: **timing and scope of conditionals**.
+The auto path runs only the cores plus a deterministic set of
+extras based on issue labels; the manual path lets you pick any
+extras you want.
+
+## Score-band notes (issue phase calibration)
+
+Issues are concrete enough to expect tighter scores than specs:
+
+- **9.0+** is the bar for "ready to pick up." Issues at this level
+  rarely produce R2/R3 review loops.
+- **8.0–8.9** is workable but the agent may have to make judgment
+  calls during planning.
+- **<7.5** likely produces planning round-trips.
+- **<6.0** suggests the issue should not be picked up — kick back
+  to the author for sharpening.
+
+These are advisory anchors; you (the human) decide whether to act.

--- a/plugins/blueprint-reviewer/skills/spec-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/spec-review/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: spec-review
+description: |
+  Review a specification using the spec-phase rubric library. Runs core
+  reviewers (outcome_clarity, acceptance_testability, blueprint_fidelity,
+  devils_advocate_spec) and LLM-picked conditional extras. Findings
+  appended to the spec file's section-embedded review log.
+when_to_use: |
+  Use this skill when the user wants to:
+
+  Direct invocation:
+  - "review this spec"
+  - "review specs/testing/testing-strategy.md"
+  - "/spec-review path/to/spec.md"
+
+  Active iteration:
+  - "I drafted a spec for the registration outcome — review it"
+  - "what's the cheapest way to defeat this spec?"
+  - "is the measurement plan adequate?"
+
+  Pre-PR review:
+  - "before I open the PR for this new spec, review it"
+
+  Targeted reviewer:
+  - "run blueprint_fidelity on this spec — does it descend cleanly?"
+  - "I want only the cores; skip extras"
+
+  Surveying:
+  - "what reviewers fire on the spec phase?"
+  - "what does outcome_clarity actually check?"
+---
+
+# Spec Review
+
+Run the spec-phase reviewer panel against an implementation spec,
+producing scored findings and appending them to the spec's
+section-embedded review log.
+
+## Script Location
+
+```
+~/.claude/plugins/cache/infiquetra-plugins/blueprint-reviewer/0.1.0/scripts/lifecycle_review.py
+```
+
+(During development, also at:
+`~/workspace/infiquetra/infiquetra-claude-plugins/plugins/blueprint-reviewer/scripts/lifecycle_review.py`)
+
+## Procedure
+
+### 1. Identify the spec
+
+If the user pointed at a path, use it. Otherwise ask: "which spec
+should I review?" Specs live at:
+
+- `<blueprint-repo>/specs/<area>/<spec>.md`
+
+E.g. `campps-blueprint/specs/testing/testing-strategy.md`.
+
+### 2. Read the spec + its parent blueprint section
+
+Read the spec content. Critically: **find and read the parent
+blueprint section the spec descends from**. The spec should cite
+its source. If it doesn't, that's already a `blueprint_fidelity`
+finding.
+
+Common patterns for finding the parent:
+- Spec frontmatter `source:` field pointing at a blueprint section
+- Inline cite: "Source: [Section X.Y of blueprint](...)"
+- README in the parent specs/ directory naming the source
+
+Reading the parent enables `blueprint_fidelity` to check actual
+descent (terminology, decision alignment, scope subset).
+
+Read existing review-log entries in the spec (look for
+`<!-- review-log:start -->` markers). Don't repeat findings already
+addressed.
+
+### 3. Determine which reviewers run
+
+**Always:** all spec-phase cores. Get the list:
+
+```bash
+python3 <SCRIPT> rubrics list-cores --phase spec
+```
+
+Today returns: `outcome_clarity`, `acceptance_testability`,
+`blueprint_fidelity`, `devils_advocate_spec`.
+
+**Conditionally:** pick 0-4 extras:
+
+```bash
+python3 <SCRIPT> rubrics list-extras --phase spec
+```
+
+Picking heuristics:
+
+- Spec defines a measurable outcome but no measurement plan section →
+  `measurement_plan`
+- Spec title has conjunctions ("and", "&", "with") OR ACs serve
+  multiple distinct outcomes → `scope_unity`
+- Spec depends on (or unblocks) other in-flight work → `dependency_mapping`
+- Spec proposes an experiment, MVP, pilot, or phased rollout →
+  `ramp_down_criteria`
+
+### 4. Run each selected reviewer
+
+For each reviewer:
+
+```bash
+python3 <SCRIPT> rubrics read --phase spec --slug <slug>
+```
+
+Apply the rubric to the spec. Score, verdict, findings, required
+changes. Same shape as blueprint review (see the blueprint-review
+skill for the structured-finding template).
+
+Notes specific to spec-phase reviewers:
+
+- **outcome_clarity** is strict — score down for direction-without-
+  threshold or output-instead-of-outcome ACs.
+- **acceptance_testability** is the strictest version of "ACs are
+  clear" — applied at spec time, where fuzz can still be removed
+  cheaply. Imagine reading just the AC text with no context.
+- **blueprint_fidelity** requires the parent blueprint section to be
+  read. If it wasn't found, score down and explain in findings.
+- **devils_advocate_spec** specifically asks: cheapest way to defeat
+  this? Worst version that still satisfies ACs? Predecessor failures
+  cited?
+
+### 5. Aggregate + present to user
+
+Same summary-table-first format as blueprint review. Example:
+
+```
+## Review summary — campps-blueprint/specs/registration/spec.md
+
+| Reviewer | Score | Verdict | Headline |
+|---|---|---|---|
+| outcome_clarity | 9.0 | PROCEED | outcome measurable; window specified |
+| acceptance_testability | 8.0 | REVISE | AC #4 needs methodology |
+| blueprint_fidelity | 9.5 | PROCEED | clean descent from §4 |
+| devils_advocate_spec | 7.5 | REVISE | "feature-engagement-conditional" metric loophole |
+| measurement_plan (extra) | 8.5 | PROCEED | baseline cited; instrumentation in scope |
+```
+
+### 6. Append to review log
+
+```bash
+python3 <SCRIPT> log append-section <spec-file> \
+  --reviewer <slug> \
+  --score <score> \
+  --pr-url <url-if-any> \
+  --headline "<one-line summary>"
+```
+
+For each reviewer with a finding worth recording. PR-url is included
+when invoked from a PR context.
+
+### 7. Surface action items
+
+End with:
+
+- **Action items** (REVISE/BLOCK)
+- **Optional improvements** (PROCEED nits)
+- **Review log changes** — files modified
+
+## Important: human-in-the-loop
+
+Same as blueprint review: surface findings, append to review log,
+**don't** apply changes or move the spec. Human decides.
+
+## Targeted invocations
+
+```
+/spec-review path/to/spec.md --reviewers outcome_clarity,blueprint_fidelity
+/spec-review path/to/spec.md --cores-only
+/spec-review path/to/spec.md --dry-run
+```
+
+## Score-band notes (spec phase calibration)
+
+Spec phase is more concrete than idea phase, so expect tighter scores:
+
+- **9.0+** is healthy. Specs should be sharper than blueprints.
+- **8.0–8.9** is normal during active iteration; one or two REVISE
+  items.
+- **<7.5** likely needs work before issues descend.
+- **<6.0** suggests the spec is premature — kick it back to the
+  drafter for sharpening, OR escalate questions back to the parent
+  blueprint.
+
+These are advisory; the human still decides what to address.
+
+## Cross-phase note: when blueprint_fidelity blocks
+
+If `blueprint_fidelity` finds a contradiction with the parent
+blueprint, the right answer is rarely to fix the SPEC alone — it's
+either:
+
+1. Update the SPEC to comply with the blueprint, OR
+2. Update the BLUEPRINT (with its own review cycle) to authorize
+   the spec's direction, OR
+3. Add an ADR-supersession step to formally override.
+
+Surface this trade-off; don't silently pick option 1.

--- a/plugins/marketplace-lister/.claude-plugin/plugin.json
+++ b/plugins/marketplace-lister/.claude-plugin/plugin.json
@@ -1,11 +1,21 @@
 {
   "name": "marketplace-lister",
   "version": "3.0.0",
-  "description": "Identify items from photos and generate multi-platform listings for Facebook Marketplace, Mercari, and eBay — with full eBay API integration for programmatic publish, status checks, fulfillment, and monthly limit tracking",
+  "description": "Identify items from photos and generate multi-platform listings for Facebook Marketplace, Mercari, and eBay with full eBay API integration.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["marketplace", "selling", "photos", "listings", "facebook", "mercari", "ebay", "shipping", "api"]
+  "keywords": [
+    "marketplace",
+    "selling",
+    "photos",
+    "listings",
+    "facebook",
+    "mercari",
+    "ebay",
+    "shipping",
+    "api"
+  ]
 }

--- a/plugins/team-execution/.claude-plugin/plugin.json
+++ b/plugins/team-execution/.claude-plugin/plugin.json
@@ -1,11 +1,17 @@
 {
   "name": "team-execution",
   "version": "1.5.0",
-  "description": "Two-phase plan execution with automatic multi-reviewer consensus. Phase A runs during plan mode to embed a Team Structure and calls ExitPlanMode itself — the plan is a single atomic artifact (implementation + team roster + review protocol). Phase B fires TeamCreate immediately as the only permitted first action after approval, then runs plan approval gates, parallel execution, and max-3-iteration consensus loop with 9/10 threshold.",
+  "description": "Two-phase plan execution with multi-reviewer consensus. Auto-suggests on non-trivial plans, plus /team-setup wizard for tmux + Claude settings.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["team-execution", "plan-execution", "code-review", "consensus", "reviewers"]
+  "keywords": [
+    "team-execution",
+    "plan-execution",
+    "code-review",
+    "consensus",
+    "reviewers"
+  ]
 }


### PR DESCRIPTION
## Summary

Adds the **manual-driven review path** to the blueprint-reviewer plugin
(Phase B, follow-up to #110 which shipped the rubric library):

- 3 SKILL.md skills (one per phase): \`blueprint-review\`,
  \`spec-review\`, \`issue-review\`
- 3 slash command entry points: \`/blueprint-review\`, \`/spec-review\`,
  \`/issue-review\`
- 1 helper CLI: \`scripts/lifecycle_review.py\` (8 subcommands for
  rubrics, review-log appending, ADR peer-review folder writes)

The user (or an agent) invokes these directly in a Claude Code session
for ad-hoc deep-dive review of blueprints, specs, and issues.

## How it complements Phase A + C

- Phase A (\`#110\`, **merged**) — canonical rubric library
- **Phase B (this PR)** — manual review skills consuming the rubrics
- Phase C (in home-lab orchestrator, **deployed + functionally
  verified**) — automated review on PR open + Backlog transition

Both manual + automated paths share the same rubric library so
findings are consistent. Functional tests against real artifacts:

- C1 (issue review): \`infiquetra/campps-mvp#44\` → 38s round-trip
- C2 (spec PR review): \`infiquetra/campps-blueprint#2\` → 48s
- C3 + C4 (multi-artifact: section + ADR): \`infiquetra/campps-blueprint#3\` → 3:06

## What's in this PR

\`\`\`
plugins/blueprint-reviewer/
  scripts/lifecycle_review.py        — helper CLI
  skills/blueprint-review/SKILL.md   — review blueprint sections + ADRs
  skills/spec-review/SKILL.md        — review specs
  skills/issue-review/SKILL.md       — review GitHub issues
  commands/blueprint-review.md       — \`/blueprint-review\` slash command
  commands/spec-review.md            — \`/spec-review\`
  commands/issue-review.md           — \`/issue-review\`
\`\`\`

The skills follow a consistent shape: identify artifact → read parent
(if applicable) → load cores + LLM-pick extras → run each reviewer
through its rubric → produce summary table → write findings to the
appropriate review log → surface action items.

Strictly advisory: doesn't move issues, doesn't apply changes, doesn't
commit. Human always decides.

## Test plan

- [ ] \`plugin.json\` parses (already validated in #110)
- [ ] All 3 SKILL.md files have valid frontmatter
- [ ] All 3 command files have valid frontmatter
- [ ] \`scripts/lifecycle_review.py\` syntax-checks + subcommands
      smoke-test against the rubric library shipped in #110
- [ ] Manual run: install plugin, invoke \`/issue-review\` against a
      real issue, verify findings + log update