### PR TITLE
feat(sdlc-manager): flow subcommand group + card_validator shim + Beads removal (Phase C minimal)

### DIFF
--- a/plugins/sdlc-manager/.claude-plugin/plugin.json
+++ b/plugins/sdlc-manager/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "sdlc-manager",
-  "version": "1.0.0",
-  "description": "SDLC management for the Mount Olympus agent team. Kanban board operations, issue creation, label management, flow metrics, milestone tracking, and Beads task coordination.",
+  "version": "1.1.0",
+  "description": "SDLC management for the Mount Olympus agent team. Kanban board operations, issue creation, label management, flow metrics, milestone tracking, project-field assignment, sub-issue linking, and card validation.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "milestones", "beads", "mount-olympus"]
+  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "milestones", "sub-issues", "card-validator", "mount-olympus"]
 }

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [1.1.0] — 2026-05-04
 
+### Fixed (during PR #114 review)
+- **`validate_card_body` header text**: was `"Out-of-scope or non-goals"` (with "or"); home-lab card_validator.py and ALL actionable issue templates use `"Out-of-scope / non-goals"` (with "/"). Every real card would have failed validation with a phantom missing-section error. Corrected to match home-lab exactly. Same iteration also corrects `_PATH_LINE_RE` (now accepts plain filenames + bullet-prefixed paths matching home-lab) and `_CHECKLIST_RE` (now requires `\S` after `[ ]` and accepts `*` bullets matching home-lab).
+- **Drift-guard test**: added `test_required_headers_match_actual_issue_templates` that loads the real issue templates and verifies every `_REQUIRED_H3_HEADERS` entry has a matching `label:` in capability/enhancement/defect.yml. This is the test that would have caught the original "or" vs "/" bug.
+- **Pre-existing test breakage**: `tests/test_sdlc_manager.py` had a `TestBeadsClaim` class referencing the deleted `beads_claim` function. Class deleted; CHANGELOG note added in the test file.
+- **WIP-limits test fixture**: was using the old `beads_config` config-key (which now degrades to `{}`); the override test passed only by coincidence. Renamed fixture to `legacy_rollout_config`; tightened assertion to verify the OVERRIDDEN column (Ready) renders with the override limit, not just any column happening to have a "5" in its render.
+- **`flow_validate_card` exit-code path**: was calling `sys.exit(1)` directly, bypassing main()'s formatted-error path and breaking programmatic callers. Now raises `CardValidationError` (RuntimeError subclass) which main() catches; preserves the standard CLI exit code behavior + lets future callers inspect the failure.
+- **`_resolve_project_field` error message**: now includes a hint pointing at the field-creation runbook in `infiquetra-sdlc/docs/operations/operational-reference.md` when a field doesn't exist.
+- **Stale `# BEADS` banner**: removed (Beads removal had left an empty banner in the argparse section).
+- **Duplicate `import re`**: removed (validator block had a redundant import; top-level `import re` at line 61 already covers it).
+- **Unused `project_id_check` variable**: replaced with `_, items = ...` discard idiom (consistent with `board_wip` pattern).
+- **README.md**: removed the "Beads coordination" capability bullet + stale `bd` CLI prerequisite + stale `Beads Operations` section + stale `config/beads-config.json` row. Added `Flow Operations` section with the 6 new commands.
+
 ### Added
 - New `flow` subcommand group — operator-facing GraphQL + REST helpers:
   - `flow set-field` — set a single-select project field on a card (Initiative, Objective, Status, etc.)

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — sdlc-manager
 
+## [1.1.0] — 2026-05-04
+
+### Added
+- New `flow` subcommand group — operator-facing GraphQL + REST helpers:
+  - `flow set-field` — set a single-select project field on a card (Initiative, Objective, Status, etc.)
+  - `flow field-options` — list current options for a project field (live discovery, IDs not cached)
+  - `flow discover-project` — resolve which project a repo maps to
+  - `flow link-sub-issue` — link child as native sub-issue of parent (cross-repo, idempotent)
+  - `flow verify-label` — self-healing label create (404 → create, exists → no-op, other errors raise)
+  - `flow validate-card` — pre-flight check an existing issue body against the card_validator schema
+- New `validate_card_body()` Python helper — mirrors home-lab card_validator.py's high-leverage checks (6 required H3 headers, AC has ≥1 checklist, Verification has ≥1 fenced code block, Files-expected has ≥1 path-like line, no placeholder-only sections)
+- New `sdlc-flow` skill (SKILL.md) describing the `flow` commands + idempotency contract + hard rules + integration with the blueprint-to-issue workflow
+- 20 tests in `tests/test_card_validator.py` and `tests/test_flow_subcommands.py` covering: validator schema rules, idempotency contracts, error classification (404 vs auth vs server), live-discovery vs cached, helpful error messages with current options listed
+
+### Changed
+- Renamed `beads_config` config-key to `legacy_rollout_config` in `load_config` and downstream readers (`board_wip`, `rollout_status`, `rollout_update`, `config_show`). The underlying file (`beads-config.json`) was already removed from infiquetra-sdlc on 2026-04-26; the key now degrades gracefully to `{}` for back-compat. Comment in `load_config` documents the migration.
+
+### Removed
+- `beads` subcommand group (`ready`, `claim`, `update`, `complete`, `status`)
+- `_bd` shell helper for invoking the `bd` CLI
+- All `beads_*` Python functions
+- The Beads/Dolt coordination layer was removed from Mount Olympus on 2026-04-26 (see `infiquetra-sdlc/docs/engineering-journal/narratives/2026-04-26-beads-dolt-removed.md`); the agent fleet now coordinates via Redis pub/sub + GitHub Projects v2 + Discord per-card threads. The plugin's `beads` commands targeted infrastructure that no longer exists.
+
+### Migration notes
+- Operators previously running `sdlc_manager.py beads <action>` will get an `argparse` error. There is no replacement — the underlying coordination has moved off Beads entirely. Use `gh` + the new `flow` commands for direct board operations.
+- The `flow set-field` command is the canonical mechanism for Initiative + Objective assignment per the 2026-05-03 DECISION (see `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md`). The fields don't exist on the Olympus board today; create them via the operator runbook in `operational-reference.md` before using `flow set-field`.
+
 ## [1.0.0] — 2026-03-29
 
 ### Added

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -12,15 +12,14 @@ All operations run locally via the `gh` CLI, providing:
 - **Flow metrics** — cycle time, throughput, WIP age using GitHub timeline events
 - **Rollout tracking** — gap analysis and full SDLC deployment to any Infiquetra repo
 - **Milestone management** — create and track Objectives via GitHub Milestones
-- **Beads coordination** — task claiming, status updates, and completion via bd CLI
+- **Flow helpers** — `flow set-field` / `flow link-sub-issue` / `flow verify-label` / `flow validate-card` / `flow field-options` / `flow discover-project`. Operator-facing GraphQL + REST helpers for project field assignment, native sub-issue linking, self-healing label create, and card pre-flight validation
 
 ## Quick Start
 
 ### Prerequisites
 
-- `gh` CLI installed and authenticated with github.com
+- `gh` CLI installed and authenticated with github.com (Projects write scope required for `flow set-field` writes — see `gh auth status`)
 - `infiquetra-sdlc` repo checked out at `~/workspace/infiquetra/infiquetra-sdlc` (or set `INFIQUETRA_SDLC_PATH`)
-- `bd` CLI installed (for Beads task coordination)
 - Python 3.12+
 
 ### Script Location (after plugin install)
@@ -68,7 +67,9 @@ The `sdlc-operator` agent orchestrates complex multi-step operations:
 - New initiative/objective setup (labels + field options + milestone)
 - Objective progress tracking across repos
 - Batch triage of untriaged issues
-- Beads task coordination (ready -> claim -> update -> complete)
+- Project field assignment via `flow set-field` (Initiative, Objective, Status — single-select fields on the Olympus board per the 2026-05-03 DECISION)
+- Native sub-issue linking via `flow link-sub-issue` (cross-repo, idempotent)
+- Card body pre-flight validation via `flow validate-card`
 
 ## Architecture
 
@@ -183,23 +184,33 @@ python3 $SCRIPT rollout deploy-all --repo athena-service
 python3 $SCRIPT rollout update --repo athena-service --field labels --status complete
 ```
 
-### Beads Operations
+### Flow Operations (Phase C)
+
+Operator-facing GraphQL + REST helpers. See `skills/sdlc-flow/SKILL.md` for the full per-command idempotency contract.
 
 ```bash
-# Show tasks ready for claiming
-python3 $SCRIPT beads ready
+# Set Initiative or Objective on a card (project FIELDS, not labels)
+python3 $SCRIPT flow set-field --project mount-olympus \
+    --repo campps-mvp --number 42 \
+    --field Initiative --option olympus-quality
 
-# Claim a task
-python3 $SCRIPT beads claim --task-id TASK-001
+# List the live options on a project field (IDs rotate on rename)
+python3 $SCRIPT flow field-options --project mount-olympus --field Objective
 
-# Update task status
-python3 $SCRIPT beads update --task-id TASK-001 --status in-progress
+# Resolve which project a repo maps to
+python3 $SCRIPT flow discover-project --repo athena-service
 
-# Complete a task
-python3 $SCRIPT beads complete --task-id TASK-001
+# Link child as native sub-issue of parent (cross-repo, idempotent)
+python3 $SCRIPT flow link-sub-issue \
+    --parent-repo campps-blueprint --parent-number 1 \
+    --child-repo campps-mvp --child-number 42
 
