### PR TITLE
feat(sdlc-manager): typed exceptions + per-user defaults + vendored project-mappings (Phase C foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Thumbs.db
 
 # Claude Code (per-user settings and session state)
 .claude/
+uv.lock

--- a/plugins/sdlc-manager/.claude-plugin/plugin.json
+++ b/plugins/sdlc-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "SDLC management for the Mount Olympus agent team. Kanban board operations, issue creation, label management, flow metrics, milestone tracking, project-field assignment, sub-issue linking, and card validation.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [1.2.0] — 2026-05-04
 
+### Migration notes
+- **No breaking changes.** Existing CLI invocations work identically.
+- **Recommended one-time setup**: run `python3 sdlc_manager.py config init-defaults` after upgrading to seed `~/.claude/sdlc-defaults.json` with your gh login + project defaults. Future Phase C PRs will read these as suggestion values in the interactive `issue create` flow.
+- **External override still wins**: if you have `$INFIQUETRA_SDLC_PATH/config/project-mappings.json`, it continues to take precedence over the new vendored copy.
+- **Exception class names changed (PEP 8 / N818)**: `ApiNotFound` → `ApiNotFoundError`, `ApiAlreadyExists` → `ApiAlreadyExistsError`, `ApiRateLimited` → `ApiRateLimitedError`. Backward-compat aliases retained for the old names; can be removed in a follow-up after a deprecation cycle.
+
 ### Added (Phase C deferred — Foundation)
 
 - **Typed exception classes** (`GhApiError`, `ApiNotFound`, `ApiAlreadyExists`, `ApiRateLimited`, `ApiAuthError`, `CardValidationError`). `_gh` now raises the appropriate subclass via `_classify_gh_error` instead of bare `RuntimeError` with a stringy message. Replaces the fragile `"422" in str(e)` substring matching pattern. Downstream callers catch by type:

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — sdlc-manager
 
+## [1.2.0] — 2026-05-04
+
+### Added (Phase C deferred — Foundation)
+
+- **Typed exception classes** (`GhApiError`, `ApiNotFound`, `ApiAlreadyExists`, `ApiRateLimited`, `ApiAuthError`, `CardValidationError`). `_gh` now raises the appropriate subclass via `_classify_gh_error` instead of bare `RuntimeError` with a stringy message. Replaces the fragile `"422" in str(e)` substring matching pattern. Downstream callers catch by type:
+  ```python
+  try:
+      _rest_post(...)
+  except ApiAlreadyExists:
+      # idempotent re-run — treat as success
+  ```
+  The `flow_link_sub_issue` and `flow_verify_label` helpers were refactored to use this pattern. `flow_verify_label` also now handles a real race (two operators creating the same label simultaneously) via `ApiAlreadyExists` on POST.
+- **Per-user defaults file** at `~/.claude/sdlc-defaults.json`. Stores: `assignee` (gh login from `gh api user --jq .login` — *not* OS `$USER`), `default_project`, `default_status`, `default_priority`, `default_initiative`, `default_objective`, `preferred_repos`. Sticky across CLI invocations; future interactive flows read defaults as suggestion values.
+  - `load_user_defaults()` / `save_user_defaults()` helpers (atomic write via tempfile + rename; tolerant of missing file + malformed JSON)
+  - `get_default(key)` convenience reader
+  - New subcommands:
+    - `config show-defaults` — display current per-user defaults
+    - `config init-defaults [--non-interactive]` — first-run wizard. Interactive by default; `--non-interactive` seeds from `gh api user` + auto-detects `default_project` if exactly one project is mapped (no guessing on multi-project orgs).
+- **Vendored `project-mappings.json`** at `plugins/sdlc-manager/config/project-mappings.json`. The plugin now works without an external `infiquetra-sdlc` checkout for canonical Infiquetra projects.
+  - New `_resolve_project_mappings(sdlc_path)` helper implements the documented resolution order: external override (`$INFIQUETRA_SDLC_PATH/config/project-mappings.json`) → vendored canonical → remote `gh api` fallback.
+  - Project node IDs captured in the vendored file are best-effort + verified 2026-05-04. Field/option IDs are NEVER cached; always fetched live.
+
+### Tests
+- 33 new tests across 3 new test files:
+  - `test_typed_exceptions.py` (15 tests) — status-code parsing (404/401/403/429/422 disambiguation), 422-already-exists vs 422-validation-failure distinction, integration with `flow_link_sub_issue` + `flow_verify_label` (including race detection)
+  - `test_user_defaults.py` (13 tests) — read-side (missing file, malformed JSON, non-object root, unset key), write-side (atomic via tmpfile+rename, parent-dir auto-create, round-trip), `--non-interactive` wizard (gh-login seeded, multi-project no-guess, preserves unknown future keys)
+  - `test_project_mappings_resolution.py` (5 tests) — override wins over vendored, vendored used when no override, remote fallback when neither, empty dict on all-three failure, vendored file declares expected canonical state
+- Updated 3 PR #114 tests in `test_flow_subcommands.py` to use typed exceptions instead of bare `RuntimeError` with string-matching (the old pattern was testing the old implementation; new tests test the new contract).
+- Total: **64 / 64 passing** locally.
+
 ## [1.1.0] — 2026-05-04
 
 ### Fixed (during PR #114 review)

--- a/plugins/sdlc-manager/config/project-mappings.json
+++ b/plugins/sdlc-manager/config/project-mappings.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Vendored canonical project mapping for the Infiquetra org. Plugin reads this by default. Override at $INFIQUETRA_SDLC_PATH/config/project-mappings.json (per the resolution order in load_config). Project node IDs and field/option IDs are NOT cached here — they rotate on rename/recreate; fetched live via _resolve_project_field and discover_project_field_options.",
+  "_provenance": "Verified 2026-05-04 via `gh project list --owner infiquetra` (Olympus is the only project, #1). The id field below is captured for board_add convenience; if it rotates, re-run `gh project view 1 --owner infiquetra --format json -q .id` and update.",
+  "organization": "infiquetra",
+  "projects": {
+    "mount-olympus": {
+      "number": 1,
+      "id": "PVT_kwDODdfJoc4BVHOl",
+      "name": "Olympus",
+      "_id_note": "Project node id captured 2026-05-04. If it rotates (project rename/recreate), re-fetch via: gh project view 1 --owner infiquetra --format json -q .id",
+      "repositories": [
+        "campps-mvp",
+        "campps-flutter-app",
+        "campps-blueprint",
+        "mimir",
+        "mimir-blueprint",
+        "infiquetra-sdlc",
+        "infiquetra-claude-plugins",
+        "home-lab"
+      ]
+    }
+  },
+  "excluded_repositories": []
+}

--- a/plugins/sdlc-manager/config/project-mappings.json
+++ b/plugins/sdlc-manager/config/project-mappings.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Vendored canonical project mapping for the Infiquetra org. Plugin reads this by default. Override at $INFIQUETRA_SDLC_PATH/config/project-mappings.json (per the resolution order in load_config). Project node IDs and field/option IDs are NOT cached here — they rotate on rename/recreate; fetched live via _resolve_project_field and discover_project_field_options.",
-  "_provenance": "Verified 2026-05-04 via `gh project list --owner infiquetra` (Olympus is the only project, #1). The id field below is captured for board_add convenience; if it rotates, re-run `gh project view 1 --owner infiquetra --format json -q .id` and update.",
+  "_provenance": "Verified 2026-05-04: `gh project list --owner infiquetra` (Olympus is the only project, #1); `gh repo list infiquetra --json name --jq '.[].name'` (the 9 repos listed below are the canonical org-wide set as of this date). The id field is captured for board_add convenience; if it rotates, re-run `gh project view 1 --owner infiquetra --format json -q .id` and update.",
   "organization": "infiquetra",
   "projects": {
     "mount-olympus": {
@@ -9,14 +9,15 @@
       "name": "Olympus",
       "_id_note": "Project node id captured 2026-05-04. If it rotates (project rename/recreate), re-fetch via: gh project view 1 --owner infiquetra --format json -q .id",
       "repositories": [
-        "campps-mvp",
-        "campps-flutter-app",
         "campps-blueprint",
-        "mimir",
-        "mimir-blueprint",
-        "infiquetra-sdlc",
+        "campps-mvp",
+        "github-actions-runners",
+        "hermes-extensions",
+        "infiquetra-aws-infra",
         "infiquetra-claude-plugins",
-        "home-lab"
+        "infiquetra-sdlc",
+        "mimir",
+        "mimir-blueprint"
       ]
     }
   },

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -81,6 +81,79 @@ def get_sdlc_path() -> Path:
     return Path.home() / "workspace" / "infiquetra" / "infiquetra-sdlc"
 
 
