### PR TITLE
feat(scripts): Add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,17 @@
+"""Text utility helpers for Infiquetra scripts."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of *word* based on *count*.
+
+    - If *word* is empty, returns empty string regardless of other arguments.
+    - If *count* is 1, returns *word* unchanged.
+    - Otherwise, returns *plural* if provided, else *word* + "s".
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    if plural is not None:
+        return plural
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,31 @@
+"""Unit tests for text_helpers.pluralize."""
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import text_helpers directly.
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize
+
+
+def test_pluralize_returns_singular_when_count_is_one():
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural():
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string_returns_empty_string():
+    assert pluralize("", 5) == ""
+    assert pluralize("", 1) == ""
+    assert pluralize("", 2, plural="children") == ""


### PR DESCRIPTION
## Linked card

Closes #122

## What changed

- **scripts/text_helpers.py** — new module with `pluralize(word: str, count: int, *, plural: str | None = None) -> str`. Returns `word` unchanged when `count == 1`, custom `plural` arg when provided, or `word + "s"` otherwise. Short-circuits empty string to `""` regardless of count/plural.
- **tests/test_text_helpers.py** — new test file with 5 pytest test functions covering singular, regular plural, custom plural, zero count, and empty string behavior.

## How verified

```bash
cd ~/workspace/infiquetra/infiquetra-claude-plugins
pytest tests/test_text_helpers.py -v
```

Output: 5 passed in 0.06s

```bash
ruff check scripts/text_helpers.py tests/test_text_helpers.py
```

Output: All checks passed!

```bash
PYTHONPATH=scripts pytest --cov=text_helpers --cov-report=term-missing tests/test_text_helpers.py -v
```

Output: 8 statements, 0 missed, 100% coverage

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ `pluralize()` in `scripts/text_helpers.py` implements all four behaviors: singular return (count==1), regular plural (word+"s"), custom plural, and empty-string guard.
- AC 2 (All named tests pass the verification command): ✓ All 5 named test functions pass via `pytest tests/test_text_helpers.py -v`.
- AC 3 (No dependencies added unless absolutely required): ✓ No new dependencies; implementation uses zero imports, test uses only stdlib (`sys`, `pathlib`) + pytest.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependency files touched.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new.

## Notes

No deviations from the plan. No unexpected findings.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `scripts/text_helpers.py::pluralize`
- All named tests pass the verification command: ✓ addressed in `tests/test_text_helpers.py` — 5/5 tests passing
- No dependencies added unless absolutely required: ✓ confirmed — no pyproject.toml or requirements changes