-# Show overall task status
-python3 $SCRIPT beads status
+# Self-healing label create (404 → create; exists → no-op; auth/server errors raise)
+python3 $SCRIPT flow verify-label --repo campps-mvp \
+    --name high-priority --color D93F0B --description "High priority"
+
+# Pre-flight card body against the card_validator schema
+python3 $SCRIPT flow validate-card --repo campps-mvp --number 42
 ```
 
 ## Configuration
@@ -216,7 +227,7 @@ python3 $SCRIPT beads status
 |------|---------|
 | `config/project-mappings.json` | Project IDs, field IDs, repo-to-project mapping |
 | `config/labels.json` | Label definitions and auto-label rules |
-| `config/beads-config.json` | Beads/rollout tracking across repos |
+| `config/beads-config.json` | (legacy — file removed from infiquetra-sdlc on 2026-04-26; reads degrade gracefully to `{}`. The `legacy_rollout_config` key in `load_config` documents the migration.) |
 
 ## Projects
 

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -1485,17 +1485,12 @@ def rollout_update(repo: str, field: str, status: str, fmt: str) -> None:
     print(f"Updated {repo}.{field} = {status} in beads-config.json")
 
 
-# ===========================
-# BEADS OPERATIONS
-# ===========================
-
-# NOTE: Beads/Dolt was removed from the Mount Olympus coordination layer
-# on 2026-04-26. The agent fleet now coordinates via Redis pub/sub
-# (`olympus:*` channels) + GitHub Projects v2 + Discord per-card threads.
-# The previous `beads {ready,claim,update,complete,status}` subcommand
-# group + the `_bd` shell helper were removed in this PR. See
-# infiquetra-sdlc/docs/engineering-journal/narratives/2026-04-26-beads-dolt-removed.md
-# for the migration narrative.
+# NOTE: The `beads` subcommand group + `_bd` shell helper + `beads_*`
+# functions were removed in this PR. Beads/Dolt was decommissioned from
+# the Mount Olympus coordination layer on 2026-04-26 (see
+# infiquetra-sdlc/docs/engineering-journal/narratives/2026-04-26-beads-dolt-removed.md);
+# the agent fleet now coordinates via Redis pub/sub (`olympus:*` channels)
+# + GitHub Projects v2 + Discord per-card threads.
 
 
 # ===========================
@@ -1524,7 +1519,11 @@ def _resolve_project_field(project_name: str, field_name: str) -> dict:
             return {**f, "_project_id": data["organization"]["projectV2"]["id"]}
     raise RuntimeError(
         f"Field '{field_name}' not found on project '{project_name}'. "
-        f"Available fields: {[f.get('name') for f in fields]}"
+        f"Available fields: {[f.get('name') for f in fields]}. "
+        f"If you expected this field to exist (e.g., Initiative or Objective), "
+        f"the field-creation runbook is in "
+        f"`infiquetra-sdlc/docs/operations/operational-reference.md` "
+        f"under 'Initiative/Objective Tracking'."
     )
 
 
@@ -1575,7 +1574,7 @@ def flow_set_field(
         )
 
     # Find the project item for this repo+number
-    project_id_check, items = get_project_items(get_project_config(load_config(), project_name)["number"])
+    _, items = get_project_items(get_project_config(load_config(), project_name)["number"])
     target_item = next(
         (i for i in items
          if i.get("content", {}).get("number") == number
@@ -1722,26 +1721,43 @@ def flow_verify_label(
 # checks: 6 required H3 headers, AC has ≥1 checklist item, Verification has
 # ≥1 fenced code block, Files-expected has ≥1 path-like line, no placeholders.
 
-import re
+# All regexes + the placeholder set below MUST mirror the home-lab source-of-truth:
+# `home-lab/ansible/roles/hermes_orchestrator/files/card_validator.py`. When that
+# file's contract changes, update these in the same PR.
 
 _REQUIRED_H3_HEADERS = (
     "Objective",
     "Acceptance criteria",
-    "Out-of-scope or non-goals",
+    "Out-of-scope / non-goals",   # exact match: home-lab uses slash, not "or"
     "Files expected to change",
     "Tests to add or update",
     "Verification",
 )
 _OPTIONAL_H3_HEADERS = (
     "Notes / conventions",
-    "Notes/conventions",
     "Context library links",
 )
-_HEADER_RE = re.compile(r"^### (.+?)\s*$", re.MULTILINE)
-_CHECKLIST_RE = re.compile(r"^\s*- \[[ xX]\]\s", re.MULTILINE)
+_HEADER_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+# Checklist: `- [ ]`, `- [x]`, `* [ ]`, `* [X]`, with leading whitespace.
+# Requires `\S` after the bracket — empty checkbox-only lines don't count
+# (matches home-lab `card_validator.py:73`).
+_CHECKLIST_RE = re.compile(r"^\s*[-*]\s+\[[ xX]\]\s+\S", re.MULTILINE)
 _CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
-_PATH_LINE_RE = re.compile(r"^\s*[\w./_-]+/[\w./_-]+", re.MULTILINE)
-_PLACEHOLDER_LINES = {"- [ ]", "-", "* [ ]", "*", "_no response_", "none", "<!-- placeholder -->"}
+# A "plausible path" — matches home-lab `_PATH_LINE_RE` exactly:
+# optional bullet (`-` or `*`), optional quote/backtick wrapper, then a
+# token containing either `/` or `.` (so `pyproject.toml` and `- src/foo.py`
+# both pass). The orchestrator verifies actual existence; we just gate on
+# "looks like a path."
+_PATH_LINE_RE = re.compile(
+    r"^\s*(?:[-*]\s+)?"
+    r"[`'\"]?"
+    r"[\w./~\-]*[/.][\w./~\-]+"
+    r".*$",
+    re.MULTILINE,
+)
+_PLACEHOLDER_LINES = frozenset({
+    "- [ ]", "-", "* [ ]", "*", "_no response_", "none", "<!-- placeholder -->",
+})
 
 
 def _split_sections(body: str) -> dict[str, str]:
@@ -1759,9 +1775,22 @@ def _split_sections(body: str) -> dict[str, str]:
 def validate_card_body(body: str) -> tuple[bool, list[str]]:
     """Run the card_validator schema check on an issue body.
 
-    Returns (is_valid, errors). Mirrors the high-leverage checks of
-    home-lab card_validator.py — when that file's contract changes,
-    update this shim.
+    Mirrors home-lab card_validator.py's high-leverage checks. When that
+    file's contract changes, update this shim in the same PR.
+
+    Returns (is_valid, errors). The 5 checks:
+      1. All 6 required H3 sections present (Objective, Acceptance criteria,
+         Out-of-scope / non-goals, Files expected to change, Tests to add
+         or update, Verification).
+      2. Acceptance criteria has at least one `- [ ]` or `* [ ]` checklist
+         item with non-whitespace content after the bracket.
+      3. Verification has at least one fenced code block (≥2 ``` markers).
+      4. Files expected to change has at least one path-like line (matches
+         home-lab _PATH_LINE_RE — accepts plain filenames like
+         `pyproject.toml`, bullet-prefixed paths like `- src/foo.py`, and
+         backtick-wrapped paths).
+      5. No required section consists of only placeholder lines
+         (`- [ ]`, `_No response_`, `None`, etc.).
     """
     errors: list[str] = []
     sections = _split_sections(body)
@@ -1813,29 +1842,52 @@ def validate_card_body(body: str) -> tuple[bool, list[str]]:
     return (len(errors) == 0, errors)
 
 
+class CardValidationError(RuntimeError):
+    """Raised when an issue body fails the card_validator schema check.
+    `main()` catches RuntimeError and exits non-zero — using a typed
+    subclass lets future callers inspect the failure programmatically
+    while preserving the standard CLI exit-code path."""
+
+    def __init__(self, issue_ref: str, errors: list[str]):
+        self.issue_ref = issue_ref
+        self.errors = errors
+        super().__init__(
+            f"INVALID: {issue_ref} fails card_validator schema check: " +
+            "; ".join(errors)
+        )
+
+
 def flow_validate_card(repo: str, number: int, fmt: str) -> None:
-    """Fetch an issue body via gh, run card_validator, report result."""
+    """Fetch an issue body via gh, run card_validator, report result.
+
+    Consistent with other flow helpers: raises RuntimeError on failure
+    (caught by main() → exit 1). Does NOT call sys.exit() directly —
+    that would bypass main()'s formatted-error path and break programmatic
+    callers who import this function."""
+    issue_ref = f"{repo}#{number}"
     try:
         data = _rest_get(f"repos/{ORG}/{repo}/issues/{number}")
     except RuntimeError as e:
-        raise RuntimeError(f"Could not fetch issue {repo}#{number}: {e}")
+        raise RuntimeError(f"Could not fetch issue {issue_ref}: {e}")
     body = data.get("body") or ""
     if not body:
-        _out(f"Issue {repo}#{number} has no body — fails validation trivially.", fmt)
-        sys.exit(1)
+        # Empty body fails trivially — report via the standard error path
+        raise CardValidationError(issue_ref, ["Issue has empty body"])
 
     is_valid, errors = validate_card_body(body)
     if is_valid:
-        _out(f"VALID: {repo}#{number} passes card_validator schema check.", fmt)
+        _out(f"VALID: {issue_ref} passes card_validator schema check.", fmt)
         return
 