+# ===========================
+# PER-USER DEFAULTS
+# ===========================
+# Sticky defaults persisted at ~/.claude/sdlc-defaults.json. The first-run
+# wizard (`config init-defaults`) seeds the file. Subsequent commands read
+# defaults from here and present them as prompt-default values; operators
+# override per-card by typing a different value at the prompt.
+
+_USER_DEFAULTS_PATH = Path.home() / ".claude" / "sdlc-defaults.json"
+
+# Schema (all keys optional; missing keys = no default for that prompt).
+# Listed here so callers and the wizard agree on the set:
+_USER_DEFAULTS_KEYS = (
+    "assignee",          # gh login (NOT OS $USER) — fetched via `gh api user --jq .login`
+    "default_project",   # e.g., "mount-olympus"
+    "default_status",    # e.g., "Backlog"
+    "default_priority",  # e.g., "medium-priority"
+    "default_initiative",  # option name on Olympus board (None until field is created)
+    "default_objective",   # option name on Olympus board (None until field is created)
+    "preferred_repos",   # list[str] of repos the operator works with most
+)
+
+
+def load_user_defaults() -> dict[str, Any]:
+    """Read ~/.claude/sdlc-defaults.json. Returns {} if the file doesn't
+    exist (first run). Tolerates malformed JSON by returning {} + warning."""
+    if not _USER_DEFAULTS_PATH.exists():
+        return {}
+    try:
+        with open(_USER_DEFAULTS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            _warn(
+                f"User defaults at {_USER_DEFAULTS_PATH} is not a JSON "
+                f"object; ignoring."
+            )
+            return {}
+        return data
+    except json.JSONDecodeError as e:
+        _warn(
+            f"User defaults at {_USER_DEFAULTS_PATH} is malformed JSON "
+            f"({e}); ignoring."
+        )
+        return {}
+
+
+def save_user_defaults(data: dict[str, Any]) -> None:
+    """Atomically write ~/.claude/sdlc-defaults.json. Creates parent dir
+    if missing. Atomic via tempfile + rename so a crash mid-write doesn't
+    corrupt the file."""
+    _USER_DEFAULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _USER_DEFAULTS_PATH.with_suffix(".json.tmp")
+    with open(tmp_path, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp_path.replace(_USER_DEFAULTS_PATH)
+
+
+def get_default(key: str) -> Any:
+    """Convenience: read a single default. Returns None if not set."""
+    return load_user_defaults().get(key)
+
+
+def _fetch_gh_login() -> str | None:
+    """Get the operator's gh login via `gh api user --jq .login`. Returns
+    None if gh is unauthenticated or the call fails — caller decides what
+    to do. Importantly, NOT $USER (which can differ from the gh login)."""
+    try:
+        return _gh(["api", "user", "--jq", ".login"]) or None
+    except (GhApiError, RuntimeError):
+        return None
+
+
 def load_config() -> dict[str, Any]:
     """Load config from infiquetra-sdlc checkout with remote fallback."""
     sdlc_path = get_sdlc_path()
@@ -93,8 +166,17 @@ def load_config() -> dict[str, Any]:
     # config; they treat empty as "no rollout state tracked" and behave
     # sensibly. When a replacement file ships (e.g., rollout-status.json),
     # rename the key + path here.
+    #
+    # `project_mappings` resolution order (Phase C foundation):
+    #   1. External override:  $INFIQUETRA_SDLC_PATH/config/project-mappings.json
+    #   2. Vendored canonical: <plugin>/config/project-mappings.json
+    #   3. Remote `gh api` fallback (reads infiquetra-sdlc raw from GitHub)
+    # The plugin works without an external infiquetra-sdlc checkout because
+    # the vendored copy ships canonical state for the org's projects.
+    # Project node IDs captured in the vendored file are best-effort; field
+    # and option IDs are NEVER cached (rotate on rename) and are fetched
+    # live each call.
     config_files = {
-        "project_mappings": sdlc_path / "config" / "project-mappings.json",
         "labels": sdlc_path / "config" / "labels.json",
         "legacy_rollout_config": sdlc_path / "config" / "beads-config.json",
     }
@@ -115,8 +197,44 @@ def load_config() -> dict[str, Any]:
             except Exception:
                 config[key] = {}
 
+    # Project mappings — three-step resolution
+    config["project_mappings"] = _resolve_project_mappings(sdlc_path)
+
     config["sdlc_path"] = str(sdlc_path)
     return config
+
+
+def _resolve_project_mappings(sdlc_path: Path) -> dict[str, Any]:
+    """Resolve project-mappings.json via the documented order:
+    external override → vendored → remote fallback. Returns {} if all fail."""
+    # 1. External override at INFIQUETRA_SDLC_PATH/config/project-mappings.json
+    override = sdlc_path / "config" / "project-mappings.json"
+    if override.exists():
+        with open(override) as f:
+            return json.load(f)
+
+    # 2. Vendored canonical at <plugin-dir>/config/project-mappings.json
+    # Resolve relative to this file (scripts/sdlc_manager.py → ../config/)
+    vendored = Path(__file__).resolve().parent.parent / "config" / "project-mappings.json"
+    if vendored.exists():
+        with open(vendored) as f:
+            return json.load(f)
+
+    # 3. Remote fallback via gh api (reads infiquetra-sdlc directly)
+    try:
+        result = _gh(
+            ["api",
+             f"repos/{ORG}/infiquetra-sdlc/contents/config/project-mappings.json",
+             "--jq", ".content"]
+        )
+        if result:
+            import base64
+            content = base64.b64decode(result.strip()).decode()
+            return json.loads(content)
+    except (GhApiError, RuntimeError):
+        pass
+
+    return {}
 
 
 def get_project_config(config: dict, project_name: str) -> dict:
@@ -157,8 +275,95 @@ def get_projects_for_repo(config: dict, repo_name: str) -> list[dict]:
 # GH CLI WRAPPER
 # ===========================
 
+# ===========================
+# TYPED EXCEPTIONS
+# ===========================
+# Replaces fragile `"422" in str(e)` substring matching across the
+# flow_* helpers. The parser inspects gh CLI stderr ONCE (in `_gh`)
+# and raises the appropriate subclass; downstream handlers catch by type.
+# This is the upgrade-path from PR #114's substring matches.
+
+class GhApiError(RuntimeError):
+    """Base for typed gh-API errors. Carries the parsed HTTP status_code
+    when one could be extracted; otherwise None."""
+
+    def __init__(self, message: str, *, status_code: int | None = None,
+                 stderr: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.stderr = stderr
+
+
+class ApiNotFound(GhApiError):
+    """HTTP 404 from gh api. Used to detect 'label/issue/repo doesn't exist'
+    cases without parsing English error strings."""
+
+
+class ApiAlreadyExists(GhApiError):
+    """HTTP 422 from gh api when the conflict is a duplicate-resource case
+    (sub-issue already linked, label already exists, etc.). Used by the
+    flow helpers to honor idempotency contracts. Note: 422 is also used
+    by GitHub for general validation failures; this class is raised only
+    when the response body matches a duplicate-resource pattern."""
+
+
+class ApiRateLimited(GhApiError):
+    """HTTP 403 with rate-limit signals, or 429."""
+
+
+class ApiAuthError(GhApiError):
+    """HTTP 401 or 403 (non-rate-limit)."""
+
+
+# Status-code parser. gh CLI prints stderr like:
+#   "gh: Not Found (HTTP 404)"
+#   "HTTP 422: Validation Failed (https://...)\n... 'sub_issue_id': sub-issue already exists"
+# We extract the status from the first occurrence of "HTTP NNN" and
+# classify duplicate-resource 422s by message-body inspection.
+_HTTP_STATUS_RE = re.compile(r"HTTP\s+(\d{3})\b", re.IGNORECASE)
+_DUPLICATE_RESOURCE_HINTS = (
+    "already exists",
+    "already a child",
+    "already linked",
+    "name has already been taken",  # GitHub label already exists
+)
+
+
+def _classify_gh_error(stderr: str, returncode: int) -> RuntimeError:
+    """Inspect gh CLI stderr + return the appropriate exception type.
+    Public for tests; called from _gh on non-zero exit."""
+    msg = stderr.strip() if stderr else "Unknown error"
+    full = f"gh command failed: {msg}"
+
+    # Extract HTTP status (if present)
+    match = _HTTP_STATUS_RE.search(stderr)
+    status = int(match.group(1)) if match else None
+
+    if status == 404:
+        return ApiNotFound(full, status_code=404, stderr=stderr)
+    if status in (401, 403):
+        # Distinguish rate-limit from auth
+        if "rate limit" in stderr.lower() or "x-ratelimit" in stderr.lower():
+            return ApiRateLimited(full, status_code=status, stderr=stderr)
+        return ApiAuthError(full, status_code=status, stderr=stderr)
+    if status == 429:
+        return ApiRateLimited(full, status_code=429, stderr=stderr)
+    if status == 422:
+        lower = stderr.lower()
+        if any(hint in lower for hint in _DUPLICATE_RESOURCE_HINTS):
+            return ApiAlreadyExists(full, status_code=422, stderr=stderr)
+        # Other 422s (validation failures) fall through to generic GhApiError
+        return GhApiError(full, status_code=422, stderr=stderr)
+
+    # Any other status / no parseable status
+    return GhApiError(full, status_code=status, stderr=stderr)
+
+
 def _gh(args: list[str], input_data: str | None = None, capture: bool = True) -> str:
-    """Run gh CLI command."""
+    """Run gh CLI command. Raises a typed GhApiError subclass on non-zero
+    exit (ApiNotFound for 404, ApiAlreadyExists for duplicate-resource 422,
+    ApiRateLimited / ApiAuthError as appropriate, GhApiError otherwise).
+    Callers can catch the base GhApiError or RuntimeError."""
     cmd = ["gh"] + args
     try:
         result = subprocess.run(
@@ -169,11 +374,10 @@ def _gh(args: list[str], input_data: str | None = None, capture: bool = True) ->
             timeout=60,
         )
         if result.returncode != 0:
-            err = result.stderr.strip() if result.stderr else "Unknown error"
-            raise RuntimeError(f"gh command failed: {err}")
+            raise _classify_gh_error(result.stderr or "", result.returncode)
         return result.stdout.strip() if capture else ""
     except subprocess.TimeoutExpired:
-        raise RuntimeError("gh command timed out after 60s")
+        raise GhApiError("gh command timed out after 60s")
     except FileNotFoundError:
         _error("gh CLI not found. Install from: https://cli.github.com/")
         sys.exit(1)
@@ -1662,17 +1866,14 @@ def flow_link_sub_issue(
             f"{parent_repo}#{parent_number}",
             fmt,
         )
-    except RuntimeError as e:
-        # Detect "already exists" to honor idempotency
-        msg = str(e).lower()
-        if "already exists" in msg or "422" in msg:
-            _out(
-                f"Already linked: {child_repo}#{child_number} is already a "
-                f"sub-issue of {parent_repo}#{parent_number} (idempotent re-run).",
-                fmt,
-            )
-            return
-        raise
+    except ApiAlreadyExists:
+        # Idempotency: 422 with a duplicate-resource hint = already linked.
+        # Treat as success.
+        _out(
+            f"Already linked: {child_repo}#{child_number} is already a "
+            f"sub-issue of {parent_repo}#{parent_number} (idempotent re-run).",
+            fmt,
+        )
 
 
 def flow_verify_label(
@@ -1683,22 +1884,20 @@ def flow_verify_label(
     fmt: str,
 ) -> None:
     """Self-healing label create. If the label exists on the repo, no-op.
-    If 404, create with given color + description. Distinguishes 404
-    (missing → create) from other errors (auth, rate-limit, server)."""
-    # Probe for existence via gh api; capture stderr to detect 404 vs other failures
-    cmd = ["api", f"repos/{ORG}/{repo}/labels/{name}"]
+    If 404, create with given color + description. Auth/rate-limit/server
+    errors propagate as their typed exceptions — NOT silently treated as
+    missing (which would create labels under the wrong auth context)."""
+    # Probe for existence via gh api. Typed exception parsing in `_gh`
+    # raises ApiNotFound on 404, ApiAuthError on 401/403, etc.
     try:
-        _gh(cmd)
+        _gh(["api", f"repos/{ORG}/{repo}/labels/{name}"])
         _out(f"Label '{name}' already exists on {ORG}/{repo} (no-op).", fmt)
         return
-    except RuntimeError as e:
-        msg = str(e)
-        if "Not Found" not in msg and "404" not in msg:
-            # Re-raise non-404 errors verbatim — auth, rate-limit, server.
-            # Do NOT silently treat them as missing.
-            raise RuntimeError(
-                f"verify-label probe failed with non-404 error (not creating): {msg}"
-            )
+    except ApiNotFound:
+        # 404 — fall through to create
+        pass
+    # All other GhApiError subclasses (auth, rate-limit, server) propagate.
+    # No string matching; we trust the typed exception classifier.
 
     # 404 — create the label
     body: dict[str, str] = {"name": name}
@@ -1706,8 +1905,16 @@ def flow_verify_label(
         body["color"] = color.lstrip("#")  # GH API rejects leading '#'
     if description:
         body["description"] = description
-    _rest_post(f"repos/{ORG}/{repo}/labels", body)
-    _out(f"Created label '{name}' on {ORG}/{repo}.", fmt)
+    try:
+        _rest_post(f"repos/{ORG}/{repo}/labels", body)
+        _out(f"Created label '{name}' on {ORG}/{repo}.", fmt)
+    except ApiAlreadyExists:
+        # Race: another process created the label between our probe and POST.
+        # Idempotency contract — treat as success.
+        _out(
+            f"Label '{name}' was just created (race detected; treating as no-op).",
+            fmt,
+        )
 
 
 # ===========================
@@ -1919,6 +2126,123 @@ def config_show(fmt: str) -> None:
     beads = config.get("legacy_rollout_config", {})
     summary = beads.get("summary", {})
     print(f"\nRollout: {summary.get('completed', 0)}/{summary.get('total_repos', 0)} repos complete")
+
+    # Per-user defaults (Phase C)
+    defaults = load_user_defaults()
+    print(f"\nUser defaults: {_USER_DEFAULTS_PATH}")
+    if defaults:
+        for key in _USER_DEFAULTS_KEYS:
+            if key in defaults:
+                print(f"  {key:22s} = {defaults[key]!r}")
+    else:
+        print("  (none — run `config init-defaults` to seed)")
+
+
+def config_show_defaults(fmt: str) -> None:
+    """Display the current per-user defaults from ~/.claude/sdlc-defaults.json."""
+    defaults = load_user_defaults()
+    if fmt == "json":
+        _out({"path": str(_USER_DEFAULTS_PATH), "defaults": defaults}, fmt)
+        return
+    print(f"\nUser defaults: {_USER_DEFAULTS_PATH}")
+    if not defaults:
+        print("  (none set — run `config init-defaults` to seed)")
+        return
+    for key in _USER_DEFAULTS_KEYS:
+        if key in defaults:
+            print(f"  {key:22s} = {defaults[key]!r}")
+        else:
+            print(f"  {key:22s} = (not set)")
+
+
+def config_init_defaults(non_interactive: bool, fmt: str) -> None:
+    """First-run wizard: seed ~/.claude/sdlc-defaults.json.
+
+    Interactive by default — prompts for each key with the existing value
+    (or a sensible suggestion) as the default.
+
+    --non-interactive seeds with auto-detected values only (gh login as
+    assignee; default_project=mount-olympus if exactly one project mapped
+    in config; everything else left unset). Useful for CI / scripted setup."""
+    existing = load_user_defaults()
+    new: dict[str, Any] = dict(existing)  # start from existing; preserve unknown keys
+
+    # Always re-fetch the gh login (in case the operator changed accounts)
+    gh_login = _fetch_gh_login()
+
+    # Auto-detect default_project if exactly one project is mapped
+    auto_project: str | None = None
+    try:
+        cfg = load_config()
+        projects = cfg.get("project_mappings", {}).get("projects", {})
+        if len(projects) == 1:
+            auto_project = next(iter(projects.keys()))
+    except Exception:
+        pass  # config load failed; not fatal for the wizard
+
+    # Field-by-field seeding. For each key, the order is:
+    #   suggested = existing[key] OR auto-detected OR a built-in default
+    suggestions = {
+        "assignee": gh_login or existing.get("assignee"),
+        "default_project": existing.get("default_project") or auto_project,
+        "default_status": existing.get("default_status") or "Backlog",
+        "default_priority": existing.get("default_priority") or "medium-priority",
+        "default_initiative": existing.get("default_initiative"),  # no default
+        "default_objective": existing.get("default_objective"),    # no default
+        "preferred_repos": existing.get("preferred_repos") or [],
+    }
+
+    if non_interactive:
+        # Seed with suggestions only
+        for key in _USER_DEFAULTS_KEYS:
+            if suggestions.get(key) not in (None, []):
+                new[key] = suggestions[key]
+        save_user_defaults(new)
+        if fmt == "json":
+            _out({"saved_to": str(_USER_DEFAULTS_PATH), "defaults": new}, fmt)
+        else:
+            print(f"Seeded {_USER_DEFAULTS_PATH} with auto-detected values:")
+            for key in _USER_DEFAULTS_KEYS:
+                if key in new:
+                    print(f"  {key:22s} = {new[key]!r}")
+        return
+
+    # Interactive wizard
+    print(f"\nFirst-run wizard for {_USER_DEFAULTS_PATH}")
+    print("Press Enter to accept the [default]; type a value to override; type '-' to skip.\n")
+
+    for key in _USER_DEFAULTS_KEYS:
+        suggestion = suggestions.get(key)
+        if key == "preferred_repos":
+            current = ", ".join(suggestion) if suggestion else ""
+            prompt = f"  preferred_repos (comma-separated) [{current}]: "
+            answer = input(prompt).strip()
+            if answer == "-":
+                new.pop(key, None)
+            elif answer:
+                new[key] = [r.strip() for r in answer.split(",") if r.strip()]
+            elif suggestion:
+                new[key] = suggestion
+            continue
+
+        display = repr(suggestion) if suggestion is not None else "(not set)"
+        prompt = f"  {key} [{display}]: "
+        try:
+            answer = input(prompt).strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nWizard aborted (no changes saved).")
+            return
+        if answer == "-":
+            new.pop(key, None)
+        elif answer:
+            new[key] = answer
+        elif suggestion is not None:
+            new[key] = suggestion
+        # else: leave unset
+
+    save_user_defaults(new)
+    print(f"\nSaved to {_USER_DEFAULTS_PATH}")
+    config_show_defaults(fmt)
 
 
 # ===========================
@@ -2181,6 +2505,16 @@ def main() -> None:
     config_p = subparsers.add_parser("config", help="Configuration operations")
     config_sp = config_p.add_subparsers(dest="action", required=True)
     config_sp.add_parser("show", help="Show loaded configuration")
+    config_sp.add_parser("show-defaults", help="Show per-user defaults from ~/.claude/sdlc-defaults.json")
+    config_init_p = config_sp.add_parser(
+        "init-defaults",
+        help="First-run wizard to seed per-user defaults",
+    )
+    config_init_p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Seed with auto-detected values only (gh login as assignee, etc.); no prompts",
+    )
 
     # ===========================
     # PARSE AND ROUTE
@@ -2279,6 +2613,10 @@ def main() -> None:
         elif args.resource == "config":
             if args.action == "show":
                 config_show(fmt)
+            elif args.action == "show-defaults":
+                config_show_defaults(fmt)
+            elif args.action == "init-defaults":
+                config_init_defaults(args.non_interactive, fmt)
 
     except KeyboardInterrupt:
         print("\nAborted.", file=sys.stderr)

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -105,8 +105,14 @@ _USER_DEFAULTS_KEYS = (
 
 
 def load_user_defaults() -> dict[str, Any]:
-    """Read ~/.claude/sdlc-defaults.json. Returns {} if the file doesn't
-    exist (first run). Tolerates malformed JSON by returning {} + warning."""
+    """Read ~/.claude/sdlc-defaults.json. Returns {} on:
+      - file missing (first run)
+      - malformed JSON (warn + return {})
+      - non-object root (warn + return {})
+      - unreadable file / encoding errors (warn + return {})
+
+    The CLI must remain usable even if the defaults file is corrupt —
+    the operator can always re-run `config init-defaults` to reseed it."""
     if not _USER_DEFAULTS_PATH.exists():
         return {}
     try:
@@ -123,6 +129,14 @@ def load_user_defaults() -> dict[str, Any]:
         _warn(
             f"User defaults at {_USER_DEFAULTS_PATH} is malformed JSON "
             f"({e}); ignoring."
+        )
+        return {}
+    except (OSError, UnicodeDecodeError) as e:
+        # Permissions, broken symlink, non-UTF-8 encoding, etc. The defaults
+        # file is operator-owned and not load-bearing; warn + degrade.
+        _warn(
+            f"User defaults at {_USER_DEFAULTS_PATH} could not be read "
+            f"({type(e).__name__}: {e}); ignoring."
         )
         return {}
 
@@ -204,6 +218,16 @@ def load_config() -> dict[str, Any]:
     return config
 
 
+# Vendored project-mappings path. Module-level constant so tests can
+# `monkeypatch.setattr` it without renaming the real file (which is racy
+# under pytest-xdist + leaves a `.bak-test` orphan if the test crashes
+# between rename and `finally`). Resolves to `<plugin-dir>/config/project-mappings.json`
+# via `scripts/sdlc_manager.py → ../config/...`.
+_VENDORED_PROJECT_MAPPINGS_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "project-mappings.json"
+)
+
+
 def _resolve_project_mappings(sdlc_path: Path) -> dict[str, Any]:
     """Resolve project-mappings.json via the documented order:
     external override → vendored → remote fallback. Returns {} if all fail."""
@@ -214,10 +238,8 @@ def _resolve_project_mappings(sdlc_path: Path) -> dict[str, Any]:
             return json.load(f)
 
     # 2. Vendored canonical at <plugin-dir>/config/project-mappings.json
-    # Resolve relative to this file (scripts/sdlc_manager.py → ../config/)
-    vendored = Path(__file__).resolve().parent.parent / "config" / "project-mappings.json"
-    if vendored.exists():
-        with open(vendored) as f:
+    if _VENDORED_PROJECT_MAPPINGS_PATH.exists():
+        with open(_VENDORED_PROJECT_MAPPINGS_PATH) as f:
             return json.load(f)
 
     # 3. Remote fallback via gh api (reads infiquetra-sdlc directly)
@@ -272,42 +294,53 @@ def get_projects_for_repo(config: dict, repo_name: str) -> list[dict]:
 
 
 # ===========================
-# GH CLI WRAPPER
+# GH CLI WRAPPER + TYPED EXCEPTIONS
 # ===========================
-
-# ===========================
-# TYPED EXCEPTIONS
-# ===========================
+# `_gh` is the single subprocess shim; `_classify_gh_error` parses both
+# its stderr AND stdout streams to raise the appropriate typed subclass
+# (ApiNotFoundError, ApiAlreadyExistsError, ApiAuthError, etc.).
 # Replaces fragile `"422" in str(e)` substring matching across the
-# flow_* helpers. The parser inspects gh CLI stderr ONCE (in `_gh`)
-# and raises the appropriate subclass; downstream handlers catch by type.
-# This is the upgrade-path from PR #114's substring matches.
+# flow_* helpers. Downstream handlers catch by type.
 
 class GhApiError(RuntimeError):
     """Base for typed gh-API errors. Carries the parsed HTTP status_code
-    when one could be extracted; otherwise None."""
+    when one could be extracted; otherwise None. Also retains both stderr
+    AND stdout from the failed call — gh CLI prints the response body
+    (often containing the actual error code in JSON) to STDOUT for 4xx/5xx
+    failures, while stderr only carries a short summary like
+    `gh: Validation Failed (HTTP 422)`. Both are needed for accurate
+    classification (verified 2026-05-04 via direct `gh api` reproduction
+    of 404 + 422-duplicate-label cases)."""
 
     def __init__(self, message: str, *, status_code: int | None = None,
-                 stderr: str | None = None) -> None:
+                 stderr: str | None = None, stdout: str | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.stderr = stderr
+        self.stdout = stdout
 
 
-class ApiNotFound(GhApiError):
+# N818 — exception class names end in `Error`
+class ApiNotFoundError(GhApiError):
     """HTTP 404 from gh api. Used to detect 'label/issue/repo doesn't exist'
     cases without parsing English error strings."""
 
 
-class ApiAlreadyExists(GhApiError):
+class ApiAlreadyExistsError(GhApiError):
     """HTTP 422 from gh api when the conflict is a duplicate-resource case
     (sub-issue already linked, label already exists, etc.). Used by the
-    flow helpers to honor idempotency contracts. Note: 422 is also used
-    by GitHub for general validation failures; this class is raised only
-    when the response body matches a duplicate-resource pattern."""
+    flow helpers to honor idempotency contracts.
+
+    Note: 422 is also used by GitHub for general validation failures.
+    This class is raised only when the response body matches a duplicate-
+    resource pattern. The pattern check inspects BOTH stdout (where gh
+    puts the JSON body — `{"errors":[{"code":"already_exists",...}]}` for
+    label-already-exists; or English text for sub-issue link duplicates)
+    AND stderr (which carries only the short status summary). Verified
+    2026-05-04 against real GitHub responses."""
 
 
-class ApiRateLimited(GhApiError):
+class ApiRateLimitedError(GhApiError):
     """HTTP 403 with rate-limit signals, or 429."""
 
 
@@ -317,52 +350,102 @@ class ApiAuthError(GhApiError):
 
 # Status-code parser. gh CLI prints stderr like:
 #   "gh: Not Found (HTTP 404)"
-#   "HTTP 422: Validation Failed (https://...)\n... 'sub_issue_id': sub-issue already exists"
-# We extract the status from the first occurrence of "HTTP NNN" and
-# classify duplicate-resource 422s by message-body inspection.
+#   "gh: Validation Failed (HTTP 422)"
+# AND prints the JSON response body to stdout, e.g.:
+#   {"message":"Not Found","status":"404"}
+#   {"message":"Validation Failed","errors":[{"resource":"Label",
+#    "code":"already_exists","field":"name"}],"status":"422"}
+# Both streams are inspected. Verified 2026-05-04 by reproducing each
+# error type against the real GitHub API.
 _HTTP_STATUS_RE = re.compile(r"HTTP\s+(\d{3})\b", re.IGNORECASE)
+# The structured indicator: GitHub's JSON error body uses these `code:`
+# values for resource-already-exists. This is the canonical signal.
+_DUPLICATE_RESOURCE_CODES = (
+    '"code":"already_exists"',  # label-already-exists, etc. (no whitespace)
+    '"code": "already_exists"',  # same with whitespace variant
+)
+# English-text fallback hints for cases where gh emits the message but
+# not the structured code (e.g., sub-issue link duplicate where the
+# response body uses different wording).
 _DUPLICATE_RESOURCE_HINTS = (
     "already exists",
     "already a child",
     "already linked",
-    "name has already been taken",  # GitHub label already exists
+    "name has already been taken",
 )
 
 
-def _classify_gh_error(stderr: str, returncode: int) -> RuntimeError:
-    """Inspect gh CLI stderr + return the appropriate exception type.
-    Public for tests; called from _gh on non-zero exit."""
+def _classify_gh_error(
+    stderr: str,
+    returncode: int,
+    stdout: str = "",
+) -> RuntimeError:
+    """Inspect gh CLI stderr + stdout, return the appropriate exception
+    type. Public for tests; called from `_gh` on non-zero exit.
+
+    `stdout` defaults to "" for back-compat with tests written before
+    the dual-stream classifier — passing only stderr still works for
+    tests that synthesize stderr containing both status + body."""
     msg = stderr.strip() if stderr else "Unknown error"
     full = f"gh command failed: {msg}"
 
-    # Extract HTTP status (if present)
+    # Status extraction — check stderr first (where gh puts the summary
+    # `(HTTP NNN)` line), fall back to stdout JSON's `"status":"NNN"`.
     match = _HTTP_STATUS_RE.search(stderr)
+    if not match:
+        match = re.search(r'"status"\s*:\s*"?(\d{3})"?', stdout)
     status = int(match.group(1)) if match else None
 
+    # Combined haystack for substring searches (both streams)
+    combined_lower = (stderr + "\n" + stdout).lower()
+
     if status == 404:
-        return ApiNotFound(full, status_code=404, stderr=stderr)
+        return ApiNotFoundError(full, status_code=404, stderr=stderr, stdout=stdout)
     if status in (401, 403):
-        # Distinguish rate-limit from auth
-        if "rate limit" in stderr.lower() or "x-ratelimit" in stderr.lower():
-            return ApiRateLimited(full, status_code=status, stderr=stderr)
-        return ApiAuthError(full, status_code=status, stderr=stderr)
+        # Distinguish rate-limit from auth (rate-limit signals appear
+        # in both streams)
+        if "rate limit" in combined_lower or "x-ratelimit" in combined_lower:
+            return ApiRateLimitedError(
+                full, status_code=status, stderr=stderr, stdout=stdout
+            )
+        return ApiAuthError(full, status_code=status, stderr=stderr, stdout=stdout)
     if status == 429:
-        return ApiRateLimited(full, status_code=429, stderr=stderr)
+        return ApiRateLimitedError(
+            full, status_code=429, stderr=stderr, stdout=stdout
+        )
     if status == 422:
-        lower = stderr.lower()
-        if any(hint in lower for hint in _DUPLICATE_RESOURCE_HINTS):
-            return ApiAlreadyExists(full, status_code=422, stderr=stderr)
+        # Duplicate-resource detection: structured `"code":"already_exists"`
+        # in stdout JSON is the canonical signal; English-text hints in
+        # stderr are the fallback.
+        body_combined = stderr + stdout  # both streams, case-preserving for code match
+        if any(code in body_combined for code in _DUPLICATE_RESOURCE_CODES):
+            return ApiAlreadyExistsError(
+                full, status_code=422, stderr=stderr, stdout=stdout
+            )
+        if any(hint in combined_lower for hint in _DUPLICATE_RESOURCE_HINTS):
+            return ApiAlreadyExistsError(
+                full, status_code=422, stderr=stderr, stdout=stdout
+            )
         # Other 422s (validation failures) fall through to generic GhApiError
-        return GhApiError(full, status_code=422, stderr=stderr)
+        return GhApiError(full, status_code=422, stderr=stderr, stdout=stdout)
 
     # Any other status / no parseable status
-    return GhApiError(full, status_code=status, stderr=stderr)
+    return GhApiError(full, status_code=status, stderr=stderr, stdout=stdout)
+
+
+# Backward-compat aliases for callers using the original names. Removable
+# once a deprecation cycle has elapsed; kept here so any in-flight branches
+# can still merge cleanly.
+ApiNotFound = ApiNotFoundError
+ApiAlreadyExists = ApiAlreadyExistsError
+ApiRateLimited = ApiRateLimitedError
 
 
 def _gh(args: list[str], input_data: str | None = None, capture: bool = True) -> str:
     """Run gh CLI command. Raises a typed GhApiError subclass on non-zero
-    exit (ApiNotFound for 404, ApiAlreadyExists for duplicate-resource 422,
-    ApiRateLimited / ApiAuthError as appropriate, GhApiError otherwise).
+    exit (ApiNotFoundError for 404, ApiAlreadyExistsError for duplicate-
+    resource 422, ApiRateLimitedError / ApiAuthError as appropriate,
+    GhApiError otherwise).
     Callers can catch the base GhApiError or RuntimeError."""
     cmd = ["gh"] + args
     try:
@@ -374,7 +457,14 @@ def _gh(args: list[str], input_data: str | None = None, capture: bool = True) ->
             timeout=60,
         )
         if result.returncode != 0:
-            raise _classify_gh_error(result.stderr or "", result.returncode)
+            # Pass BOTH streams to the classifier — gh prints the JSON
+            # error body to stdout for 4xx/5xx responses; stderr only
+            # carries the short summary line.
+            raise _classify_gh_error(
+                result.stderr or "",
+                result.returncode,
+                stdout=result.stdout or "",
+            )
         return result.stdout.strip() if capture else ""
     except subprocess.TimeoutExpired:
         raise GhApiError("gh command timed out after 60s")
@@ -1866,7 +1956,7 @@ def flow_link_sub_issue(
             f"{parent_repo}#{parent_number}",
             fmt,
         )
-    except ApiAlreadyExists:
+    except ApiAlreadyExistsError:
         # Idempotency: 422 with a duplicate-resource hint = already linked.
         # Treat as success.
         _out(
@@ -1887,17 +1977,17 @@ def flow_verify_label(
     If 404, create with given color + description. Auth/rate-limit/server
     errors propagate as their typed exceptions — NOT silently treated as
     missing (which would create labels under the wrong auth context)."""
-    # Probe for existence via gh api. Typed exception parsing in `_gh`
-    # raises ApiNotFound on 404, ApiAuthError on 401/403, etc.
+    # Probe for existence. The try/except/else makes the two-branch nature
+    # explicit: success (label exists) vs ApiNotFoundError (need to create).
+    # Other typed exceptions (ApiAuthError, ApiRateLimitedError, generic
+    # GhApiError) propagate to the caller.
     try:
         _gh(["api", f"repos/{ORG}/{repo}/labels/{name}"])
+    except ApiNotFoundError:
+        pass  # fall through to create
+    else:
         _out(f"Label '{name}' already exists on {ORG}/{repo} (no-op).", fmt)
         return
-    except ApiNotFound:
-        # 404 — fall through to create
-        pass
-    # All other GhApiError subclasses (auth, rate-limit, server) propagate.
-    # No string matching; we trust the typed exception classifier.
 
     # 404 — create the label
     body: dict[str, str] = {"name": name}
@@ -1907,14 +1997,15 @@ def flow_verify_label(
         body["description"] = description
     try:
         _rest_post(f"repos/{ORG}/{repo}/labels", body)
-        _out(f"Created label '{name}' on {ORG}/{repo}.", fmt)
-    except ApiAlreadyExists:
+    except ApiAlreadyExistsError:
         # Race: another process created the label between our probe and POST.
         # Idempotency contract — treat as success.
         _out(
             f"Label '{name}' was just created (race detected; treating as no-op).",
             fmt,
         )
+        return
+    _out(f"Created label '{name}' on {ORG}/{repo}.", fmt)
 
 
 # ===========================
@@ -2159,11 +2250,18 @@ def config_init_defaults(non_interactive: bool, fmt: str) -> None:
     """First-run wizard: seed ~/.claude/sdlc-defaults.json.
 
     Interactive by default — prompts for each key with the existing value
-    (or a sensible suggestion) as the default.
+    (or a sensible suggestion) as the default. Type a value to override;
+    press Enter to accept the suggestion; type '-' to skip / unset.
 
     --non-interactive seeds with auto-detected values only (gh login as
-    assignee; default_project=mount-olympus if exactly one project mapped
-    in config; everything else left unset). Useful for CI / scripted setup."""
+    assignee; default_project=<sole-project> ONLY if exactly one project
+    mapped in config — no guessing on multi-project orgs). Useful for
+    CI / scripted setup.
+
+    **Both modes preserve existing values** — running this command again
+    against an already-populated defaults file does NOT clobber it. Keys
+    not recognized by the current schema (e.g., from a future plugin
+    version) are also preserved. Re-running is safe."""
     existing = load_user_defaults()
     new: dict[str, Any] = dict(existing)  # start from existing; preserve unknown keys
 
@@ -2216,7 +2314,11 @@ def config_init_defaults(non_interactive: bool, fmt: str) -> None:
         if key == "preferred_repos":
             current = ", ".join(suggestion) if suggestion else ""
             prompt = f"  preferred_repos (comma-separated) [{current}]: "
-            answer = input(prompt).strip()
+            try:
+                answer = input(prompt).strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nWizard aborted (no changes saved).")
+                return
             if answer == "-":
                 new.pop(key, None)
             elif answer:

--- a/plugins/sdlc-manager/tests/test_flow_subcommands.py
+++ b/plugins/sdlc-manager/tests/test_flow_subcommands.py
@@ -25,7 +25,11 @@ import sdlc_manager  # noqa: E402
 
 def test_link_sub_issue_idempotent_on_already_exists() -> None:
     """A duplicate POST returns HTTP 422 with 'already exists'; we treat
-    this as success, not failure (idempotency contract)."""
+    this as success, not failure (idempotency contract).
+
+    Phase C foundation: the contract is now expressed via the typed
+    `ApiAlreadyExists` exception (raised by `_classify_gh_error`), not
+    string-matching. See test_typed_exceptions.py for the classifier tests."""
     with patch.object(sdlc_manager, "_rest_get") as mock_get, \
          patch.object(sdlc_manager, "_rest_post") as mock_post, \
          patch.object(sdlc_manager, "_out") as mock_out:
@@ -33,8 +37,9 @@ def test_link_sub_issue_idempotent_on_already_exists() -> None:
             {"id": 12345},                               # child
             {"id": 67890, "title": "parent issue"},      # parent (no pull_request key)
         ]
-        mock_post.side_effect = RuntimeError(
-            "API call failed: 422 Unprocessable Entity — sub-issue already exists"
+        mock_post.side_effect = sdlc_manager.ApiAlreadyExists(
+            "API call failed: HTTP 422 sub-issue already exists",
+            status_code=422,
         )
 
         sdlc_manager.flow_link_sub_issue(
@@ -109,11 +114,13 @@ def test_verify_label_no_op_when_label_exists() -> None:
 
 
 def test_verify_label_creates_on_404() -> None:
-    """Probe raises 404 → POST creates the label."""
+    """Probe raises ApiNotFound (typed 404) → POST creates the label."""
     with patch.object(sdlc_manager, "_gh") as mock_gh, \
          patch.object(sdlc_manager, "_rest_post") as mock_post, \
-         patch.object(sdlc_manager, "_out") as mock_out:
-        mock_gh.side_effect = RuntimeError("API call failed: 404 Not Found")
+         patch.object(sdlc_manager, "_out"):
+        mock_gh.side_effect = sdlc_manager.ApiNotFound(
+            "API call failed: HTTP 404", status_code=404,
+        )
         sdlc_manager.flow_verify_label(
             "campps-mvp", "high-priority", "D93F0B", "High priority", fmt="text"
         )
@@ -129,7 +136,9 @@ def test_verify_label_strips_leading_hash_from_color() -> None:
     it; the helper strips it before POST."""
     with patch.object(sdlc_manager, "_gh") as mock_gh, \
          patch.object(sdlc_manager, "_rest_post") as mock_post:
-        mock_gh.side_effect = RuntimeError("API call failed: 404 Not Found")
+        mock_gh.side_effect = sdlc_manager.ApiNotFound(
+            "API call failed: HTTP 404", status_code=404,
+        )
         sdlc_manager.flow_verify_label(
             "r", "label", "#ABCDEF", None, fmt="text"
         )
@@ -140,13 +149,16 @@ def test_verify_label_strips_leading_hash_from_color() -> None:
 def test_verify_label_does_NOT_create_on_non_404_error() -> None:
     """Auth / rate-limit / server errors must propagate — silently treating
     them as 'missing' would mask real problems and create labels under wrong
-    auth context."""
+    auth context. With the typed-exception refactor, ApiAuthError /
+    ApiRateLimited / generic GhApiError propagate out of the `except
+    ApiNotFound:` block."""
     with patch.object(sdlc_manager, "_gh") as mock_gh, \
          patch.object(sdlc_manager, "_rest_post") as mock_post:
-        mock_gh.side_effect = RuntimeError(
-            "API call failed: 401 Bad credentials"
+        mock_gh.side_effect = sdlc_manager.ApiAuthError(
+            "API call failed: HTTP 401 Bad credentials",
+            status_code=401,
         )
-        with pytest.raises(RuntimeError, match="non-404|401"):
+        with pytest.raises(sdlc_manager.ApiAuthError):
             sdlc_manager.flow_verify_label(
                 "r", "label", None, None, fmt="text"
             )

--- a/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
+++ b/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
@@ -5,7 +5,9 @@ The plugin resolves project_mappings via three steps:
   2. Vendored canonical: <plugin>/config/project-mappings.json
   3. Remote `gh api` fallback (reads infiquetra-sdlc raw from GitHub)
 
-These tests pin each branch.
+These tests pin each branch using `monkeypatch.setattr` on the module's
+_VENDORED_PROJECT_MAPPINGS_PATH constant — no renaming the real vendored
+file (which would be racy under pytest-xdist + leave orphans on crash).
 """
 
 from pathlib import Path
@@ -13,12 +15,23 @@ import json
 import sys
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import sdlc_manager  # noqa: E402
 
 
-def test_external_override_wins_over_vendored(tmp_path) -> None:
+@pytest.fixture
+def fake_vendored_path(tmp_path, monkeypatch):
+    """Redirect _VENDORED_PROJECT_MAPPINGS_PATH to a tmp dir. Caller controls
+    whether the file exists (write to fake_path to make it exist)."""
+    fake_path = tmp_path / "vendored-project-mappings.json"
+    monkeypatch.setattr(sdlc_manager, "_VENDORED_PROJECT_MAPPINGS_PATH", fake_path)
+    return fake_path
+
+
+def test_external_override_wins_over_vendored(tmp_path, fake_vendored_path) -> None:
     """If $INFIQUETRA_SDLC_PATH/config/project-mappings.json exists, it
     takes precedence over the vendored copy. This lets a developer test
     against a custom project layout without modifying the plugin."""
@@ -32,99 +45,93 @@ def test_external_override_wins_over_vendored(tmp_path) -> None:
     }
     (cfg_dir / "project-mappings.json").write_text(json.dumps(override_data))
 
-    # No need to mock anything — _resolve_project_mappings is called
-    # with the override path directly
+    # Also write a different vendored — to prove override wins
+    fake_vendored_path.write_text(json.dumps({"projects": {"vendored": {"number": 1}}}))
+
     result = sdlc_manager._resolve_project_mappings(sdlc_path)
     assert result == override_data
 
 
-def test_vendored_used_when_no_override(tmp_path) -> None:
-    """If the override doesn't exist, the vendored copy is used.
-    The vendored copy ships in the plugin and is verified to exist
-    (`plugins/sdlc-manager/config/project-mappings.json`)."""
-    # Point to a non-existent override path so resolution falls through
+def test_vendored_used_when_no_override(tmp_path, fake_vendored_path) -> None:
+    """Override missing → fall through to vendored. We control the
+    vendored content via the fixture so the test is hermetic."""
     no_override_path = tmp_path / "nonexistent-sdlc"
+    fake_vendored_path.write_text(json.dumps({
+        "organization": "infiquetra",
+        "projects": {"vendored-project": {"number": 1}},
+    }))
+
     result = sdlc_manager._resolve_project_mappings(no_override_path)
-
-    # Should have loaded the real vendored file
-    assert "projects" in result
-    assert "mount-olympus" in result["projects"]
-    assert result["projects"]["mount-olympus"]["number"] == 1
+    assert "vendored-project" in result["projects"]
 
 
-def test_remote_fallback_when_neither_exists(tmp_path) -> None:
+def test_remote_fallback_when_neither_exists(tmp_path, fake_vendored_path) -> None:
     """If both override and vendored are missing, fall back to `gh api`.
-    We mock _gh to verify the API call is made + simulate a base64
-    response from the GitHub Contents API."""
+    Mock `_gh` to verify the API call + simulate a base64 response."""
     import base64
     fake_payload = json.dumps({"projects": {"remote": {"number": 5}}})
     fake_b64 = base64.b64encode(fake_payload.encode()).decode()
 
     no_override_path = tmp_path / "nonexistent-sdlc"
+    # fake_vendored_path is a tmp path that doesn't exist (we never wrote to it)
+    assert not fake_vendored_path.exists()
 
-    # Patch the vendored path to also be missing for this test
-    fake_vendored = tmp_path / "fake-plugin-config-no-such-file.json"
-    with patch.object(
-        sdlc_manager, "Path",
-        wraps=Path,  # default behavior
-    ) as mock_path_cls:
-        # Hard to mock Path(__file__) cleanly; instead, just monkeypatch
-        # the vendored file probe by ensuring the test never finds it.
-        # The simplest approach: construct a controlled environment.
-        pass
-
-    # Cleaner approach: temporarily move the vendored file out of the way
-    real_vendored = (
-        Path(sdlc_manager.__file__).resolve().parent.parent
-        / "config" / "project-mappings.json"
-    )
-    backup = real_vendored.with_suffix(".json.bak-test")
-    real_vendored.rename(backup)
-    try:
-        with patch.object(sdlc_manager, "_gh", return_value=fake_b64):
-            result = sdlc_manager._resolve_project_mappings(no_override_path)
-        assert result == {"projects": {"remote": {"number": 5}}}
-    finally:
-        backup.rename(real_vendored)
+    with patch.object(sdlc_manager, "_gh", return_value=fake_b64):
+        result = sdlc_manager._resolve_project_mappings(no_override_path)
+    assert result == {"projects": {"remote": {"number": 5}}}
 
 
-def test_returns_empty_dict_when_all_three_fail(tmp_path) -> None:
+def test_returns_empty_dict_when_all_three_fail(tmp_path, fake_vendored_path) -> None:
     """If override missing, vendored missing, AND remote `gh api` raises,
     we return {} rather than crashing — caller handles empty config."""
     no_override_path = tmp_path / "nonexistent-sdlc"
-    real_vendored = (
-        Path(sdlc_manager.__file__).resolve().parent.parent
-        / "config" / "project-mappings.json"
-    )
-    backup = real_vendored.with_suffix(".json.bak-test")
-    real_vendored.rename(backup)
-    try:
-        with patch.object(
-            sdlc_manager, "_gh",
-            side_effect=sdlc_manager.GhApiError("simulated failure"),
-        ):
-            result = sdlc_manager._resolve_project_mappings(no_override_path)
-        assert result == {}
-    finally:
-        backup.rename(real_vendored)
+    assert not fake_vendored_path.exists()
+
+    with patch.object(
+        sdlc_manager, "_gh",
+        side_effect=sdlc_manager.GhApiError("simulated failure"),
+    ):
+        result = sdlc_manager._resolve_project_mappings(no_override_path)
+    assert result == {}
 
 
 def test_vendored_project_mappings_has_expected_canonical_state() -> None:
     """The vendored project-mappings.json must declare the canonical
-    org-wide state: Olympus is project #1; project_id captured (best-effort);
-    several known repos mapped. If this test fails, either the vendored
-    file was edited or the org's project layout changed — both are events
-    the operator should know about."""
-    vendored = (
-        Path(sdlc_manager.__file__).resolve().parent.parent
-        / "config" / "project-mappings.json"
-    )
+    org-wide state: Olympus is project #1; the repo list matches the
+    actual `gh repo list infiquetra` output as of the file's `_provenance`
+    date. If this test fails, either the vendored file was edited or the
+    org's repo set has drifted — both are events the operator should know
+    about. The expected list is captured here verbatim so drift is
+    visible in code review.
+
+    NOTE: This test reads the REAL vendored file (not the fixture) — it's
+    the canonical-state guard, not a hermetic unit test."""
+    vendored = sdlc_manager._VENDORED_PROJECT_MAPPINGS_PATH
     assert vendored.exists(), f"Vendored file missing at {vendored}"
     data = json.loads(vendored.read_text())
     assert data["organization"] == "infiquetra"
     assert "mount-olympus" in data["projects"]
     olympus = data["projects"]["mount-olympus"]
     assert olympus["number"] == 1
-    # repo list must include the canonical repos
-    repos = set(olympus["repositories"])
-    assert {"campps-mvp", "mimir", "infiquetra-sdlc", "infiquetra-claude-plugins"}.issubset(repos)
+
+    # Exact repo set from `gh repo list infiquetra --json name --jq '.[].name'`
+    # captured 2026-05-04. If the org adds/removes a repo, the vendored
+    # file needs updating + this test needs updating in the same PR — the
+    # symmetry forces the operator to re-verify.
+    expected_repos = {
+        "campps-blueprint",
+        "campps-mvp",
+        "github-actions-runners",
+        "hermes-extensions",
+        "infiquetra-aws-infra",
+        "infiquetra-claude-plugins",
+        "infiquetra-sdlc",
+        "mimir",
+        "mimir-blueprint",
+    }
+    actual_repos = set(olympus["repositories"])
+    assert actual_repos == expected_repos, (
+        f"Vendored repo list drifted from canonical. "
+        f"Missing: {expected_repos - actual_repos}; "
+        f"Unexpected: {actual_repos - expected_repos}"
+    )

--- a/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
+++ b/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
@@ -1,0 +1,130 @@
+"""Tests for project-mappings.json resolution order.
+
+The plugin resolves project_mappings via three steps:
+  1. External override:  $INFIQUETRA_SDLC_PATH/config/project-mappings.json
+  2. Vendored canonical: <plugin>/config/project-mappings.json
+  3. Remote `gh api` fallback (reads infiquetra-sdlc raw from GitHub)
+
+These tests pin each branch.
+"""
+
+from pathlib import Path
+import json
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+def test_external_override_wins_over_vendored(tmp_path) -> None:
+    """If $INFIQUETRA_SDLC_PATH/config/project-mappings.json exists, it
+    takes precedence over the vendored copy. This lets a developer test
+    against a custom project layout without modifying the plugin."""
+    # Set up an override file
+    sdlc_path = tmp_path / "infiquetra-sdlc"
+    cfg_dir = sdlc_path / "config"
+    cfg_dir.mkdir(parents=True)
+    override_data = {
+        "organization": "infiquetra",
+        "projects": {"override-project": {"number": 99, "name": "Override"}},
+    }
+    (cfg_dir / "project-mappings.json").write_text(json.dumps(override_data))
+
+    # No need to mock anything — _resolve_project_mappings is called
+    # with the override path directly
+    result = sdlc_manager._resolve_project_mappings(sdlc_path)
+    assert result == override_data
+
+
+def test_vendored_used_when_no_override(tmp_path) -> None:
+    """If the override doesn't exist, the vendored copy is used.
+    The vendored copy ships in the plugin and is verified to exist
+    (`plugins/sdlc-manager/config/project-mappings.json`)."""
+    # Point to a non-existent override path so resolution falls through
+    no_override_path = tmp_path / "nonexistent-sdlc"
+    result = sdlc_manager._resolve_project_mappings(no_override_path)
+
+    # Should have loaded the real vendored file
+    assert "projects" in result
+    assert "mount-olympus" in result["projects"]
+    assert result["projects"]["mount-olympus"]["number"] == 1
+
+
+def test_remote_fallback_when_neither_exists(tmp_path) -> None:
+    """If both override and vendored are missing, fall back to `gh api`.
+    We mock _gh to verify the API call is made + simulate a base64
+    response from the GitHub Contents API."""
+    import base64
+    fake_payload = json.dumps({"projects": {"remote": {"number": 5}}})
+    fake_b64 = base64.b64encode(fake_payload.encode()).decode()
+
+    no_override_path = tmp_path / "nonexistent-sdlc"
+
+    # Patch the vendored path to also be missing for this test
+    fake_vendored = tmp_path / "fake-plugin-config-no-such-file.json"
+    with patch.object(
+        sdlc_manager, "Path",
+        wraps=Path,  # default behavior
+    ) as mock_path_cls:
+        # Hard to mock Path(__file__) cleanly; instead, just monkeypatch
+        # the vendored file probe by ensuring the test never finds it.
+        # The simplest approach: construct a controlled environment.
+        pass
+
+    # Cleaner approach: temporarily move the vendored file out of the way
+    real_vendored = (
+        Path(sdlc_manager.__file__).resolve().parent.parent
+        / "config" / "project-mappings.json"
+    )
+    backup = real_vendored.with_suffix(".json.bak-test")
+    real_vendored.rename(backup)
+    try:
+        with patch.object(sdlc_manager, "_gh", return_value=fake_b64):
+            result = sdlc_manager._resolve_project_mappings(no_override_path)
+        assert result == {"projects": {"remote": {"number": 5}}}
+    finally:
+        backup.rename(real_vendored)
+
+
+def test_returns_empty_dict_when_all_three_fail(tmp_path) -> None:
+    """If override missing, vendored missing, AND remote `gh api` raises,
+    we return {} rather than crashing — caller handles empty config."""
+    no_override_path = tmp_path / "nonexistent-sdlc"
+    real_vendored = (
+        Path(sdlc_manager.__file__).resolve().parent.parent
+        / "config" / "project-mappings.json"
+    )
+    backup = real_vendored.with_suffix(".json.bak-test")
+    real_vendored.rename(backup)
+    try:
+        with patch.object(
+            sdlc_manager, "_gh",
+            side_effect=sdlc_manager.GhApiError("simulated failure"),
+        ):
+            result = sdlc_manager._resolve_project_mappings(no_override_path)
+        assert result == {}
+    finally:
+        backup.rename(real_vendored)
+
+
+def test_vendored_project_mappings_has_expected_canonical_state() -> None:
+    """The vendored project-mappings.json must declare the canonical
+    org-wide state: Olympus is project #1; project_id captured (best-effort);
+    several known repos mapped. If this test fails, either the vendored
+    file was edited or the org's project layout changed — both are events
+    the operator should know about."""
+    vendored = (
+        Path(sdlc_manager.__file__).resolve().parent.parent
+        / "config" / "project-mappings.json"
+    )
+    assert vendored.exists(), f"Vendored file missing at {vendored}"
+    data = json.loads(vendored.read_text())
+    assert data["organization"] == "infiquetra"
+    assert "mount-olympus" in data["projects"]
+    olympus = data["projects"]["mount-olympus"]
+    assert olympus["number"] == 1
+    # repo list must include the canonical repos
+    repos = set(olympus["repositories"])
+    assert {"campps-mvp", "mimir", "infiquetra-sdlc", "infiquetra-claude-plugins"}.issubset(repos)

--- a/plugins/sdlc-manager/tests/test_typed_exceptions.py
+++ b/plugins/sdlc-manager/tests/test_typed_exceptions.py
@@ -7,7 +7,7 @@ GhApiError subclass; downstream callers catch by type instead of doing
 
 from pathlib import Path
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -92,10 +92,81 @@ def test_classifies_422_validation_failure_as_generic_GhApiError() -> None:
         stderr="HTTP 422: Validation Failed\n... 'color': must be a 6-character hex string",
         returncode=1,
     )
-    # Generic GhApiError, not ApiAlreadyExists
+    # Generic GhApiError, not ApiAlreadyExistsError
     assert isinstance(exc, sdlc_manager.GhApiError)
-    assert not isinstance(exc, sdlc_manager.ApiAlreadyExists)
+    assert not isinstance(exc, sdlc_manager.ApiAlreadyExistsError)
     assert exc.status_code == 422
+
+
+# --- Dual-stream classifier (the DA blocker fix) ---------------------------
+
+
+def test_classifies_real_label_already_exists_via_stdout_json() -> None:
+    """Real `gh api --method POST repos/.../labels` for an existing label
+    (verified 2026-05-04 against the actual GitHub API):
+      stderr: 'gh: Validation Failed (HTTP 422)'
+      stdout: '{"message":"Validation Failed","errors":[{"resource":"Label",
+              "code":"already_exists","field":"name"}],"status":"422"}'
+
+    Stderr alone has NO duplicate-resource hint. Without inspecting
+    stdout, the duplicate-detection in PR #115's original implementation
+    silently failed in production. This test pins that the classifier
+    inspects stdout's `"code":"already_exists"` JSON marker."""
+    real_stderr = "gh: Validation Failed (HTTP 422)\n"
+    real_stdout = (
+        '{"message":"Validation Failed",'
+        '"errors":[{"resource":"Label","code":"already_exists","field":"name"}],'
+        '"documentation_url":"https://docs.github.com/rest/issues/labels#create-a-label",'
+        '"status":"422"}'
+    )
+    exc = sdlc_manager._classify_gh_error(
+        stderr=real_stderr,
+        returncode=1,
+        stdout=real_stdout,
+    )
+    assert isinstance(exc, sdlc_manager.ApiAlreadyExistsError)
+    assert exc.status_code == 422
+    # The exception should retain BOTH streams for debugging
+    assert exc.stderr == real_stderr
+    assert exc.stdout == real_stdout
+
+
+def test_classifies_real_404_via_stderr_summary() -> None:
+    """Real `gh api repos/.../nonexistent` (verified 2026-05-04):
+      stderr: 'gh: Not Found (HTTP 404)'
+      stdout: '{"message":"Not Found","status":"404"}'
+    Stderr has the (HTTP 404) marker; stdout has the JSON. Either is
+    sufficient for status detection."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr="gh: Not Found (HTTP 404)\n",
+        returncode=1,
+        stdout='{"message":"Not Found","status":"404"}',
+    )
+    assert isinstance(exc, sdlc_manager.ApiNotFoundError)
+    assert exc.status_code == 404
+
+
+def test_classifies_status_from_stdout_when_stderr_lacks_http_marker() -> None:
+    """Defensive: if some future `gh` version omits the (HTTP NNN) summary
+    from stderr, fall back to parsing the JSON body's `"status":"NNN"`."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr="gh: Something went wrong\n",  # no HTTP marker
+        returncode=1,
+        stdout='{"message":"Not Found","status":"404"}',
+    )
+    assert exc.status_code == 404
+    assert isinstance(exc, sdlc_manager.ApiNotFoundError)
+
+
+def test_class_alias_compatibility() -> None:
+    """The old class names (ApiNotFound, ApiAlreadyExists, ApiRateLimited)
+    are retained as aliases for the *Error-suffixed PEP 8 names. Code that
+    catches the old names continues to work; isinstance checks pass either way."""
+    exc = sdlc_manager.ApiNotFoundError("test", status_code=404)
+    assert isinstance(exc, sdlc_manager.ApiNotFound)        # alias
+    assert isinstance(exc, sdlc_manager.ApiNotFoundError)   # canonical name
+    assert sdlc_manager.ApiAlreadyExists is sdlc_manager.ApiAlreadyExistsError
+    assert sdlc_manager.ApiRateLimited is sdlc_manager.ApiRateLimitedError
 
 
 # --- _classify_gh_error: edge cases ----------------------------------------

--- a/plugins/sdlc-manager/tests/test_typed_exceptions.py
+++ b/plugins/sdlc-manager/tests/test_typed_exceptions.py
@@ -1,0 +1,225 @@
+"""Tests for the typed-exception classifier (replaces fragile string matching).
+
+`_classify_gh_error` parses gh CLI stderr ONCE and raises the appropriate
+GhApiError subclass; downstream callers catch by type instead of doing
+`"422" in str(e)` substring matching.
+"""
+
+from pathlib import Path
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+# --- _classify_gh_error: status-code parsing -------------------------------
+
+
+def test_classifies_404_as_ApiNotFound() -> None:
+    exc = sdlc_manager._classify_gh_error(
+        stderr="gh: Not Found (HTTP 404)\n",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiNotFound)
+    assert exc.status_code == 404
+
+
+def test_classifies_401_as_ApiAuthError() -> None:
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 401: Bad credentials\n",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiAuthError)
+    assert not isinstance(exc, sdlc_manager.ApiRateLimited)
+
+
+def test_classifies_403_with_rate_limit_signal_as_ApiRateLimited() -> None:
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 403: API rate limit exceeded\n",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiRateLimited)
+
+
+def test_classifies_403_without_rate_limit_as_ApiAuthError() -> None:
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 403: Forbidden — insufficient scope\n",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiAuthError)
+    assert not isinstance(exc, sdlc_manager.ApiRateLimited)
+
+
+def test_classifies_429_as_ApiRateLimited() -> None:
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 429: Too Many Requests\n",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiRateLimited)
+
+
+# --- _classify_gh_error: 422 disambiguation --------------------------------
+
+
+def test_classifies_422_with_already_exists_as_ApiAlreadyExists() -> None:
+    """Sub-issue API duplicate-link case."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 422: Validation Failed\n... 'sub_issue_id': sub-issue already exists",
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiAlreadyExists)
+    assert exc.status_code == 422
+
+
+def test_classifies_422_with_label_already_taken_as_ApiAlreadyExists() -> None:
+    """Label create duplicate case (different message text but same intent)."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr='HTTP 422: Validation Failed\n... "name has already been taken"',
+        returncode=1,
+    )
+    assert isinstance(exc, sdlc_manager.ApiAlreadyExists)
+
+
+def test_classifies_422_validation_failure_as_generic_GhApiError() -> None:
+    """A 422 that's NOT a duplicate-resource case (e.g., bad field value)
+    must NOT be classified as ApiAlreadyExists — it's a real validation failure
+    the caller needs to handle differently."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr="HTTP 422: Validation Failed\n... 'color': must be a 6-character hex string",
+        returncode=1,
+    )
+    # Generic GhApiError, not ApiAlreadyExists
+    assert isinstance(exc, sdlc_manager.GhApiError)
+    assert not isinstance(exc, sdlc_manager.ApiAlreadyExists)
+    assert exc.status_code == 422
+
+
+# --- _classify_gh_error: edge cases ----------------------------------------
+
+
+def test_classifies_unparseable_stderr_as_generic_GhApiError() -> None:
+    """No HTTP status in stderr → status_code is None; bare GhApiError raised."""
+    exc = sdlc_manager._classify_gh_error(
+        stderr="some weird subprocess error",
+        returncode=2,
+    )
+    assert isinstance(exc, sdlc_manager.GhApiError)
+    assert exc.status_code is None
+
+
+def test_empty_stderr_does_not_crash_classifier() -> None:
+    exc = sdlc_manager._classify_gh_error(stderr="", returncode=1)
+    assert isinstance(exc, sdlc_manager.GhApiError)
+
+
+# --- Integration: flow_link_sub_issue with typed exceptions ----------------
+
+
+def test_flow_link_sub_issue_idempotent_via_ApiAlreadyExists() -> None:
+    """The Phase C foundation refactor: link-sub-issue catches the typed
+    ApiAlreadyExists, not a substring match. This test ensures the typed
+    path works when the classifier raises the right type."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_get.side_effect = [
+            {"id": 12345},
+            {"id": 67890, "title": "parent issue"},
+        ]
+        # Raise the typed exception directly — what _classify_gh_error
+        # would produce on the duplicate-link 422
+        mock_post.side_effect = sdlc_manager.ApiAlreadyExists(
+            "gh command failed: HTTP 422 ... already exists",
+            status_code=422,
+            stderr="HTTP 422: Validation Failed ... already exists",
+        )
+
+        sdlc_manager.flow_link_sub_issue(
+            "campps-blueprint", 1, "campps-mvp", 42, fmt="text"
+        )
+
+        msgs = [c.args[0] for c in mock_out.call_args_list]
+        assert any("Already linked" in m for m in msgs), \
+            f"Expected idempotent success message; got: {msgs}"
+
+
+def test_flow_link_sub_issue_raises_on_non_duplicate_422() -> None:
+    """A 422 that's NOT a duplicate (validation failure on the body) must
+    NOT be silently treated as 'already exists' — it should propagate so
+    the operator sees the real error."""
+    with patch.object(sdlc_manager, "_rest_get") as mock_get, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post:
+        mock_get.side_effect = [
+            {"id": 12345},
+            {"id": 67890},
+        ]
+        # Generic GhApiError with 422 status (not ApiAlreadyExists)
+        mock_post.side_effect = sdlc_manager.GhApiError(
+            "gh command failed: HTTP 422 ... validation failed",
+            status_code=422,
+        )
+        with pytest.raises(sdlc_manager.GhApiError) as exc_info:
+            sdlc_manager.flow_link_sub_issue(
+                "campps-blueprint", 1, "campps-mvp", 42, fmt="text"
+            )
+        # Confirm it's not the ApiAlreadyExists subclass
+        assert not isinstance(exc_info.value, sdlc_manager.ApiAlreadyExists)
+
+
+# --- Integration: flow_verify_label with typed exceptions ------------------
+
+
+def test_flow_verify_label_creates_via_ApiNotFound() -> None:
+    """Probe raises ApiNotFound (typed 404) → fall through to create."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out"):
+        mock_gh.side_effect = sdlc_manager.ApiNotFound(
+            "gh command failed: HTTP 404",
+            status_code=404,
+        )
+        sdlc_manager.flow_verify_label(
+            "campps-mvp", "high-priority", "D93F0B", "High priority", fmt="text"
+        )
+        mock_post.assert_called_once()
+
+
+def test_flow_verify_label_propagates_ApiAuthError() -> None:
+    """Probe raises ApiAuthError (typed 401/403) → must NOT silently
+    create; the auth failure propagates so the operator sees it."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post:
+        mock_gh.side_effect = sdlc_manager.ApiAuthError(
+            "gh command failed: HTTP 401 Bad credentials",
+            status_code=401,
+        )
+        with pytest.raises(sdlc_manager.ApiAuthError):
+            sdlc_manager.flow_verify_label(
+                "campps-mvp", "x", None, None, fmt="text"
+            )
+        mock_post.assert_not_called()
+
+
+def test_flow_verify_label_handles_race_via_ApiAlreadyExists_on_post() -> None:
+    """Race: two operators run verify-label simultaneously, both see 404
+    on probe, both POST, second gets 422-already-exists. Our impl must
+    treat that as success (idempotency contract), not propagate."""
+    with patch.object(sdlc_manager, "_gh") as mock_gh, \
+         patch.object(sdlc_manager, "_rest_post") as mock_post, \
+         patch.object(sdlc_manager, "_out") as mock_out:
+        mock_gh.side_effect = sdlc_manager.ApiNotFound("404", status_code=404)
+        mock_post.side_effect = sdlc_manager.ApiAlreadyExists(
+            "name has already been taken",
+            status_code=422,
+        )
+        # Should NOT raise
+        sdlc_manager.flow_verify_label(
+            "campps-mvp", "high-priority", "D93F0B", None, fmt="text"
+        )
+        msgs = [c.args[0] for c in mock_out.call_args_list]
+        assert any("just created" in m or "race detected" in m for m in msgs), \
+            f"Expected race-detection message; got: {msgs}"

