### PR TITLE
[BENCH t01 deepseek-v4-pro-c] feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,20 @@
+"""Text formatting helpers for Infiquetra Claude plugins."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the correct singular or plural form of a word based on count.
+
+    Args:
+        word: The singular form of the word.
+        count: The number to determine singular/plural form.
+        plural: Optional custom plural form. If not provided, appends "s".
+
+    Returns:
+        The word unchanged if count is 1, otherwise the plural form.
+        Empty string input returns empty string regardless of count.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    return plural if plural is not None else f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,34 @@
+"""Unit tests for text_helpers.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize  # noqa: E402
+
+
+def test_pluralize_returns_word_for_singular_count():
+    """Singular count returns the word unchanged."""
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_appends_s_for_regular_plural():
+    """Plural count appends 's' when no custom plural provided."""
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural_when_provided():
+    """Custom plural is used when provided for non-singular counts."""
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_treats_zero_as_plural():
+    """Zero count is treated as plural (appends 's')."""
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_returns_empty_string_regardless_of_count():
+    """Empty string input returns empty string for any count."""
+    assert pluralize("", 5) == ""
+    assert pluralize("", 1, plural="ignored") == ""


### PR DESCRIPTION
## Linked card

Closes #120

## What changed

- Created `scripts/text_helpers.py` with `pluralize(word: str, count: int, *, plural: str | None = None) -> str`
- Created `tests/test_text_helpers.py` with 5 pytest cases covering singular, regular plural, custom plural, zero count, and empty string
- No imports beyond stdlib (`sys`, `pathlib`) + existing pytest infrastructure

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```

All 5 tests pass, 100% line coverage on `scripts/text_helpers.py` (6/6 statements):
```
tests/test_text_helpers.py::test_pluralize_returns_word_for_singular_count PASSED
tests/test_text_helpers.py::test_pluralize_appends_s_for_regular_plural PASSED
tests/test_text_helpers.py::test_pluralize_uses_custom_plural_when_provided PASSED
tests/test_text_helpers.py::test_pluralize_treats_zero_as_plural PASSED
tests/test_text_helpers.py::test_pluralize_returns_empty_string_regardless_of_count PASSED
```

Ruff lint clean on both files.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body → ✓ Three-branch implementation (`word == ""` early return, `count == 1` guard, custom-plural/appended-s fallback). All examples from the Notes verified by test cases.
- AC 2: All named tests pass the verification command → ✓ 5 pytest cases pass (`pytest tests/test_text_helpers.py -v`)
- AC 3: No dependencies added unless absolutely required → ✓ stdlib only; no pyproject.toml/requirements changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below → Not violated. Only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed.
- Do NOT add third-party dependencies unless required by the task body → Not violated. Stdlib only.
- Do NOT refactor unrelated code in the touched files → Not violated. Both files are net-new; no unrelated edits.

## Notes

No deviations from the approved plan. Self-critique pass timed out (120s) and was not blocking per the rules.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `scripts/text_helpers.py` `pluralize()` (lines 3-17)
- AC 2 (All named tests pass the verification command): ✓ addressed in `tests/test_text_helpers.py` (5 test functions)
- AC 3 (No dependencies added unless absolutely required): ✓ verified — zero imports in `scripts/text_helpers.py`, stdlib-only imports in test file