+    # For JSON callers, emit the structured payload before raising.
+    # The CardValidationError still propagates so main() exits 1.
     if fmt == "json":
-        _out({"valid": False, "errors": errors, "issue": f"{repo}#{number}"}, fmt)
+        _out({"valid": False, "errors": errors, "issue": issue_ref}, fmt)
     else:
-        print(f"INVALID: {repo}#{number} fails card_validator schema check:")
+        print(f"INVALID: {issue_ref} fails card_validator schema check:")
         for e in errors:
             print(f"  - {e}")
-    sys.exit(1)
+    raise CardValidationError(issue_ref, errors)
 
 
 # ===========================
@@ -2069,9 +2121,6 @@ def main() -> None:
     rollout_update_p.add_argument("--status", required=True,
                                    choices=["pending", "in-progress", "complete"])
 
-    # ===========================
-    # BEADS
-    # ===========================
     # ===========================
     # FLOW (Phase C — operator-facing GraphQL/REST surface)
     # ===========================

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -42,11 +42,12 @@ Usage:
     sdlc_manager.py rollout deploy-all --repo athena-service
     sdlc_manager.py rollout update --repo athena-service --field labels --status complete
 
-    sdlc_manager.py beads ready
-    sdlc_manager.py beads claim --task-id TASK-001
-    sdlc_manager.py beads update --task-id TASK-001 --status in-progress
-    sdlc_manager.py beads complete --task-id TASK-001
-    sdlc_manager.py beads status
+    sdlc_manager.py flow set-field --project mount-olympus --repo R --number N --field Initiative --option <name>
+    sdlc_manager.py flow field-options --project mount-olympus --field Objective
+    sdlc_manager.py flow discover-project --repo athena-service
+    sdlc_manager.py flow link-sub-issue --parent-repo R --parent-number P --child-repo R2 --child-number C
+    sdlc_manager.py flow verify-label --repo athena-service --name high-priority [--color D93F0B] [--description "..."]
+    sdlc_manager.py flow validate-card --repo athena-service --number 42
 
     sdlc_manager.py config show
 
@@ -85,10 +86,17 @@ def load_config() -> dict[str, Any]:
     sdlc_path = get_sdlc_path()
     config: dict[str, Any] = {}
 
+    # `legacy_rollout_config` reads `beads-config.json` for back-compat.
+    # That file was removed from infiquetra-sdlc on 2026-04-26 (Beads removal);
+    # this key now degrades gracefully to {} on missing-file. Several functions
+    # below (board_wip, rollout_status, rollout_update, config_show) read this
+    # config; they treat empty as "no rollout state tracked" and behave
+    # sensibly. When a replacement file ships (e.g., rollout-status.json),
+    # rename the key + path here.
     config_files = {
         "project_mappings": sdlc_path / "config" / "project-mappings.json",
         "labels": sdlc_path / "config" / "labels.json",
-        "beads_config": sdlc_path / "config" / "beads-config.json",
+        "legacy_rollout_config": sdlc_path / "config" / "beads-config.json",
     }
 
     for key, path in config_files.items():
@@ -634,7 +642,7 @@ def board_wip(project_name: str, fmt: str) -> None:
     # WIP limits: configurable via beads-config.json "wip_limits" section.
     # "In Development" default is 10 (conservative for a mixed human/agent team
     # where not all agents do dev work). Override in config for your team size.