--- a/plugins/sdlc-manager/tests/test_user_defaults.py
+++ b/plugins/sdlc-manager/tests/test_user_defaults.py
@@ -54,6 +54,22 @@ def test_load_user_defaults_tolerates_non_object_root(tmp_defaults_path) -> None
     assert data == {}
 
 
+def test_load_user_defaults_tolerates_unreadable_file(tmp_defaults_path, capsys) -> None:
+    """If the file can't be opened (permissions, broken symlink, encoding
+    issue), return {} + warning. The CLI must remain usable; the operator
+    can re-run init-defaults to reseed."""
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    # Create with non-UTF-8 bytes so the open()/json.load chain raises
+    # UnicodeDecodeError (caught by the widened except clause)
+    tmp_defaults_path.write_bytes(b'\xff\xfe\xfd not valid utf-8')
+    data = sdlc_manager.load_user_defaults()
+    assert data == {}
+    captured = capsys.readouterr()
+    # Either warning text or stderr should mention the issue
+    assert "could not be read" in (captured.out + captured.err).lower() \
+        or "malformed" in (captured.out + captured.err).lower()
+
+
 def test_get_default_returns_None_when_unset(tmp_defaults_path) -> None:
     assert sdlc_manager.get_default("assignee") is None
 

--- a/plugins/sdlc-manager/tests/test_user_defaults.py
+++ b/plugins/sdlc-manager/tests/test_user_defaults.py
@@ -1,0 +1,180 @@
+"""Tests for the per-user defaults file at ~/.claude/sdlc-defaults.json
+and the first-run wizard `config init-defaults`."""
+
+from pathlib import Path
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+@pytest.fixture
+def tmp_defaults_path(tmp_path, monkeypatch):
+    """Redirect _USER_DEFAULTS_PATH into a tmp dir so tests don't write
+    to the real ~/.claude/sdlc-defaults.json."""
+    fake_path = tmp_path / ".claude" / "sdlc-defaults.json"
+    monkeypatch.setattr(sdlc_manager, "_USER_DEFAULTS_PATH", fake_path)
+    return fake_path
+
+
+# --- Read-side -------------------------------------------------------------
+
+
+def test_load_user_defaults_returns_empty_when_file_missing(tmp_defaults_path) -> None:
+    assert sdlc_manager.load_user_defaults() == {}
+
+
+def test_load_user_defaults_returns_dict_when_file_present(tmp_defaults_path) -> None:
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_defaults_path.write_text('{"assignee": "namredips", "default_project": "mount-olympus"}')
+    data = sdlc_manager.load_user_defaults()
+    assert data == {"assignee": "namredips", "default_project": "mount-olympus"}
+
+
+def test_load_user_defaults_tolerates_malformed_json(tmp_defaults_path, capsys) -> None:
+    """Malformed JSON returns {} + warning — must not crash the CLI."""
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_defaults_path.write_text("{ not-valid-json")
+    data = sdlc_manager.load_user_defaults()
+    assert data == {}
+    captured = capsys.readouterr()
+    assert "malformed" in (captured.out + captured.err).lower()
+
+
+def test_load_user_defaults_tolerates_non_object_root(tmp_defaults_path) -> None:
+    """File contains a list (not a dict) — return {} + warning, not crash."""
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_defaults_path.write_text('["not", "an", "object"]')
+    data = sdlc_manager.load_user_defaults()
+    assert data == {}
+
+
+def test_get_default_returns_None_when_unset(tmp_defaults_path) -> None:
+    assert sdlc_manager.get_default("assignee") is None
+
+
+def test_get_default_returns_value_when_set(tmp_defaults_path) -> None:
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_defaults_path.write_text('{"assignee": "namredips"}')
+    assert sdlc_manager.get_default("assignee") == "namredips"
+
+
+# --- Write-side ------------------------------------------------------------
+
+
+def test_save_user_defaults_creates_parent_dir(tmp_defaults_path) -> None:
+    """First-run case: ~/.claude/ may not exist. save_user_defaults must
+    create it rather than raising FileNotFoundError."""
+    assert not tmp_defaults_path.parent.exists()
+    sdlc_manager.save_user_defaults({"assignee": "namredips"})
+    assert tmp_defaults_path.exists()
+    assert json.loads(tmp_defaults_path.read_text()) == {"assignee": "namredips"}
+
+
+def test_save_user_defaults_is_atomic(tmp_defaults_path) -> None:
+    """Atomicity: a crash mid-write must not leave a partially-written file.
+    Implementation uses tempfile + rename. We test by writing twice and
+    confirming no .tmp file is left over."""
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    sdlc_manager.save_user_defaults({"assignee": "first"})
+    sdlc_manager.save_user_defaults({"assignee": "second"})
+
+    # Final state matches second write
+    assert json.loads(tmp_defaults_path.read_text()) == {"assignee": "second"}
+
+    # No .tmp leftover
+    tmp_files = list(tmp_defaults_path.parent.glob("*.tmp"))
+    assert tmp_files == [], f"Tempfile leftover: {tmp_files}"
+
+
+def test_save_then_load_round_trips(tmp_defaults_path) -> None:
+    payload = {
+        "assignee": "namredips",
+        "default_project": "mount-olympus",
+        "default_status": "Backlog",
+        "preferred_repos": ["campps-mvp", "mimir"],
+    }
+    sdlc_manager.save_user_defaults(payload)
+    assert sdlc_manager.load_user_defaults() == payload
+
+
+# --- First-run wizard (--non-interactive path) -----------------------------
+
+
+def test_init_defaults_non_interactive_seeds_from_gh_login(tmp_defaults_path) -> None:
+    """--non-interactive: no prompts, just auto-detected values.
+    `assignee` comes from `gh api user --jq .login` (NOT $USER)."""
+    with patch.object(sdlc_manager, "_fetch_gh_login", return_value="namredips"), \
+         patch.object(sdlc_manager, "load_config") as mock_cfg:
+        mock_cfg.return_value = {
+            "project_mappings": {
+                "projects": {"mount-olympus": {"number": 1, "name": "Olympus"}}
+            }
+        }
+        sdlc_manager.config_init_defaults(non_interactive=True, fmt="text")
+
+    saved = json.loads(tmp_defaults_path.read_text())
+    assert saved["assignee"] == "namredips"
+    assert saved["default_project"] == "mount-olympus"  # auto-detected (single project)
+    assert saved["default_status"] == "Backlog"
+    assert saved["default_priority"] == "medium-priority"
+
+
+def test_init_defaults_non_interactive_skips_unset_when_no_gh_login(
+    tmp_defaults_path,
+) -> None:
+    """If `gh api user` fails (unauthenticated), assignee should NOT default
+    to $USER or any string — it should be omitted so the operator notices."""
+    with patch.object(sdlc_manager, "_fetch_gh_login", return_value=None), \
+         patch.object(sdlc_manager, "load_config") as mock_cfg:
+        mock_cfg.return_value = {"project_mappings": {"projects": {}}}
+        sdlc_manager.config_init_defaults(non_interactive=True, fmt="text")
+
+    saved = json.loads(tmp_defaults_path.read_text())
+    assert "assignee" not in saved
+
+
+def test_init_defaults_non_interactive_skips_default_project_with_multiple_projects(
+    tmp_defaults_path,
+) -> None:
+    """Auto-detection of default_project ONLY fires when exactly 1 project
+    is mapped. With 2+, the operator must choose; we don't guess."""
+    with patch.object(sdlc_manager, "_fetch_gh_login", return_value="namredips"), \
+         patch.object(sdlc_manager, "load_config") as mock_cfg:
+        mock_cfg.return_value = {
+            "project_mappings": {
+                "projects": {
+                    "olympus": {"number": 1},
+                    "strategic": {"number": 2},
+                }
+            }
+        }
+        sdlc_manager.config_init_defaults(non_interactive=True, fmt="text")
+
+    saved = json.loads(tmp_defaults_path.read_text())
+    assert "default_project" not in saved
+
+
+# --- Wizard preserves existing values -------------------------------------
+
+
+def test_init_defaults_preserves_existing_unrecognized_keys(tmp_defaults_path) -> None:
+    """A future version of the script may add new defaults keys; an older
+    script running --non-interactive must NOT clobber them."""
+    tmp_defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    sdlc_manager.save_user_defaults({
+        "assignee": "namredips",
+        "future_key_not_in_schema": "custom-value",
+    })
+    with patch.object(sdlc_manager, "_fetch_gh_login", return_value="namredips"), \
+         patch.object(sdlc_manager, "load_config") as mock_cfg:
+        mock_cfg.return_value = {"project_mappings": {"projects": {}}}
+        sdlc_manager.config_init_defaults(non_interactive=True, fmt="text")
+
+    saved = json.loads(tmp_defaults_path.read_text())
+    assert saved["future_key_not_in_schema"] == "custom-value"


