### PR TITLE
[BENCH t01 deepseek-v4-pro-c] feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,10 @@
+"""Text helper utilities."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of ``word`` for ``count``."""
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,23 @@
+from scripts.text_helpers import pluralize
+
+
+def test_pluralize_returns_singular_for_count_one():
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural():
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string_returns_empty_string_for_any_count():
+    assert pluralize("", 1) == ""
+    assert pluralize("", 5) == ""
+    assert pluralize("", 0, plural="items") == ""


### PR DESCRIPTION
## Linked card

Closes #118

## What changed

- Added `scripts/text_helpers.py` with `pluralize(word, count, *, plural=None)` — a pure stdlib function returning singular/plural form based on count
- Added `tests/test_text_helpers.py` with 5 pytest cases: singular, regular plural, custom plural, zero count, empty string

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```
Output: 5 passed in 0.09s. Coverage: 100% (6/6 statements).

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ — `pluralize()` handles singular (count=1), regular plural (count≠1), custom plural, zero count (plural form), and empty string (returns "" always)
- AC 2 (All named tests pass): ✓ — all 5 pytest cases pass; coverage at 100%
- AC 3 (No dependencies added): ✓ — stdlib only, no third-party imports

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: ✓ — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed
- Do NOT add third-party dependencies: ✓ — zero new dependencies
- Do NOT refactor unrelated code: ✓ — no refactors

## Notes

- Verification command placeholder in card resolved to `pytest tests/test_text_helpers.py -v` per plan
- Self-critique timed out (rc=124, 120s); diff is trivially small — 2 files, 18 LoC logic, 5 passing tests, 100% coverage

### Coverage

- AC 1 (verbatim): ✓ addressed in `scripts/text_helpers.py::pluralize()` — full behavior coverage via test file
- AC 2 (verbatim): ✓ addressed in `tests/test_text_helpers.py` — all 5 named test cases pass
- AC 3 (verbatim): ✓ addressed — zero new dependencies, stdlib only