### PR TITLE
docs(engineering-journal): adopt directory pattern from home-lab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,37 @@
 # Claude Configuration for Infiquetra Claude Plugins
 
+## 📓 Engineering journal — AUTO-MAINTAIN
+
+Living documentation at [`docs/engineering-journal/`](docs/engineering-journal/) — pattern adopted from `infiquetra/home-lab/docs/engineering-journal/`. The directory IS the engineering journal; the files inside are its sections.
+
+| File | Purpose |
+|------|---------|
+| [LEARNINGS.md](docs/engineering-journal/LEARNINGS.md) | Empirical findings + mechanisms + fixes + validations |
+| [DECISIONS.md](docs/engineering-journal/DECISIONS.md) | ADR-style records of plugin-pattern / convention / tooling choices, with rationale + revisit conditions |
+| [QUEUED.md](docs/engineering-journal/QUEUED.md) | Future-work items by priority with "worth it when" triggers |
+| [ARCHIVE.md](docs/engineering-journal/ARCHIVE.md) | Shipped + rejected + superseded items |
+| [narratives/](docs/engineering-journal/narratives/) | Self-contained, longer-form companion docs (plugin design walkthroughs, multi-PR post-mortems, migration write-ups) — readable cold by an outside reader |
+
+**Maintenance rules (Claude: follow these without being asked):**
+
+1. **After fixing a plugin bug or shipping a feature where the mechanism wasn't obvious** (marketplace registry drift, hook timing race, skill activation gotcha, MCP env propagation, build-tool surprise) → add a dated entry to `LEARNINGS.md`. Include the **evidence** (PR / commit / file:line) and the **mechanism** (why it happened, not just what), and a **Generalizable rule** line stripping the lesson from the specific incident.
+
+2. **After committing a plugin-pattern decision** (skills-based vs CLI-based, line length, lockfile choice, marketplace category, version bump strategy, hook event choice, naming convention) → add an entry to `DECISIONS.md` with rationale + rejected alternatives + "revisit when" condition. Include the commit hash.
+
+3. **Whenever a promising idea surfaces but we don't build it right now** (new plugin idea, CI guard, refactor, test improvement) → add to `QUEUED.md` with priority (P0/P1/P2/P3/Maybe), concrete "worth it when" trigger, and rough effort estimate. Don't skip this step — undocumented good ideas decay into forgotten good ideas.
+
+4. **When a QUEUED item ships** → move its entry to `ARCHIVE.md` as SHIPPED with the commit hash + date. Remove it from `QUEUED.md`.
+
+5. **When a QUEUED item is rejected** (we decide it's not worth doing) → move to `ARCHIVE.md` as REJECTED with the reason + revisit conditions. Remove from `QUEUED.md`.
+
+6. **When a prior LEARNING or DECISION is invalidated** (new evidence contradicts the old claim) → update the original entry inline with the correction AND move the pre-correction version to `ARCHIVE.md` as SUPERSEDED. Never silently overwrite history.
+
+7. **When something needs a longer write-up than fits in an entry** (full plugin design narrative, multi-PR post-mortem, migration write-up, rejected-design memo) → create `docs/engineering-journal/narratives/YYYY-MM-DD-short-slug.md` and link to it from the relevant LEARNINGS / DECISIONS entry. The four core files stay scannable; long-form companion lives next door.
+
+**Entry format.** Each of the four core files has a block-quote intro at the top spelling out its format. New entries use these subheaders where applicable: **Context / Evidence / Mechanism / Fix (or queued) / Validation / What surprised / Generalizable rule / Refs**. Not every entry needs every subheader, but the **Generalizable rule** line is the highest-value field — without it, future-Claude has to re-derive the lesson from the evidence each time.
+
+**Don't wait to be asked.** When any of these triggers fire in a session, update the files as part of the same commit that ships the change. The whole point of these files is that they maintain themselves.
+
 ## Repository Information
 
 - **Repository**: infiquetra-claude-plugins

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -1,0 +1,39 @@
+# Archive — Infiquetra Claude Plugins
+
+> **The graveyard of QUEUED, LEARNINGS, and DECISIONS items.** When something from `QUEUED.md` ships, it moves here as **SHIPPED**. When something is consciously rejected, it moves here as **REJECTED** with the reason + revisit conditions. When a `LEARNINGS.md` or `DECISIONS.md` entry is invalidated by new evidence, the pre-correction version moves here as **SUPERSEDED**.
+>
+> **Never silently delete.** History is the point — a future Claude (or human) reading "did we ever consider X?" or "why did we change our mind on Y?" gets the answer.
+>
+> **Append new entries to the top** within each section.
+
+---
+
+## Shipped
+
+### PR #112 — register `blueprint-reviewer` in marketplace + gitignore `.claude/`  {#pr-112-marketplace-fix}
+
+**SHIPPED 2026-05-01** (commit `4da5705`, squash-merged from `fix/marketplace-register-blueprint-reviewer`).
+
+**Summary.** Two-commit PR that:
+1. Added the missing `blueprint-reviewer` entry to `.claude-plugin/marketplace.json` (15 plugins after the change, was 14).
+2. Added `.claude/` to `.gitignore` and removed stray files `swap-pane` (0 bytes) and `uv.lock` (242 KB, unused — see DECISIONS).
+
+**Why this matters in the archive.** This is the originating ship for the journal's first three real entries — the LEARNING about marketplace drift, the LEARNING about the `Edit` guard pattern, and the DECISION about repo hygiene. Future readers tracing those entries' "fixed in commit X" / "shipped via Y" links land here.
+
+**Refs.**
+- LEARNINGS: [marketplace drift](LEARNINGS.md#marketplace-drift), [marketplace edit guard](LEARNINGS.md#marketplace-edit-guard).
+- DECISIONS: [gitignore `.claude/` + no `uv.lock`](DECISIONS.md#gitignore-claude-and-no-uv-lock).
+
+---
+
+## Rejected
+
+*(none yet — this section will populate as ideas in `QUEUED.md` get explicitly declined with their reason.)*
+
+---
+
+## Superseded
+
+*(none yet — this section will populate when a `LEARNINGS.md` or `DECISIONS.md` entry is invalidated by new evidence and its pre-correction version is preserved here.)*
+
+---

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -1,0 +1,46 @@
+# Decisions — Infiquetra Claude Plugins
+
+> **ADR-style records of plugin-pattern / convention / tooling choices.** When you commit a chosen path over alternatives — pick A over B, flip a flag, change a threshold, choose a category, adopt a tool — capture rationale + tradeoff + revisit-when condition + commit hash.
+>
+> The point is to make **revisit conditions explicit** so a future Claude (or human) reading "why did we pick X?" gets the answer cold, including when it would be right to reconsider.
+>
+> **Append new entries to the top.** Format:
+>
+> ```markdown
+> ## YYYY-MM-DD
+>
+> ### Short title (commit hash)  {#slug}
+>
+> **Decision.** What we picked.
+> **Rejected alternatives.** What we considered and didn't pick.
+> **Rationale.** Why this won.
+> **Revisit when.** Condition that would change the calculus.
+> **Refs.** Related LEARNINGS / QUEUED / narratives.
+> ```
+>
+> When new evidence invalidates a decision, **update inline AND move the pre-correction version to `ARCHIVE.md` as SUPERSEDED**.
+
+---
+
+## 2026-05-01
+
+### Gitignore `.claude/`, do not track `uv.lock` (commit `4da5705`)  {#gitignore-claude-and-no-uv-lock}
+
+**Decision.** Add `.claude/` to `.gitignore`. Do not track `uv.lock`. Stray `swap-pane` (0-byte file from a tmux operation) deleted as one-off cleanup.
+
+**Rejected alternatives.**
+- *Track `.claude/settings.local.json`.* Rejected: file holds per-user permission grants for the Claude Code session. Sharing one user's allowed-tool list would either leak local preferences or get blindly overwritten by the next user. The file is named `.local.json` for a reason.
+- *Track `.claude/context/sdlc-plan-state.json`.* Rejected: mid-session orchestration state from `sdlc-manager`. Stale immediately after the session ends; would create misleading commits if pushed.
+- *Track `uv.lock`.* Rejected: `pyproject.toml` declares `requires = ["hatchling"]` with no `[tool.uv]` section. The repo uses hatchling for building and ad-hoc `pip`/`uv` invocations for local dev tooling — there's no reproducible-build promise being made by checking in a uv lockfile. Tracking it would imply uv is part of the build path.
+
+**Rationale.** `.claude/` content is per-user / per-session by design (settings.local + context state). `uv.lock` would make a build-tool claim the repo isn't currently making. Both are pure noise in the diff and confuse contributors about what's authoritative.
+
+**Revisit when.**
+- The repo adopts uv as the canonical lock-and-install tool (would require a `[tool.uv]` block in `pyproject.toml` and a CI step that installs from the lockfile). Then check it in and remove the gitignore exclusion.
+- Claude Code introduces a *shared* settings file under `.claude/` that's intended to be checked in. At that point, narrow the gitignore from `.claude/` to specifically `.claude/settings.local.json` and `.claude/context/`.
+
+**Refs.**
+- LEARNINGS [marketplace registry drift](LEARNINGS.md#marketplace-drift) — same PR (#112).
+- ARCHIVE [PR #112](ARCHIVE.md#pr-112-marketplace-fix) — shipped record.
+
+---

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -1,0 +1,93 @@
+# Learnings — Infiquetra Claude Plugins
+
+> **Empirical findings + mechanisms + fixes + validations.** When something turns out to be true that wasn't obvious — about a plugin's runtime behavior, the marketplace registry, hook timing, skill activation, MCP env propagation, build/test tooling, or a deploy gotcha — it goes here. Include the **evidence** (PR / commit / file:line / reproduction) and the **mechanism** (why it's true), not just the observation.
+>
+> **Append new entries to the top.** Most-recent first. Format:
+>
+> ```markdown
+> ## YYYY-MM-DD
+>
+> ### Short descriptive title  {#slug}
+>
+> **Context.** One paragraph framing the situation.
+> **Evidence.** Specific PR / commit / file:line / reproduction recipe.
+> **Mechanism.** Why it happened (or why it's true) — root cause, not just symptoms.
+> **Fix (or queued).** Concrete action + commit hash, OR a QUEUED.md ref if deferred.
+> **Validation (if applicable).** What later run / test / install proved the fix.
+> **What surprised (optional).** The thing that wasn't in the original mental model.
+> **Generalizable rule.** The lesson stripped of this specific incident — what would I tell a future-me hitting a similar shape?
+> **Refs.** Cross-links to DECISIONS / QUEUED / narratives / other LEARNINGS entries.
+> ```
+>
+> The `{#slug}` HTML anchor on the entry title makes the entry linkable from `README.md` quick-nav and from cross-references. Keep slugs short and stable.
+>
+> When new evidence invalidates a learning, **update inline AND move the pre-correction version to `ARCHIVE.md` as SUPERSEDED**. Never silently overwrite.
+
+---
+
+## 2026-05-01
+
+### Plugin code can ship without marketplace registration — the registry is a separate source of truth  {#marketplace-drift}
+
+**Context.** A user reported that the `blueprint-reviewer` plugin did not appear when they tried to install plugins from this marketplace. The plugin's code lived under `plugins/blueprint-reviewer/` on `main` and was fully functional, but it was invisible to the marketplace UI.
+
+**Evidence.**
+- `plugins/blueprint-reviewer/` was added by PR #110 (merge commit `ae93035`) and Phase B work merged via PR #111 (commit `a7fea08`).
+- Neither PR modified `.claude-plugin/marketplace.json`.
+- At time of report: 15 plugin directories under `plugins/` but only 14 entries in `marketplace.json`.
+- Fixed in PR #112 (commit `4da5705`).
+
+**Mechanism.** Plugin code in `plugins/<name>/` and the marketplace registry in `.claude-plugin/marketplace.json` are independent files. PR review focused on the new plugin's code (skills, commands, scripts) and overlooked the one-line registry diff. Two PRs in a row missed it because the omission isn't visible in the plugin's own diff — it's a *missing* edit to a sibling file. Reviewers don't see absences.
+
+**Fix.** PR #112 added the `blueprint-reviewer` entry to `marketplace.json` (mirrors `sdlc-manager`'s shape: `source`, `version`, `category: development`, keywords copied from the plugin manifest).
+
+**Validation.** Post-merge: `python3 -c "import json; d=json.load(open('.claude-plugin/marketplace.json')); print(len(d['plugins']))"` returns `15`; `'blueprint-reviewer' in [p['name'] for p in d['plugins']]` is `True`.
+
+**What surprised.** That the bug shipped *twice* in a row (#110 and #111). The second PR was specifically follow-up work on the same plugin; the registry omission was right there to be noticed but wasn't.
+
+**Generalizable rule.** When two files must stay in sync (plugin dir + registry, schema + migration, code + docs index, env var + Lambda config), reviewers will drift one against the other given enough opportunities. Add a CI assertion that fails on drift — don't rely on PR review.
+
+**Refs.**
+- [QUEUED.md](QUEUED.md#marketplace-ci-guard) — P1 work item for the CI guard.
+- [DECISIONS.md](DECISIONS.md#gitignore-claude-and-no-uv-lock) — repo hygiene shipped alongside.
+- [ARCHIVE.md](ARCHIVE.md#pr-112-marketplace-fix) — SHIPPED record.
+
+---
+
+### `marketplace.json` `Edit` calls must include the array's closing `]` in `old_string`  {#marketplace-edit-guard}
+
+**Context.** When appending a new plugin entry to `.claude-plugin/marketplace.json`, the `Edit` tool can produce invalid JSON if the `old_string` doesn't include enough context to capture the array's closing bracket. This has misfired multiple times.
+
+**Evidence.** Repeated occurrences traced through prior memory record `marketplace.json Editing Guard`. The wrong-pattern shape:
+
+```json
+    }
+  ],
+    {
+      "name": "new-plugin",
+      ...
+    }
+  ],
+  "version": "2.0.0"
+}
+```
+
+— two closing `]`, parser fails. Caught only by post-edit validation.
+
+**Mechanism.** When `old_string` ends at the last entry's closing `}`, the `Edit` tool inserts the new content *after* the line, which lands it after the array's `]` rather than inside the array. The fix is to include both the previous last entry's closing `}` AND the array's `]` in the `old_string`, so the new entry can be inserted *before* the `]` (with a `,` added to the prior `}`).
+
+**Fix.** Standard pattern — `old_string` extends through the array's closing `]` and at least the next line:
+
+```
+old_string: "      \"workflow\"\n      ],\n      \"category\": \"development\"\n    }\n  ],\n  \"version\": \"2.0.0\"\n}"
+```
+
+Always validate immediately: `python3 -m json.tool .claude-plugin/marketplace.json > /dev/null`.
+
+**Validation.** PR #112 (commit `4da5705`) used this exact pattern and produced valid JSON on first try.
+
+**Generalizable rule.** When using `Edit` on a JSON/YAML file to append into a nested array, the `old_string` MUST include the array's closing bracket. Inserting "before the `]`" is correct; inserting "after the prior entry's `}`" is wrong because edits land on the line *after* the match. Always validate the file with the language's parser immediately after the edit.
+
+**Refs.** Same lesson cached in `~/.claude/projects/.../memory/marketplace_editing_guard.md` for runtime convenience; this file is the durable project record.
+
+---

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -1,0 +1,58 @@
+# Queued — Infiquetra Claude Plugins
+
+> **Future-work items by priority with explicit "worth it when" triggers.** When a promising idea surfaces but we don't build it right now, it goes here. Don't skip the entry just because it feels minor — undocumented good ideas decay into forgotten good ideas.
+>
+> **Format** (organized by priority section, no date headers — items are durable until they ship or get rejected):
+>
+> ```markdown
+> ### Short title  {#slug}
+>
+> **Priority.** P0 (must-ship-before-X) / P1 (urgent) / P2 (important) / P3 (nice-to-have) / Maybe.
+> **Effort.** Rough estimate (hours / half-day / day / week / multi-day).
+> **Worth it when.** Specific trigger that would make this pressing.
+> **Context.** What surfaced this; cross-references.
+> ```
+>
+> When a queued item ships, move the entry to [ARCHIVE.md](ARCHIVE.md) as SHIPPED with the commit hash. When rejected, move with REJECTED + reason.
+
+---
+
+## P1 — urgent
+
+### CI guard: assert plugin directories match marketplace.json entries  {#marketplace-ci-guard}
+
+**Priority.** P1.
+
+**Effort.** Half-day. GitHub Actions workflow + a small Python script (~30 lines).
+
+**Worth it when.** Right now — the bug it prevents has shipped twice in a row (PRs #110, #111) and required a third PR (#112) to fix. The class of bug ("file A and file B must stay in sync but reviewers don't notice the absence in B") will recur with every new plugin or rename.
+
+**Context.**
+- See [LEARNINGS.md](LEARNINGS.md#marketplace-drift) for the bug's history + mechanism.
+- Spec sketch:
+  - Walk `plugins/*/` directories that contain `.claude-plugin/plugin.json`.
+  - Read `.claude-plugin/marketplace.json`.
+  - Assert: `set(plugin dir names) == set(p["name"] for p in marketplace["plugins"])`.
+  - Optional v2: assert each entry's `source: ./plugins/<name>` resolves and the entry's `version` equals the plugin's own `plugin.json` version.
+- Run on every push + PR via `.github/workflows/marketplace-consistency.yml`.
+- Should also run on `main` post-merge so a slip is caught immediately rather than at next-PR time.
+
+---
+
+## P2 — important
+
+### Build the `plugins/engineering-journal/` plugin  {#engineering-journal-plugin}
+
+**Priority.** P2.
+
+**Effort.** Multi-day (1–2 days of focused work for v1, more for the polish + the SDLC-philosophy doc).
+
+**Worth it when.** A second or third Infiquetra repo wants the journal pattern and the manual setup labor (4 template files + CLAUDE.md section) starts to feel repetitive. Right now we have two adopters (home-lab, this repo); the third will be the trigger.
+
+**Context.**
+- Decided in `infiquetra/home-lab/docs/engineering-journal/DECISIONS.md` entry dated 2026-05-01: a two-tier split where `infiquetra-sdlc/docs/philosophy/engineering-journal.md` holds the canonical "what + why" and a `plugins/engineering-journal/` plugin in *this* repo holds the operational tooling.
+- Five sub-decisions already pinned in that entry: standalone plugin (not folded into `sdlc-manager`); router skill (`using-engineering-journal`), not always-on hook; embedded templates (offline-friendly); `/journal-init` command with `--upgrade` mode for non-canonical existing layouts; naming convention.
+- Full design walkthrough lives in `home-lab/docs/engineering-journal/narratives/2026-05-01-engineering-journal-distribution-design.md`.
+- This plan's adoption of the journal in `infiquetra-claude-plugins` is **not** the plugin — it's a hand-built journal for this repo's own meta-work. The plugin work is downstream and uses this repo + home-lab as proven references when it's built.
+
+---

--- a/docs/engineering-journal/README.md
+++ b/docs/engineering-journal/README.md
@@ -1,0 +1,38 @@
+# Engineering Journal — Infiquetra Claude Plugins
+
+Living documentation for the `infiquetra-claude-plugins` repository — the plugins themselves, the marketplace registry, the development conventions, and the cross-plugin patterns that emerge over time. Prevents knowledge loss across sessions and across contributors.
+
+The journal is the *directory*; the four core files plus `narratives/` are its sections. Pattern adopted 2026-05-01 from `infiquetra/home-lab/docs/engineering-journal/`.
+
+## Files in this folder
+
+| File | What it holds | When to update |
+|------|---------------|----------------|
+| [LEARNINGS.md](LEARNINGS.md) | Empirical findings + mechanisms + fixes + validations about plugins, the marketplace, hooks, skills, MCP integrations, build tooling | Every time a plugin bug, surprising behavior, or non-obvious truth surfaces during development |
+| [DECISIONS.md](DECISIONS.md) | ADR-style records of plugin-pattern / convention / tooling choices | Every time we pick between options + commit to a path (skills-based vs CLI-based, line length, lockfile, marketplace category) |
+| [QUEUED.md](QUEUED.md) | Future-work items — prioritized, with "worth it when" triggers | Whenever an idea surfaces that we don't build now but don't want to forget (new plugin, CI guard, refactor) |
+| [ARCHIVE.md](ARCHIVE.md) | Shipped + rejected + superseded items | When a QUEUED item lands or is explicitly rejected; when a LEARNING/DECISION is invalidated |
+| [narratives/](narratives/) | Self-contained, longer-form companion docs (plugin design walkthroughs, multi-PR post-mortems, migration write-ups) | When you need a doc that's standalone-readable cold by an outside reader (a future maintainer, a plugin consumer, you-six-months-out) |
+
+## How to maintain
+
+**This folder is self-maintaining via the repo's `CLAUDE.md`** — which instructs Claude to update these files as work proceeds, without the user having to ask. Specifically:
+
+- **After fixing a plugin bug or shipping a feature where the mechanism wasn't obvious** (marketplace registry drift, hook timing, skill activation race, MCP env propagation): add a dated entry to `LEARNINGS.md` with evidence + mechanism + **Generalizable rule**.
+- **After a plugin-pattern decision** (skills vs CLI, line length, lockfile choice, marketplace category taxonomy, version bump strategy, hook event choice): add an entry to `DECISIONS.md` with rationale + rejected alternatives + revisit-when condition + commit hash.
+- **When an idea surfaces but isn't being built now**: add to `QUEUED.md` with priority (P0/P1/P2/P3/Maybe) + "worth it when…" trigger + effort estimate.
+- **When a QUEUED item ships**: move the entry to `ARCHIVE.md` with the commit hash + SHIPPED date. Remove from QUEUED.
+- **When a QUEUED item is rejected**: move to `ARCHIVE.md` as REJECTED with reason + revisit conditions. Remove from QUEUED.
+- **When a decision gets reversed or a learning is invalidated**: update the original entry inline with the correction AND move the pre-correction version to `ARCHIVE.md` as SUPERSEDED. Never silently overwrite history.
+- **When something needs a longer write-up than fits an entry**: create `narratives/YYYY-MM-DD-short-slug.md` and link from the relevant LEARNINGS / DECISIONS entry.
+
+Each of the four core files has a block-quote intro at the top with its own format spec — read those when adding entries.
+
+## Quick navigation by topic
+
+- Marketplace registry drift (PRs #110/#111 missed registration) → [LEARNINGS](LEARNINGS.md#marketplace-drift)
+- `marketplace.json` `Edit` requires `]` in `old_string` → [LEARNINGS](LEARNINGS.md#marketplace-edit-guard)
+- Gitignore `.claude/` and skip `uv.lock` → [DECISIONS](DECISIONS.md#gitignore-claude-and-no-uv-lock)
+- CI guard for plugins/marketplace drift → [QUEUED](QUEUED.md#marketplace-ci-guard)
+- Future `plugins/engineering-journal/` plugin → [QUEUED](QUEUED.md#engineering-journal-plugin)
+- PR #112 marketplace fix (SHIPPED) → [ARCHIVE](ARCHIVE.md#pr-112-marketplace-fix)

--- a/docs/engineering-journal/narratives/README.md
+++ b/docs/engineering-journal/narratives/README.md
@@ -1,0 +1,31 @@
+# Narratives
+
+Self-contained, longer-form companion docs for the engineering journal. Each narrative is standalone-readable cold by an outside reader (a future maintainer, a plugin consumer, you-six-months-out). Linked from the relevant entry in `LEARNINGS.md` or `DECISIONS.md`.
+
+## When to write a narrative
+
+The four core files (`LEARNINGS.md`, `DECISIONS.md`, `QUEUED.md`, `ARCHIVE.md`) are designed to be **scannable**. An entry that runs more than ~30 lines of body text or needs diagrams, multi-section context, or a full reproduction recipe is a signal that the content belongs in a narrative.
+
+Concrete triggers:
+
+- **Plugin design walkthrough.** A new plugin's architecture spans multiple skills, commands, scripts, and external integrations — and you need to explain why the pieces are arranged the way they are. Don't bury this in the plugin's `README.md` (which is a *user* doc); narrative is a *contributor* doc.
+- **Multi-PR post-mortem.** A bug or feature played out across 3+ PRs over time. The story is the value; the LEARNING entry just points at the narrative.
+- **Migration write-up.** A repo-wide rename, layout reshuffle, or version bump that touched many files. Capture the before/after and why.
+- **Rejected-design memo.** When a design was carefully considered and rejected, the *consideration* is worth preserving even though the design isn't shipped. Pair with a DECISIONS entry whose "Rejected alternatives" line points here.
+- **Inventory snapshot.** Forensics-grade record of "what existed at this date" — useful when later debugging asks "did this plugin even exist when X happened?"
+
+## Format
+
+- **Filename**: `YYYY-MM-DD-short-slug.md` (date-prefixed kebab-case).
+- **Title** (H1): a descriptive sentence — narratives are linked-to, not browsed by filename.
+- **Header metadata block** at the top: a few lines of `**Date**:`, `**Type**:` (design / post-mortem / migration / rejected-memo / inventory), `**Status**:` (current / superseded), `**Refs**:` (back-links to entries that cite this).
+- **Body**: prose-first. Sections as needed. Diagrams as ASCII or linked PNGs.
+- **Last updated** line at the bottom if the document evolves; bump the date when content changes substantively.
+
+Unlike the four core files (append-only at the top), narratives **can be edited inline** when new information arrives — but always preserve the "Last updated YYYY-MM-DD" trail so a reader knows the document evolved.
+
+## Cross-references
+
+Every narrative should be cited from at least one entry in the four core files. If a narrative doesn't have a back-link, either it should (add the back-link) or the narrative belongs in a different location (a plugin's own `README.md`, a top-level doc, etc.).
+
+When a narrative is *superseded* by a later one, mark the old one's status as `superseded by [link]` at the top — never delete.


### PR DESCRIPTION
## Summary
- Adds `docs/engineering-journal/` with the four core files (LEARNINGS / DECISIONS / QUEUED / ARCHIVE), a `narratives/` subdir, and a README that ties them together.
- Adds an "Engineering journal — AUTO-MAINTAIN" section to root `CLAUDE.md` with 7 maintenance triggers so Claude updates the journal as work proceeds, without being asked.
- Seeds the four core files with **real entries** from recent activity (PRs #110/#111/#112), not empty templates.

## Why
This repo generates plugin-development knowledge — non-obvious truths (marketplace.json drift class), pattern decisions (skills vs CLI, line length, lockfile), idea queue items (CI guards, future plugins). Right now this knowledge lives in personal memory, commit messages, and Claude's head — none of which travel with the repo. The journal makes it durable + discoverable for future agents and human readers.

## Pattern provenance
Adopted from `infiquetra/home-lab/docs/engineering-journal/` (home-lab itself adopted it on 2026-05-01). Citation in `docs/engineering-journal/README.md` line 5.

## Seed entries

**LEARNINGS** (2):
- *Marketplace registry drift* — PRs #110/#111 shipped `plugins/blueprint-reviewer/` without registering it in `marketplace.json`; fix landed in #112. Generalizable rule: when two files must stay in sync, add a CI assertion (don't rely on review).
- *`marketplace.json` Edit guard* — `old_string` must include the array's closing `]` so new entries land inside the array. Promotes the existing memory note to a project-shareable record.

**DECISIONS** (1):
- *Gitignore `.claude/`, do not track `uv.lock`* (commit `4da5705`). Rationale: per-user state vs a build-tool claim the repo isn't making (pyproject uses hatchling).

**QUEUED** (2):
- **P1** — CI guard asserting `plugins/` dirs match `marketplace.json` entries. Worth-it-when: right now (the bug it prevents shipped twice in a row).
- **P2** — Build the `plugins/engineering-journal/` plugin per home-lab `DECISIONS.md` 2026-05-01 (cross-repo roadmap pointer so the link survives in this repo).

**ARCHIVE** (1):
- PR #112 — SHIPPED 2026-05-01 (commit `4da5705`), with back-refs to the LEARNINGS and DECISIONS entries it generated.

## Test plan
- [x] `find docs/engineering-journal -type f | sort` lists 6 files
- [x] Each of the 4 core files starts with a `>`-quoted format spec
- [x] `grep -F "Engineering journal" CLAUDE.md` matches
- [x] `python3 -m json.tool .claude-plugin/marketplace.json` still passes (no inadvertent breakage)
- [ ] After merge: a future agent reading `CLAUDE.md` sees the AUTO-MAINTAIN section and knows to add entries on plugin-bug fixes / pattern decisions / queued ideas