### PR DESCRIPTION
## Summary

First of **3 PRs** shipping the deferred Phase C items. This PR is the *foundation*; the next 2 PRs (interactive \`issue create\` rewrite + \`sdlc-operator\` subagent) build on this.

## What's added

### 1. Typed exception classes
Replaces the fragile \`\"422\" in str(e)\` substring matching pattern flagged by python-expert review of PR #114.
- \`GhApiError\` (base) + \`ApiNotFound\`, \`ApiAlreadyExists\`, \`ApiRateLimited\`, \`ApiAuthError\`
- \`_gh\` now classifies stderr ONCE via \`_classify_gh_error\` and raises the appropriate subclass
- 422 disambiguation: duplicate-resource (ApiAlreadyExists) vs validation failure (generic GhApiError) by inspecting response body
- \`flow_link_sub_issue\` and \`flow_verify_label\` refactored to catch by type
- \`flow_verify_label\` now also handles the legitimate race (two operators creating same label simultaneously) via ApiAlreadyExists on POST

### 2. Per-user defaults file
\`~/.claude/sdlc-defaults.json\` with sticky values across CLI invocations.
- Schema: \`assignee\` (gh login from \`gh api user\`, NOT \`$USER\`), \`default_project\`, \`default_status\`, \`default_priority\`, \`default_initiative\`, \`default_objective\`, \`preferred_repos\`
- \`load_user_defaults()\` / \`save_user_defaults()\` (atomic write; tolerant of missing file + malformed JSON + non-object root)
- \`config show-defaults\` — display current
- \`config init-defaults [--non-interactive]\` — first-run wizard. \`--non-interactive\` seeds with auto-detected values only (gh login as assignee; default_project iff exactly one project mapped — no guessing on multi-project orgs); preserves unrecognized future-version keys

### 3. Vendored project-mappings.json
Plugin works without external \`infiquetra-sdlc\` checkout.
- File at \`plugins/sdlc-manager/config/project-mappings.json\`
- New \`_resolve_project_mappings()\` implements the documented order: external override (\`\$INFIQUETRA_SDLC_PATH/config/\`) → vendored canonical → remote \`gh api\` fallback
- Project node IDs captured best-effort (verified 2026-05-04). Field/option IDs NEVER cached; fetched live

## Tests (64 / 64 passing)

3 new test files covering the new code:
- \`test_typed_exceptions.py\` (15 tests) — status-code parsing (404/401/403/429/422 disambiguation), 422-already-exists vs 422-validation-failure, integration with flow helpers (including race detection)
- \`test_user_defaults.py\` (13 tests) — read-side, write-side (atomic), \`--non-interactive\` wizard
- \`test_project_mappings_resolution.py\` (5 tests) — each branch of the resolution order + the canonical-state guard

3 PR #114 tests in test_flow_subcommands.py updated to use typed exceptions.

## Plugin manifest
1.1.0 → 1.2.0

## Side fix
Added \`uv.lock\` to \`.gitignore\` (was getting staged by test runs).

## Test plan
- [ ] All 64 tests pass: \`uv run --with pytest --with pytest-cov python -m pytest plugins/sdlc-manager/tests/ tests/test_sdlc_manager.py -v --no-cov\`
- [ ] \`config init-defaults --non-interactive\` produces valid JSON at \`~/.claude/sdlc-defaults.json\` (manual)
- [ ] Vendored \`project-mappings.json\` declares \`mount-olympus\` with project number 1 + canonical repos
- [ ] Reviewers: clarity-reviewer, devils-advocate-reviewer, python-expert