### PR TITLE
fix(marketplace): register blueprint-reviewer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -314,6 +314,31 @@
         "workflow"
       ],
       "category": "development"
+    },
+    {
+      "name": "blueprint-reviewer",
+      "source": "./plugins/blueprint-reviewer",
+      "version": "0.1.0",
+      "description": "Rubric-driven review for upstream-of-PR Infiquetra SDLC phases: blueprint sections, ADRs, specs, and GitHub issues. Complements home-lab orchestrator's plan/PR review.",
+      "author": {
+        "name": "Infiquetra",
+        "email": "hello@infiquetra.com"
+      },
+      "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+      "license": "MIT",
+      "keywords": [
+        "blueprint",
+        "spec",
+        "issue",
+        "reviewer",
+        "rubrics",
+        "sdlc",
+        "ideation",
+        "fidelity",
+        "devils-advocate",
+        "mount-olympus"
+      ],
+      "category": "development"
     }
   ],
   "version": "2.0.0"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 *.log
 .env
 .env.local
+
+# Claude Code (per-user settings and session state)
+.claude/


### PR DESCRIPTION
## Summary
- Registers `blueprint-reviewer` in `.claude-plugin/marketplace.json` so it's discoverable when users browse the marketplace.
- Adds `.claude/` to `.gitignore` and removes two stray files (`swap-pane`, `uv.lock`) that don't belong in version control.

## Why this matters
A user reported that `blueprint-reviewer` does not appear when they try to install plugins from this marketplace. Confirmed: of the 15 plugin directories under `plugins/`, only 14 were listed in `marketplace.json`. PRs #110 (initial rubrics) and #111 (Phase B skills + commands) added the plugin's code but neither registered it in `marketplace.json`.

## Changes

**`fix(marketplace): register blueprint-reviewer plugin`**
- New entry mirrors `sdlc-manager`'s structure: `source: ./plugins/blueprint-reviewer`, `version: 0.1.0`, `category: development`
- Keywords copied verbatim from `plugins/blueprint-reviewer/.claude-plugin/plugin.json`

**`chore(repo): ignore .claude/ and remove stray swap-pane/uv.lock`**
- `.claude/` holds per-user settings (`settings.local.json`) and session state (`context/sdlc-plan-state.json`) — never appropriate for VCS
- `swap-pane` was a 0-byte stray file
- `uv.lock` was an unused 242KB lockfile (`pyproject.toml` uses hatchling, not uv)

## Test plan
- [x] `python3 -m json.tool .claude-plugin/marketplace.json` — valid JSON
- [x] Plugin count is now 15 and includes `blueprint-reviewer`
- [x] `source` path resolves to a real `plugin.json` on disk
- [x] `git status` shows no untracked files after the gitignore change
- [ ] After merge: re-load marketplace in Claude Code and confirm `blueprint-reviewer` is offered for install