-    config_wip = config.get("beads_config", {}).get("wip_limits", {})
+    config_wip = config.get("legacy_rollout_config", {}).get("wip_limits", {})
     wip_limits = {
         "Ready": config_wip.get("ready", 10),
         "In Development": config_wip.get("in_development", 10),
@@ -1284,7 +1292,7 @@ def milestones_link(repo: str, issue_num: int, milestone_num: int, fmt: str) -> 
 def rollout_status(team_filter: str | None, fmt: str) -> None:
     """Show rollout status from config."""
     config = load_config()
-    status = config.get("beads_config", {})
+    status = config.get("legacy_rollout_config", {})
     repos = status.get("repositories", {})
     summary = status.get("summary", {})
 
@@ -1447,7 +1455,7 @@ def rollout_update(repo: str, field: str, status: str, fmt: str) -> None:
     status_file = sdlc_path / "config" / "beads-config.json"
 
     config = load_config()
-    beads = config.get("beads_config", {})
+    beads = config.get("legacy_rollout_config", {})
     repos = beads.get("repositories", {})
 
     if repo not in repos:
@@ -1481,55 +1489,353 @@ def rollout_update(repo: str, field: str, status: str, fmt: str) -> None:
 # BEADS OPERATIONS
 # ===========================
 
-def _bd(args: list[str]) -> str:
-    """Run bd (Beads/Dolt) CLI command."""
-    cmd = ["bd"] + args
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=30,
+# NOTE: Beads/Dolt was removed from the Mount Olympus coordination layer
+# on 2026-04-26. The agent fleet now coordinates via Redis pub/sub
+# (`olympus:*` channels) + GitHub Projects v2 + Discord per-card threads.
+# The previous `beads {ready,claim,update,complete,status}` subcommand
+# group + the `_bd` shell helper were removed in this PR. See
+# infiquetra-sdlc/docs/engineering-journal/narratives/2026-04-26-beads-dolt-removed.md
+# for the migration narrative.
+
+
+# ===========================
+# FLOW OPERATIONS (Phase C)
+# ===========================
+# `flow` is a thin operator-facing surface over the GraphQL + REST APIs the
+# plugin already uses elsewhere. Commands here are the minimum viable set
+# needed to make the blueprint-to-issue workflow executable end-to-end:
+#   - set-field          set a single-select project field on a card
+#   - field-options      list current options for a project field
+#   - discover-project   resolve which project a repo is mapped to
+#   - link-sub-issue     wrap the native sub-issue API
+#   - verify-label       self-heal missing labels (404 → create; exists → no-op)
+#   - validate-card      run the card_validator schema check on an issue body
+
+
+def _resolve_project_field(project_name: str, field_name: str) -> dict:
+    """Look up a project field by name. Returns the field node (with
+    id, name, options if SINGLE_SELECT). Raises RuntimeError if missing."""
+    config = load_config()
+    proj = get_project_config(config, project_name)
+    data = _graphql(QUERY_GET_PROJECT_FIELDS, {"org": ORG, "number": proj["number"]})
+    fields = data.get("organization", {}).get("projectV2", {}).get("fields", {}).get("nodes", [])
+    for f in fields:
+        if f.get("name", "").lower() == field_name.lower():
+            return {**f, "_project_id": data["organization"]["projectV2"]["id"]}
+    raise RuntimeError(
+        f"Field '{field_name}' not found on project '{project_name}'. "
+        f"Available fields: {[f.get('name') for f in fields]}"
+    )
+
+
+def flow_field_options(project_name: str, field_name: str, fmt: str) -> None:
+    """List the current options for a project single-select field.
+    Live discovery — option IDs rotate on rename/recreate; never cache them."""
+    field = _resolve_project_field(project_name, field_name)
+    options = field.get("options", [])
+    if not options:
+        _out(
+            f"Field '{field_name}' has no options (or is not a SINGLE_SELECT field).",
+            fmt,
         )
-        if result.returncode != 0:
-            err = result.stderr.strip() if result.stderr else "Unknown error"
-            raise RuntimeError(f"bd command failed: {err}")
-        return result.stdout.strip()
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("bd command timed out after 30s")
-    except FileNotFoundError:
-        _error("bd CLI not found. Install Beads/Dolt tools first.")
+        return
+    if fmt == "json":
+        _out([{"id": o["id"], "name": o["name"]} for o in options], fmt)
+    else:
+        print(f"\nOptions for {project_name}.{field_name}:")
+        for o in options:
+            print(f"  {o['name']:30s}  (id: {o['id']})")
+
+
+def flow_set_field(
+    project_name: str,
+    repo: str,
+    number: int,
+    field_name: str,
+    option_name: str,
+    fmt: str,
+) -> None:
+    """Set a single-select field value on a card. Idempotent: re-running
+    with the same option produces the same final state."""
+    field = _resolve_project_field(project_name, field_name)
+    project_id = field["_project_id"]
+
+    # Find the option by name (case-insensitive)
+    options = field.get("options", [])
+    option = next(
+        (o for o in options if o.get("name", "").lower() == option_name.lower()),
+        None,
+    )
+    if not option:
+        raise RuntimeError(
+            f"Option '{option_name}' not found on field '{field_name}'. "
+            f"Available: {[o['name'] for o in options]}. "
+            f"Hint: use `flow field-options --project {project_name} --field {field_name}` "
+            f"to see current options."
+        )
+
+    # Find the project item for this repo+number
+    project_id_check, items = get_project_items(get_project_config(load_config(), project_name)["number"])
+    target_item = next(
+        (i for i in items
+         if i.get("content", {}).get("number") == number
+         and i.get("content", {}).get("repository", {}).get("name") == repo),
+        None,
+    )
+    if not target_item:
+        raise RuntimeError(
+            f"Issue {repo}#{number} is not on project '{project_name}'. "
+            f"Use `sdlc_manager.py board add --repo {repo} --number {number}` first."
+        )
+
+    _graphql(QUERY_SET_FIELD_VALUE, {
+        "projectId": project_id,
+        "itemId": target_item["id"],
+        "fieldId": field["id"],
+        "optionId": option["id"],
+    })
+    _out(f"Set {field_name}='{option_name}' on {repo}#{number} ({project_name})", fmt)
+
+
+def flow_discover_project(repo: str, fmt: str) -> None:
+    """Resolve which project(s) a repo is mapped to via project-mappings.json.
+    Returns a list of {name, number} entries; empty list if unmapped."""
+    config = load_config()
+    projects = get_projects_for_repo(config, repo)
+    if not projects:
+        mappings = config.get("project_mappings", {})
+        excluded = mappings.get("excluded_repositories", [])
+        if repo in excluded:
+            _out(f"Repo '{repo}' is in excluded_repositories.", fmt)
+        else:
+            _out(f"Repo '{repo}' is not mapped to any project.", fmt)
+        return
+    if fmt == "json":
+        _out([{"name": p["name"], "number": p["number"]} for p in projects], fmt)
+    else:
+        print(f"\n{repo} maps to:")
+        for p in projects:
+            print(f"  - {p['name']} (#{p['number']})")
+
+
+def flow_link_sub_issue(
+    parent_repo: str,
+    parent_number: int,
+    child_repo: str,
+    child_number: int,
+    fmt: str,
+) -> None:
+    """Link child as a native GitHub sub-issue of parent. Uses the REST
+    sub-issues API. Cross-repo supported. Idempotent — re-POST returns
+    HTTP 422 with 'already exists' which we treat as success."""
+    # Look up child's database ID (the sub-issues API uses db_id, not node id)
+    try:
+        child_data = _rest_get(f"repos/{ORG}/{child_repo}/issues/{child_number}")
+    except RuntimeError as e:
+        raise RuntimeError(f"Could not fetch child {child_repo}#{child_number}: {e}")
+    child_db_id = child_data.get("id")
+    if not isinstance(child_db_id, int):
+        raise RuntimeError(
+            f"Child {child_repo}#{child_number} returned no integer 'id'; "
+            f"got {child_db_id!r}. Cannot link."
+        )
+
+    # Validate parent exists + is an issue (not a PR)
+    try:
+        parent_data = _rest_get(f"repos/{ORG}/{parent_repo}/issues/{parent_number}")
+    except RuntimeError as e:
+        raise RuntimeError(f"Could not fetch parent {parent_repo}#{parent_number}: {e}")
+    if "pull_request" in parent_data:
+        raise RuntimeError(
+            f"Parent {parent_repo}#{parent_number} is a PR, not an issue. "
+            f"Sub-issues require an issue parent."
+        )
+
+    # POST the link. Endpoint is /repos/{owner}/{repo}/issues/{N}/sub_issues
+    # with body {"sub_issue_id": <child_db_id>}. Idempotent on duplicate.
+    try:
+        _rest_post(
+            f"repos/{ORG}/{parent_repo}/issues/{parent_number}/sub_issues",
+            {"sub_issue_id": child_db_id},
+        )
+        _out(
+            f"Linked {child_repo}#{child_number} as sub-issue of "
+            f"{parent_repo}#{parent_number}",
+            fmt,
+        )
+    except RuntimeError as e:
+        # Detect "already exists" to honor idempotency
+        msg = str(e).lower()
+        if "already exists" in msg or "422" in msg:
+            _out(
+                f"Already linked: {child_repo}#{child_number} is already a "
+                f"sub-issue of {parent_repo}#{parent_number} (idempotent re-run).",
+                fmt,
+            )
+            return
+        raise
+
+
+def flow_verify_label(
+    repo: str,
+    name: str,
+    color: str | None,
+    description: str | None,
+    fmt: str,
+) -> None:
+    """Self-healing label create. If the label exists on the repo, no-op.
+    If 404, create with given color + description. Distinguishes 404
+    (missing → create) from other errors (auth, rate-limit, server)."""
+    # Probe for existence via gh api; capture stderr to detect 404 vs other failures
+    cmd = ["api", f"repos/{ORG}/{repo}/labels/{name}"]
+    try:
+        _gh(cmd)
+        _out(f"Label '{name}' already exists on {ORG}/{repo} (no-op).", fmt)
+        return
+    except RuntimeError as e:
+        msg = str(e)
+        if "Not Found" not in msg and "404" not in msg:
+            # Re-raise non-404 errors verbatim — auth, rate-limit, server.
+            # Do NOT silently treat them as missing.
+            raise RuntimeError(
+                f"verify-label probe failed with non-404 error (not creating): {msg}"
+            )
+
+    # 404 — create the label
+    body: dict[str, str] = {"name": name}
+    if color:
+        body["color"] = color.lstrip("#")  # GH API rejects leading '#'
+    if description:
+        body["description"] = description
+    _rest_post(f"repos/{ORG}/{repo}/labels", body)
+    _out(f"Created label '{name}' on {ORG}/{repo}.", fmt)
+
+
+# ===========================
+# CARD VALIDATOR (mirror of home-lab card_validator.py)
+# ===========================
+# Mirrors the home-lab orchestrator's card_validator.py contract enough to
+# pre-flight check an issue body before plan-review fires. This is NOT a
+# strict re-implementation — the home-lab validator is the source of truth
+# (`home-lab/ansible/roles/hermes_orchestrator/files/card_validator.py`) and
+# should be consulted when the contract changes. We mirror the high-leverage
+# checks: 6 required H3 headers, AC has ≥1 checklist item, Verification has
+# ≥1 fenced code block, Files-expected has ≥1 path-like line, no placeholders.
+
+import re
+
+_REQUIRED_H3_HEADERS = (
+    "Objective",
+    "Acceptance criteria",
+    "Out-of-scope or non-goals",
+    "Files expected to change",
+    "Tests to add or update",
+    "Verification",
+)
+_OPTIONAL_H3_HEADERS = (
+    "Notes / conventions",
+    "Notes/conventions",
+    "Context library links",
+)
+_HEADER_RE = re.compile(r"^### (.+?)\s*$", re.MULTILINE)
+_CHECKLIST_RE = re.compile(r"^\s*- \[[ xX]\]\s", re.MULTILINE)
+_CODE_BLOCK_RE = re.compile(r"^```", re.MULTILINE)
+_PATH_LINE_RE = re.compile(r"^\s*[\w./_-]+/[\w./_-]+", re.MULTILINE)
+_PLACEHOLDER_LINES = {"- [ ]", "-", "* [ ]", "*", "_no response_", "none", "<!-- placeholder -->"}
+
+
+def _split_sections(body: str) -> dict[str, str]:
+    """Split a card body on `### H3` headers. Returns {header_text: section_text}."""
+    matches = list(_HEADER_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        header = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[header] = body[start:end].strip()
+    return sections
+
+
+def validate_card_body(body: str) -> tuple[bool, list[str]]:
+    """Run the card_validator schema check on an issue body.
+
+    Returns (is_valid, errors). Mirrors the high-leverage checks of
+    home-lab card_validator.py — when that file's contract changes,
+    update this shim.
+    """
+    errors: list[str] = []
+    sections = _split_sections(body)
+    section_names = set(sections.keys())
+
+    # 1. Required headers present
+    missing = [h for h in _REQUIRED_H3_HEADERS if h not in section_names]
+    if missing:
+        errors.append(f"Missing required H3 sections: {missing}")
+
+    # 2. Acceptance criteria has ≥1 checklist item
+    if "Acceptance criteria" in sections:
+        ac = sections["Acceptance criteria"]
+        if not _CHECKLIST_RE.search(ac):
+            errors.append(
+                "'Acceptance criteria' has no `- [ ]` checklist item "
+                "(card_validator requires at least one)"
+            )
+
+    # 3. Verification has ≥1 fenced code block
+    if "Verification" in sections:
+        v = sections["Verification"]
+        # Need at least 2 ``` markers to form one fenced block
+        if len(_CODE_BLOCK_RE.findall(v)) < 2:
+            errors.append(
+                "'Verification' has no fenced code block "
+                "(card_validator requires at least one ``` block)"
+            )
+
+    # 4. Files expected has ≥1 path-like line
+    if "Files expected to change" in sections:
+        f = sections["Files expected to change"]
+        if not _PATH_LINE_RE.search(f):
+            errors.append(
+                "'Files expected to change' has no path-like line "
+                "(card_validator requires at least one `dir/file` style entry)"
+            )
+
+    # 5. No placeholder-only sections
+    for header in _REQUIRED_H3_HEADERS:
+        if header not in sections:
+            continue
+        text = sections[header].strip()
+        # Strip blank lines + check whether all remaining lines are placeholders
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        if lines and all(ln.lower() in _PLACEHOLDER_LINES for ln in lines):
+            errors.append(f"'{header}' contains only placeholder text")
+
+    return (len(errors) == 0, errors)
+
+
+def flow_validate_card(repo: str, number: int, fmt: str) -> None:
+    """Fetch an issue body via gh, run card_validator, report result."""
+    try:
+        data = _rest_get(f"repos/{ORG}/{repo}/issues/{number}")
+    except RuntimeError as e:
+        raise RuntimeError(f"Could not fetch issue {repo}#{number}: {e}")
+    body = data.get("body") or ""
+    if not body:
+        _out(f"Issue {repo}#{number} has no body — fails validation trivially.", fmt)
         sys.exit(1)
 
+    is_valid, errors = validate_card_body(body)
+    if is_valid:
+        _out(f"VALID: {repo}#{number} passes card_validator schema check.", fmt)
+        return
 
-def beads_ready(fmt: str) -> None:
-    """Show tasks ready for claiming."""
-    output = _bd(["ready"])
-    _out(output, fmt)
-
-
-def beads_claim(task_id: str, fmt: str) -> None:
-    """Claim a Beads task."""
-    output = _bd(["claim", task_id])
-    _out(output, fmt)
-
-
-def beads_update(task_id: str, status: str, fmt: str) -> None:
-    """Update a Beads task status."""
-    output = _bd(["update", task_id, status])
-    _out(output, fmt)
-
-
-def beads_complete(task_id: str, fmt: str) -> None:
-    """Complete a Beads task."""
-    output = _bd(["complete", task_id])
-    _out(output, fmt)
-
-
-def beads_status(fmt: str) -> None:
-    """Show Beads task status overview."""
-    output = _bd(["status"])
-    _out(output, fmt)
+    if fmt == "json":
+        _out({"valid": False, "errors": errors, "issue": f"{repo}#{number}"}, fmt)
+    else:
+        print(f"INVALID: {repo}#{number} fails card_validator schema check:")
+        for e in errors:
+            print(f"  - {e}")
+    sys.exit(1)
 
 
 # ===========================
@@ -1558,7 +1864,7 @@ def config_show(fmt: str) -> None:
     labels = config.get("labels", {}).get("labels", [])
     print(f"\nLabels: {len(labels)} defined")
 
-    beads = config.get("beads_config", {})
+    beads = config.get("legacy_rollout_config", {})
     summary = beads.get("summary", {})
     print(f"\nRollout: {summary.get('completed', 0)}/{summary.get('total_repos', 0)} repos complete")
 
@@ -1766,22 +2072,59 @@ def main() -> None:
     # ===========================
     # BEADS
     # ===========================
-    beads_p = subparsers.add_parser("beads", help="Beads/Dolt task coordination")
-    beads_sp = beads_p.add_subparsers(dest="action", required=True)
+    # ===========================
+    # FLOW (Phase C — operator-facing GraphQL/REST surface)
+    # ===========================
+    flow_p = subparsers.add_parser("flow", help="Operator-facing GraphQL + REST helpers")
+    flow_sp = flow_p.add_subparsers(dest="action", required=True)
 
-    beads_sp.add_parser("ready", help="Show tasks ready for claiming")
+    flow_setfield_p = flow_sp.add_parser(
+        "set-field",
+        help="Set a single-select project field on a card",
+    )
+    flow_setfield_p.add_argument("--project", required=True, help="Project name (e.g., mount-olympus)")
+    flow_setfield_p.add_argument("--repo", required=True)
+    flow_setfield_p.add_argument("--number", required=True, type=int)
+    flow_setfield_p.add_argument("--field", required=True, help="Field name (e.g., Initiative, Objective, Status)")
+    flow_setfield_p.add_argument("--option", required=True, help="Option name (case-insensitive)")
 
-    beads_claim_p = beads_sp.add_parser("claim", help="Claim a task")
-    beads_claim_p.add_argument("--task-id", required=True, help="Task ID to claim")
+    flow_options_p = flow_sp.add_parser(
+        "field-options",
+        help="List current options for a project field (live discovery)",
+    )
+    flow_options_p.add_argument("--project", required=True)
+    flow_options_p.add_argument("--field", required=True)
 
-    beads_update_p = beads_sp.add_parser("update", help="Update task status")
-    beads_update_p.add_argument("--task-id", required=True, help="Task ID")
-    beads_update_p.add_argument("--status", required=True, help="New status")
+    flow_disc_p = flow_sp.add_parser(
+        "discover-project",
+        help="Resolve which project(s) a repo is mapped to",
+    )
+    flow_disc_p.add_argument("--repo", required=True)
 
-    beads_complete_p = beads_sp.add_parser("complete", help="Complete a task")
-    beads_complete_p.add_argument("--task-id", required=True, help="Task ID to complete")
+    flow_link_p = flow_sp.add_parser(
+        "link-sub-issue",
+        help="Link child as native sub-issue of parent (cross-repo supported, idempotent)",
+    )
+    flow_link_p.add_argument("--parent-repo", required=True)
+    flow_link_p.add_argument("--parent-number", required=True, type=int)
+    flow_link_p.add_argument("--child-repo", required=True)
+    flow_link_p.add_argument("--child-number", required=True, type=int)
 
-    beads_sp.add_parser("status", help="Show task status overview")
+    flow_label_p = flow_sp.add_parser(
+        "verify-label",
+        help="Self-healing label create (404 → create; exists → no-op; other errors raise)",
+    )
+    flow_label_p.add_argument("--repo", required=True)
+    flow_label_p.add_argument("--name", required=True)
+    flow_label_p.add_argument("--color", default=None, help="Hex color without leading '#'")
+    flow_label_p.add_argument("--description", default=None)
+
+    flow_validate_p = flow_sp.add_parser(
+        "validate-card",
+        help="Run card_validator schema check on an existing issue body",
+    )
+    flow_validate_p.add_argument("--repo", required=True)
+    flow_validate_p.add_argument("--number", required=True, type=int)
 
     # ===========================
     # CONFIG
@@ -1867,17 +2210,22 @@ def main() -> None:
             elif args.action == "update":
                 rollout_update(args.repo, args.field, args.status, fmt)
 
-        elif args.resource == "beads":
-            if args.action == "ready":
-                beads_ready(fmt)
-            elif args.action == "claim":
-                beads_claim(args.task_id, fmt)
-            elif args.action == "update":
-                beads_update(args.task_id, args.status, fmt)
-            elif args.action == "complete":
-                beads_complete(args.task_id, fmt)
-            elif args.action == "status":
-                beads_status(fmt)
+        elif args.resource == "flow":
+            if args.action == "set-field":
+                flow_set_field(args.project, args.repo, args.number,
+                               args.field, args.option, fmt)
+            elif args.action == "field-options":
+                flow_field_options(args.project, args.field, fmt)
+            elif args.action == "discover-project":
+                flow_discover_project(args.repo, fmt)
+            elif args.action == "link-sub-issue":
+                flow_link_sub_issue(args.parent_repo, args.parent_number,
+                                    args.child_repo, args.child_number, fmt)
+            elif args.action == "verify-label":
+                flow_verify_label(args.repo, args.name, args.color,
+                                  args.description, fmt)
+            elif args.action == "validate-card":
+                flow_validate_card(args.repo, args.number, fmt)
 
         elif args.resource == "config":
             if args.action == "show":

--- a/plugins/sdlc-manager/skills/sdlc-flow/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-flow/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: sdlc-flow
+description: |
+  Operator-facing GraphQL + REST helpers for the Mount Olympus board. Wraps
+  the GitHub APIs the orchestrator uses, so Jeff can do per-card work
+  (set Initiative/Objective fields, link sub-issues, validate card bodies,
+  self-heal labels, discover project mappings) without writing GraphQL by
+  hand. Each command is idempotent where possible, and surfaces partial
+  failures clearly.
+when_to_use: |
+  Use this skill when the user wants to:
+
+  Set Initiative or Objective on a card (project FIELDS, not labels):
+  - "Set Initiative on this card to olympus-quality"
+  - "Mark this issue as part of the Auth MVP Objective"
+  - "Update the Objective field on campps-mvp#42"
+
+  Discover what fields/options exist on a project (live, not cached):
+  - "What Initiative options exist?"
+  - "List the Objective field options"
+  - "What can I set Initiative to?"
+
+  Find which project a repo belongs to:
+  - "Which project does athena-service map to?"
+  - "Where do I add cards from this repo?"
+
+  Link a child issue as a sub-issue of a parent:
+  - "Link #43 as a sub-issue of #42"
+  - "Make this a child of campps-blueprint#1"
+  - "Set up the parent/child relationship between these issues"
+
+  Self-heal missing labels (so other operations don't fail mid-flow):
+  - "Make sure the high-priority label exists on campps-mvp"
+  - "Verify hermes-task is on this repo's label set"
+  - "Create the capability label if it's missing"
+
+  Pre-flight an issue body against the card_validator schema:
+  - "Validate the card body for #42"
+  - "Will this issue pass plan-review?"
+  - "Check if my issue body matches the card_validator contract"
+
+  Don't use this skill for:
+  - Creating issues (use `sdlc-issues:create`)
+  - Moving cards between Status columns (use `sdlc-board:move`)
+  - General board health (use `sdlc-board:view`)
+
+  These are *helpers*, not full workflows. The full sub-issue-first
+  card-creation workflow is in `infiquetra-sdlc/docs/workflows/blueprint-to-issue.md`;
+  this skill provides the building blocks the workflow uses.
+---
+
+# sdlc-flow
+
+Operator-facing helpers over the GraphQL + REST APIs Mount Olympus uses.
+Each command is a thin wrapper with idempotency + clear error messages.
+
+## Commands
+
+```bash
+# Set a single-select project field on a card
+sdlc_manager.py flow set-field \
+  --project mount-olympus --repo campps-mvp --number 42 \
+  --field Initiative --option olympus-quality
+
+# List the options on a project field (live discovery — IDs rotate)
+sdlc_manager.py flow field-options \
+  --project mount-olympus --field Objective
+
+# Resolve which project a repo maps to
+sdlc_manager.py flow discover-project --repo athena-service
+
+# Link child as native sub-issue of parent (cross-repo OK; idempotent)
+sdlc_manager.py flow link-sub-issue \
+  --parent-repo campps-blueprint --parent-number 1 \
+  --child-repo campps-mvp --child-number 42
+
+# Self-healing label: 404 → create; exists → no-op; other errors raise
+sdlc_manager.py flow verify-label \
+  --repo campps-mvp --name high-priority \
+  --color D93F0B --description "High priority"
+
+# Pre-flight a card body against the card_validator schema
+sdlc_manager.py flow validate-card --repo campps-mvp --number 42
+```
+
+## Idempotency contract (per command)
+
+| Command | Idempotent? | Failure behavior |
+|---|---|---|
+| `set-field` | yes (same option = same final state) | Raises if option doesn't exist; error message lists current options |
+| `field-options` | read-only | Raises if project or field doesn't exist |
+| `discover-project` | read-only | Returns "not mapped" or "excluded" without erroring |
+| `link-sub-issue` | yes (re-POST returns 422 "already exists" → success) | Raises on non-422 errors; rejects PR-as-parent |
+| `verify-label` | yes (no-op if exists; create if 404) | Raises on auth/rate-limit/server errors (NOT silently treated as missing) |
+| `validate-card` | read-only | Exits non-zero if card body fails validation |
+
+## Hard rules
+
+- **Never apply `objective:*` or `initiative:*` colon-prefixed labels.** Both are project FIELDS on the Olympus board (decided 2026-05-03; see [DECISIONS](../../../../infiquetra-sdlc/docs/engineering-journal/DECISIONS.md)). Use `flow set-field` instead.
+- **Field option IDs rotate on rename/recreate.** Never cache them. Every command that reads field state calls `flow field-options` (or its equivalent GraphQL query) at start.
+- **Verify-label distinguishes 404 from other errors.** A 401/403/5xx must NOT be silently treated as missing — that would create labels under the wrong auth context or mask real failures.
+- **Link-sub-issue requires an issue parent.** PRs can't be parents in GitHub's native sub-issue API; the command rejects them with a clear error.
+
+## Where this fits in the broader workflow
+
+The Phase A carry-over #2 decision (Initiative + Objective as Olympus
+project fields) made `flow set-field` the canonical mechanism for hierarchy
+assignment. The blueprint-to-issue workflow's Step 8 calls into:
+
+- `flow link-sub-issue` (parent/child relationship)
+- `flow set-field` (Initiative + Objective + Status fields)
+
+`validate-card` is the pre-flight check before plan-review fires. If a card
+body doesn't pass `validate-card`, the orchestrator will reject it on the
+Ready → Planning transition; running this command before pushing the card
+to Ready saves a round-trip.
+
+## Authoritative source
+
+The card_validator schema is mirrored from
+`home-lab/ansible/roles/hermes_orchestrator/files/card_validator.py`. When
+that file's contract changes, update `validate_card_body` in
+`scripts/sdlc_manager.py` to match.
+
+## Related
+
+- `sdlc-issues` — issue creation flows (will adopt sub-issue-first interactive flow in a follow-up Phase C PR)
+- `sdlc-board` — Status column moves + board view
+- `sdlc-labels` — bulk label deploy (this skill's `verify-label` is the per-call self-heal)
+- `sdlc-milestones` — per-repo milestone management (Objective tracking is now project-field-based; milestones are an optional secondary mechanism)
+- `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md` — Initiative/Objective decision (2026-05-03)
+- `infiquetra-sdlc/docs/workflows/blueprint-to-issue.md` — full 8-step issue-creation playbook

--- a/plugins/sdlc-manager/tests/test_card_validator.py
+++ b/plugins/sdlc-manager/tests/test_card_validator.py
@@ -1,0 +1,133 @@
+"""Tests for the card_validator shim.
+
+The shim mirrors home-lab/.../card_validator.py's high-leverage checks:
+6 required H3 headers, AC has ≥1 checklist item, Verification has ≥1
+fenced code block, Files-expected has ≥1 path-like line, no placeholders.
+"""
+
+from pathlib import Path
+import sys
+
+# Make scripts importable as a package: tests/ is sibling of scripts/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+VALID_BODY = """### Objective
+Add schema validator that gates plan-review on structured card fields.
+
+### Acceptance criteria
+- [ ] Validator runs on `projects_v2_item` webhook when status becomes Ready
+- [ ] Cards missing required fields get a `needs-author-action` label
+
+### Out-of-scope or non-goals
+- Do NOT change the planner prompt in this card
+- Do NOT add new required fields beyond those in the plan spec
+
+### Files expected to change
+ansible/roles/hermes_orchestrator/files/card_validator.py
+ansible/roles/hermes_orchestrator/files/handlers.py
+
+### Tests to add or update
+tests/test_card_validator.py::test_accepts_fully_populated_card
+
+### Verification
+```bash
+cd ansible/roles/hermes_orchestrator/files
+pytest tests/test_card_validator.py -v
+```
+
+### Notes / conventions
+- GitHub issue forms render fields as `### <Field Label>` headers
+
+### Context library links
+- architecture_decisions: https://github.com/infiquetra/blueprint/adr/042.md
+"""
+
+
+def test_accepts_fully_populated_card() -> None:
+    is_valid, errors = sdlc_manager.validate_card_body(VALID_BODY)
+    assert is_valid, f"Expected valid; got errors: {errors}"
+    assert errors == []
+
+
+def test_rejects_missing_required_header() -> None:
+    body = VALID_BODY.replace("### Verification\n", "### Removed\n", 1)
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Missing required H3 sections" in e and "Verification" in e for e in errors)
+
+
+def test_rejects_missing_checklist_in_acceptance_criteria() -> None:
+    body = VALID_BODY.replace(
+        "- [ ] Validator runs on `projects_v2_item` webhook when status becomes Ready\n"
+        "- [ ] Cards missing required fields get a `needs-author-action` label",
+        "Validator runs on webhook events. Cards without required fields fail.",
+    )
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Acceptance criteria" in e and "checklist" in e for e in errors)
+
+
+def test_rejects_missing_code_block_in_verification() -> None:
+    body = VALID_BODY.replace(
+        "```bash\ncd ansible/roles/hermes_orchestrator/files\n"
+        "pytest tests/test_card_validator.py -v\n```",
+        "Run pytest in the orchestrator role directory.",
+    )
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Verification" in e and "fenced code block" in e for e in errors)
+
+
+def test_rejects_missing_path_line_in_files_expected() -> None:
+    body = VALID_BODY.replace(
+        "ansible/roles/hermes_orchestrator/files/card_validator.py\n"
+        "ansible/roles/hermes_orchestrator/files/handlers.py",
+        "TBD — will figure out at implementation time",
+    )
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Files expected to change" in e and "path-like" in e for e in errors)
+
+
+def test_rejects_placeholder_only_section() -> None:
+    body = VALID_BODY.replace(
+        "Add schema validator that gates plan-review on structured card fields.",
+        "_No response_",
+    )
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Objective" in e and "placeholder" in e for e in errors)
+
+
+def test_handles_empty_body() -> None:
+    is_valid, errors = sdlc_manager.validate_card_body("")
+    assert not is_valid
+    # All 6 required sections missing
+    assert any("Missing required H3" in e for e in errors)
+
+
+def test_section_split_handles_h3_with_trailing_whitespace() -> None:
+    # Some GitHub markdown renderers add trailing whitespace after the title;
+    # the parser must accept it.
+    body = VALID_BODY.replace("### Objective\n", "### Objective   \n", 1)
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert is_valid, f"Expected valid even with trailing whitespace; got: {errors}"
+
+
+def test_h2_headers_do_not_match_h3_parser() -> None:
+    # An H2 with the same name should NOT be treated as an H3 section
+    body = VALID_BODY.replace("### Objective", "## Objective")
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert not is_valid
+    assert any("Missing required H3 sections" in e and "Objective" in e for e in errors)
+
+
+def test_optional_sections_not_required() -> None:
+    # Strip the optional Notes + Context library links sections — body should still validate
+    body = VALID_BODY
+    body = body.split("### Notes / conventions")[0].rstrip() + "\n"
+    is_valid, errors = sdlc_manager.validate_card_body(body)
+    assert is_valid, f"Expected valid without optional sections; got: {errors}"

--- a/plugins/sdlc-manager/tests/test_card_validator.py
+++ b/plugins/sdlc-manager/tests/test_card_validator.py
@@ -21,7 +21,7 @@ Add schema validator that gates plan-review on structured card fields.
 - [ ] Validator runs on `projects_v2_item` webhook when status becomes Ready
 - [ ] Cards missing required fields get a `needs-author-action` label
 
-### Out-of-scope or non-goals
+### Out-of-scope / non-goals
 - Do NOT change the planner prompt in this card
 - Do NOT add new required fields beyond those in the plan spec
 
@@ -131,3 +131,44 @@ def test_optional_sections_not_required() -> None:
     body = body.split("### Notes / conventions")[0].rstrip() + "\n"
     is_valid, errors = sdlc_manager.validate_card_body(body)
     assert is_valid, f"Expected valid without optional sections; got: {errors}"
+
+
+def test_required_headers_match_actual_issue_templates() -> None:
+    """Drift guard: the validator's _REQUIRED_H3_HEADERS list must match the
+    `label:` fields in `infiquetra-sdlc/.github/ISSUE_TEMPLATE/{capability,
+    enhancement,defect}.yml`. If a template adds/renames a section, this
+    test fails so the validator can be updated in the same PR.
+
+    This is the test that PR #114's review caught was missing — the original
+    validator used 'Out-of-scope or non-goals' (with 'or') while the actual
+    templates use 'Out-of-scope / non-goals' (with '/'), and no test was
+    pinning the contract end-to-end."""
+    import os
+    sdlc_path = Path(
+        os.environ.get("INFIQUETRA_SDLC_PATH",
+                       Path.home() / "workspace/infiquetra/infiquetra-sdlc")
+    )
+    template_dir = sdlc_path / ".github" / "ISSUE_TEMPLATE"
+    if not template_dir.exists():
+        # Skip if running outside the developer's workspace (e.g., on a
+        # build agent without the sibling repo). The drift guard runs in
+        # CI when the repos are checked out together.
+        import pytest
+        pytest.skip(f"Templates not at {template_dir}; skipping drift check")
+
+    # Extract `label:` strings from the 3 actionable templates
+    import re as _re
+    template_headers: dict[str, set[str]] = {}
+    for tmpl in ("capability.yml", "enhancement.yml", "defect.yml"):
+        text = (template_dir / tmpl).read_text()
+        labels = set(_re.findall(r"^\s+label:\s*(.+?)\s*$", text, _re.MULTILINE))
+        template_headers[tmpl] = labels
+
+    # Every required validator header must appear as a label in every
+    # actionable template
+    for tmpl, labels in template_headers.items():
+        for required in sdlc_manager._REQUIRED_H3_HEADERS:
+            assert required in labels, (
+                f"Validator requires '{required}' but {tmpl} doesn't have a "
+                f"matching `label:` field. Templates have: {sorted(labels)}"
+            )

--- a/plugins/sdlc-manager/tests/test_flow_subcommands.py
+++ b/plugins/sdlc-manager/tests/test_flow_subcommands.py
@@ -1,0 +1,237 @@
+"""Tests for the `flow` subcommand group helpers.
+
+These tests focus on the *logic* of the flow helpers — argument validation,
+idempotency handling, error classification — without making real GitHub or
+GraphQL calls. The `_gh`, `_graphql`, `_rest_get`, `_rest_post` helpers are
+patched at the sdlc_manager-module level.
+
+End-to-end tests (real `gh` calls against a fixture project) are tracked
+as a P3 follow-up.
+"""
+
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+# --- flow_link_sub_issue ----------------------------------------------------
+
+
+def test_link_sub_issue_idempotent_on_already_exists() -> None:
+    """A duplicate POST returns HTTP 422 with 'already exists'; we treat
+    this as success, not failure (idempotency contract)."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_get.side_effect = [
+            {"id": 12345},                               # child
+            {"id": 67890, "title": "parent issue"},      # parent (no pull_request key)
+        ]
+        mock_post.side_effect = RuntimeError(
+            "API call failed: 422 Unprocessable Entity — sub-issue already exists"
+        )
+
+        sdlc_manager.flow_link_sub_issue(
+            "campps-blueprint", 1, "campps-mvp", 42, fmt="text"
+        )
+
+        # Should NOT have raised; should have called _out with idempotent message
+        msgs = [c.args[0] for c in mock_out.call_args_list]
+        assert any("Already linked" in m for m in msgs), \
+            f"Expected idempotent success message; got: {msgs}"
+
+
+def test_link_sub_issue_raises_on_real_error() -> None:
+    """A non-422 error (auth, server, network) must propagate, not get
+    swallowed as 'already exists'."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post:
+        mock_get.side_effect = [
+            {"id": 12345},
+            {"id": 67890},
+        ]
+        mock_post.side_effect = RuntimeError(
+            "API call failed: 500 Internal Server Error"
+        )
+
+        with pytest.raises(RuntimeError, match="500"):
+            sdlc_manager.flow_link_sub_issue(
+                "campps-blueprint", 1, "campps-mvp", 42, fmt="text"
+            )
+
+
+def test_link_sub_issue_rejects_pr_as_parent() -> None:
+    """The sub-issue API requires an issue parent, not a PR. The flow
+    helper must detect this before POSTing — error message points at it."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get:
+        mock_get.side_effect = [
+            {"id": 12345},  # child
+            {"id": 67890, "pull_request": {"url": "..."}},  # parent has pull_request key → it's a PR
+        ]
+        with pytest.raises(RuntimeError, match="parent.*PR.*not an issue|Parent.*is a PR"):
+            sdlc_manager.flow_link_sub_issue(
+                "campps-mvp", 1, "campps-mvp", 42, fmt="text"
+            )
+
+
+def test_link_sub_issue_rejects_missing_child_db_id() -> None:
+    """If the child fetch returns no integer id (corrupt payload, network
+    truncation), the helper must raise — never POST with a bad sub_issue_id."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get:
+        mock_get.return_value = {"id": None}
+        with pytest.raises(RuntimeError, match="no integer 'id'|Cannot link"):
+            sdlc_manager.flow_link_sub_issue(
+                "r", 1, "r", 2, fmt="text"
+            )
+
+
+# --- flow_verify_label ------------------------------------------------------
+
+
+def test_verify_label_no_op_when_label_exists() -> None:
+    """Probe returns 200 → label exists → no POST, just a 'no-op' message."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_gh.return_value = '{"name":"high-priority","color":"D93F0B"}'
+        sdlc_manager.flow_verify_label(
+            "campps-mvp", "high-priority", "D93F0B", "High priority", fmt="text"
+        )
+        mock_post.assert_not_called()
+        msgs = [c.args[0] for c in mock_out.call_args_list]
+        assert any("already exists" in m for m in msgs)
+
+
+def test_verify_label_creates_on_404() -> None:
+    """Probe raises 404 → POST creates the label."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_gh.side_effect = RuntimeError("API call failed: 404 Not Found")
+        sdlc_manager.flow_verify_label(
+            "campps-mvp", "high-priority", "D93F0B", "High priority", fmt="text"
+        )
+        mock_post.assert_called_once()
+        body = mock_post.call_args.args[1]
+        assert body["name"] == "high-priority"
+        assert body["color"] == "D93F0B"  # leading '#' stripped if any
+        assert body["description"] == "High priority"
+
+
+def test_verify_label_strips_leading_hash_from_color() -> None:
+    """Operators may pass '#D93F0B' (with leading hash). GitHub API rejects
+    it; the helper strips it before POST."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post:
+        mock_gh.side_effect = RuntimeError("API call failed: 404 Not Found")
+        sdlc_manager.flow_verify_label(
+            "r", "label", "#ABCDEF", None, fmt="text"
+        )
+        body = mock_post.call_args.args[1]
+        assert body["color"] == "ABCDEF"
+
+
+def test_verify_label_does_NOT_create_on_non_404_error() -> None:
+    """Auth / rate-limit / server errors must propagate — silently treating
+    them as 'missing' would mask real problems and create labels under wrong
+    auth context."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post:
+        mock_gh.side_effect = RuntimeError(
+            "API call failed: 401 Bad credentials"
+        )
+        with pytest.raises(RuntimeError, match="non-404|401"):
+            sdlc_manager.flow_verify_label(
+                "r", "label", None, None, fmt="text"
+            )
+        mock_post.assert_not_called()
+
+
+# --- flow_field_options + flow_set_field -----------------------------------
+
+
+def test_field_options_reads_live_from_graphql() -> None:
+    """field-options is a live discovery — never cached. Call must hit
+    QUERY_GET_PROJECT_FIELDS."""
+    with patch.object(sdlc_manager, "load_config") as mock_load, \
+         patch.object(sdlc_manager, "_graphql") as mock_gql, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_load.return_value = {
+            "project_mappings": {
+                "projects": {"mount-olympus": {"number": 1, "name": "Olympus"}},
+            }
+        }
+        mock_gql.return_value = {
+            "organization": {
+                "projectV2": {
+                    "id": "PVT_kwx",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "FLD_kwabc",
+                                "name": "Initiative",
+                                "options": [
+                                    {"id": "opt1", "name": "olympus-quality"},
+                                    {"id": "opt2", "name": "olympus-performance"},
+                                ],
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        sdlc_manager.flow_field_options("mount-olympus", "Initiative", fmt="json")
+        # Verify it called the GraphQL query (no caching)
+        assert mock_gql.called
+        # Verify output contains both options with their (live) IDs
+        out_payload = mock_out.call_args.args[0]
+        names = [o["name"] for o in out_payload]
+        assert "olympus-quality" in names
+        assert "olympus-performance" in names
+
+
+def test_set_field_raises_with_helpful_message_on_unknown_option() -> None:
+    """If the operator passes an option that doesn't exist on the field,
+    the error must list the actual options so they can correct."""
+    with patch.object(sdlc_manager, "load_config") as mock_load, \
+         patch.object(sdlc_manager, "_graphql") as mock_gql:
+        mock_load.return_value = {
+            "project_mappings": {
+                "projects": {"mount-olympus": {"number": 1, "name": "Olympus"}},
+            }
+        }
+        mock_gql.return_value = {
+            "organization": {
+                "projectV2": {
+                    "id": "PVT_kwx",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "FLD_kwabc",
+                                "name": "Initiative",
+                                "options": [
+                                    {"id": "o1", "name": "olympus-quality"},
+                                    {"id": "o2", "name": "olympus-performance"},
+                                ],
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        with pytest.raises(RuntimeError) as exc:
+            sdlc_manager.flow_set_field(
+                "mount-olympus", "campps-mvp", 42,
+                "Initiative", "nonexistent-option", fmt="text",
+            )
+        msg = str(exc.value)
+        assert "nonexistent-option" in msg
+        # Helpful: includes the actual options + the discovery command hint
+        assert "olympus-quality" in msg or "olympus-performance" in msg
+        assert "field-options" in msg

--- a/tests/test_sdlc_manager.py
+++ b/tests/test_sdlc_manager.py
@@ -308,63 +308,9 @@ class TestBoardArchive:
         assert "archiveProjectV2Item" in call_args[0][0]
 
 
-# ===========================
-# Beads: bd CLI wrapper
-# ===========================
-
-class TestBeadsClaim:
-    """Tests for beads_claim calling bd CLI correctly."""
-
-    def test_claim_calls_bd_with_correct_args(self, monkeypatch, capsys):
-        """beads_claim calls 'bd claim <task-id>'."""
-        mock_run = MagicMock(return_value=make_subprocess_result(
-            stdout="Claimed task TASK-042"
-        ))
-        monkeypatch.setattr("subprocess.run", mock_run)
-
-        sdlc_manager.beads_claim("TASK-042", "text")
-
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
-        assert cmd == ["bd", "claim", "TASK-042"]
-        output = capsys.readouterr().out
-        assert "Claimed task TASK-042" in output
-
-    def test_claim_failure_raises(self, monkeypatch):
-        """beads_claim raises on bd CLI failure."""
-        mock_run = MagicMock(return_value=make_subprocess_result(
-            stderr="task not found", returncode=1
-        ))
-        monkeypatch.setattr("subprocess.run", mock_run)
-
-        with pytest.raises(RuntimeError, match="bd command failed"):
-            sdlc_manager.beads_claim("TASK-999", "text")
-
-    def test_complete_calls_bd_with_correct_args(self, monkeypatch, capsys):
-        """beads_complete calls 'bd complete <task-id>'."""
-        mock_run = MagicMock(return_value=make_subprocess_result(
-            stdout="Completed task TASK-042"
-        ))
-        monkeypatch.setattr("subprocess.run", mock_run)
-
-        sdlc_manager.beads_complete("TASK-042", "text")
-
-        cmd = mock_run.call_args[0][0]
-        assert cmd == ["bd", "complete", "TASK-042"]
-
-    def test_beads_ready_calls_bd(self, monkeypatch, capsys):
-        """beads_ready calls 'bd ready'."""
-        mock_run = MagicMock(return_value=make_subprocess_result(
-            stdout="TASK-001: Implement auth\nTASK-002: Fix tests"
-        ))
-        monkeypatch.setattr("subprocess.run", mock_run)
-
-        sdlc_manager.beads_ready("text")
-
-        cmd = mock_run.call_args[0][0]
-        assert cmd == ["bd", "ready"]
-        output = capsys.readouterr().out
-        assert "TASK-001" in output
+# NOTE: The Beads/Dolt subcommand group was removed in PR #114 (Phase C).
+# Tests for beads_claim / beads_complete / beads_ready are deleted here;
+# the underlying coordination layer was decommissioned 2026-04-26.
 
 
 # ===========================
@@ -372,19 +318,25 @@ class TestBeadsClaim:
 # ===========================
 
 class TestWipLimitsConfigurable:
-    """Tests for configurable WIP limits from beads-config.json."""
+    """Tests for configurable WIP limits from legacy_rollout_config.
+
+    The config key was renamed from `beads_config` → `legacy_rollout_config`
+    in PR #114 (Beads removal); the underlying file (beads-config.json)
+    was already removed from infiquetra-sdlc on 2026-04-26 so the key
+    degrades gracefully to {} in production. These tests mock the loader
+    to inject overrides, exercising the override path."""
 
     @patch.object(sdlc_manager, "get_project_items")
     @patch.object(sdlc_manager, "load_config")
     def test_uses_config_wip_limits(self, mock_config, mock_items, capsys):
-        """WIP limits from beads-config.json override defaults."""
+        """WIP limits from legacy_rollout_config override defaults."""
         mock_config.return_value = {
             "project_mappings": {
                 "projects": {
                     "mount-olympus": {"number": 1, "name": "MO Ops", "id": "P1"}
                 }
             },
-            "beads_config": {
+            "legacy_rollout_config": {
                 "wip_limits": {
                     "ready": 5,
                     "in_development": 8,
@@ -398,20 +350,26 @@ class TestWipLimitsConfigurable:
         sdlc_manager.board_wip("mount-olympus", "text")
 
         output = capsys.readouterr().out
-        # Should use config limit of 5 for Ready, not default 10
+        # Tighten the assertion to verify the OVERRIDDEN column (Ready)
+        # specifically renders with the override limit (5), not just any
+        # rendering that happens to contain "5".
+        assert "Ready" in output
+        # The rendered limit could be "0/5" or "0/ 5" depending on column
+        # widths; either form indicates the override was applied (default
+        # would be 10, not 5).
         assert " 0/ 5" in output or "0/5" in output
 
     @patch.object(sdlc_manager, "get_project_items")
     @patch.object(sdlc_manager, "load_config")
     def test_falls_back_to_defaults(self, mock_config, mock_items, capsys):
-        """Missing wip_limits in config falls back to defaults."""
+        """Missing wip_limits in legacy_rollout_config falls back to defaults."""
         mock_config.return_value = {
             "project_mappings": {
                 "projects": {
                     "mount-olympus": {"number": 1, "name": "MO Ops", "id": "P1"}
                 }
             },
-            "beads_config": {},
+            "legacy_rollout_config": {},
         }
         mock_items.return_value = ("P1", [])
 


### PR DESCRIPTION
## Summary

Phase C of the SDLC reality-alignment work (companion to \`infiquetra-sdlc\` PRs #8-#17). This PR's scope is the **minimum viable plugin update** needed to make the blueprint-to-issue workflow executable end-to-end. Larger Phase C work (per-user defaults, sub-issue-first interactive flow rewrite, paired-card flow, vendored project-mappings, sdlc-operator subagent) is deferred to follow-up PRs.

## What's added

### \`flow\` subcommand group (6 commands)

| Command | Purpose |
|---|---|
| \`flow set-field\` | Set a single-select project field on a card. **Canonical mechanism for Initiative + Objective per the 2026-05-03 DECISION.** |
| \`flow field-options\` | List current options for a project field. Live discovery — option IDs rotate, never cached. |
| \`flow discover-project\` | Resolve which project a repo maps to. |
| \`flow link-sub-issue\` | Wrap the native GitHub sub-issues API. Cross-repo. Idempotent (422 "already exists" treated as success). Validates parent is an issue, not a PR. |
| \`flow verify-label\` | Self-healing label create. 404 → create; exists → no-op; auth/rate-limit/server errors propagate (not silently treated as missing). |
| \`flow validate-card\` | Pre-flight an existing issue body against \`card_validator\` schema. |

### \`validate_card_body()\` Python helper

Mirrors home-lab \`card_validator.py\`'s high-leverage checks:
- 6 required H3 headers
- AC has ≥1 \`- [ ]\` checklist
- Verification has ≥1 fenced code block
- Files-expected has ≥1 path-like line
- No placeholder-only sections

### \`sdlc-flow\` skill (new \`SKILL.md\`)

Describes the \`flow\` commands, the per-command idempotency contract, hard rules (NEVER apply \`objective:*\`/\`initiative:*\` labels — they're project FIELDS), and integration with the blueprint-to-issue workflow.

### 20 tests (all passing)

- \`tests/test_card_validator.py\` — 10 tests covering each validator rule + edge cases
- \`tests/test_flow_subcommands.py\` — 10 tests covering idempotency contracts, error classification (404 vs auth vs server), live discovery (no caching), helpful error messages

## What's removed

- \`beads\` subcommand group entirely (\`ready\`, \`claim\`, \`update\`, \`complete\`, \`status\`)
- \`_bd\` shell helper
- All \`beads_*\` Python functions

The Beads/Dolt coordination layer was removed from Mount Olympus on 2026-04-26 (see \`infiquetra-sdlc/docs/engineering-journal/narratives/2026-04-26-beads-dolt-removed.md\`). The plugin's \`beads\` commands targeted infrastructure that no longer exists.

## Renamed

- \`beads_config\` config-key → \`legacy_rollout_config\` in \`load_config\` + downstream readers. The underlying file (\`beads-config.json\`) was already removed from infiquetra-sdlc on 2026-04-26; the key now degrades gracefully to \`{}\`. Comment documents the migration.

## Migration

- Operators previously running \`sdlc_manager.py beads <action>\` get an argparse error. **No replacement** — the underlying coordination has moved off Beads.
- \`flow set-field\` is the canonical mechanism for Initiative + Objective assignment per the 2026-05-03 DECISION. **The fields don't exist on the Olympus board today**; create them via the operator runbook in \`operational-reference.md\` before using \`flow set-field\`.

## Plugin manifest

- Version 1.0.0 → 1.1.0
- Removed "beads" + "Beads task coordination" from description + keywords
- Added "sub-issues", "card-validator" to keywords

## Test plan

- [ ] All 20 tests pass: \`uv run --with pytest --with pytest-cov python -m pytest plugins/sdlc-manager/tests/ -v\`
- [ ] No remaining references to deleted Beads commands
- [ ] \`legacy_rollout_config\` references degrade gracefully (file doesn't exist; readers return \`{}\`)
- [ ] \`plugin.json\` is valid JSON
- [ ] Reviewers: clarity-reviewer, devils-advocate-reviewer, code-quality-reviewer (or python-expert), testing-reviewer, architecture-reviewer