### PR TITLE
feat(scripts): add pluralize() text helper

### DIFF
--- a/scripts/text_helpers.py
+++ b/scripts/text_helpers.py
@@ -1,0 +1,21 @@
+"""Text helper utilities for string formatting."""
+
+
+def pluralize(word: str, count: int, *, plural: str | None = None) -> str:
+    """Return the singular or plural form of a word based on count.
+
+    Args:
+        word: The singular form of the word.
+        count: The quantity determining singular vs. plural.
+        plural: Custom plural form. If omitted, appends "s" to word.
+
+    Returns:
+        The appropriate form of the word, or empty string if word is empty.
+    """
+    if word == "":
+        return ""
+    if count == 1:
+        return word
+    if plural is not None:
+        return plural
+    return f"{word}s"

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,29 @@
+"""Tests for scripts.text_helpers.pluralize."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from text_helpers import pluralize  # noqa: E402
+
+
+def test_pluralize_returns_singular_for_count_one():
+    assert pluralize("cat", 1) == "cat"
+
+
+def test_pluralize_adds_s_for_regular_plural():
+    assert pluralize("cat", 2) == "cats"
+
+
+def test_pluralize_uses_custom_plural():
+    assert pluralize("child", 2, plural="children") == "children"
+
+
+def test_pluralize_zero_count_uses_plural_form():
+    assert pluralize("cat", 0) == "cats"
+
+
+def test_pluralize_empty_string_returns_empty():
+    assert pluralize("", 5) == ""
+    assert pluralize("", 1) == ""


### PR DESCRIPTION
## Linked card

Closes #124

## What changed

- Added `scripts/text_helpers.py` with `pluralize(word: str, count: int, *, plural: str | None = None) -> str`
- Added `tests/test_text_helpers.py` with 5 pytest test cases

## How verified

```bash
$ pytest tests/test_text_helpers.py -v
tests/test_text_helpers.py::test_pluralize_returns_singular_for_count_one PASSED
tests/test_text_helpers.py::test_pluralize_adds_s_for_regular_plural PASSED
tests/test_text_helpers.py::test_pluralize_uses_custom_plural PASSED
tests/test_text_helpers.py::test_pluralize_zero_count_uses_plural_form PASSED
tests/test_text_helpers.py::test_pluralize_empty_string_returns_empty PASSED
5 passed in 0.07s

$ pytest tests/test_text_helpers.py --cov=text_helpers --cov-report=term-missing
Name                      Stmts   Miss  Cover   Missing
-------------------------------------------------------
scripts/text_helpers.py       8      0   100%
TOTAL                         8      0   100%

$ ruff check scripts/text_helpers.py tests/test_text_helpers.py
All checks passed!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): `pluralize()` in `scripts/text_helpers.py` handles all 4 behaviors — empty-string guard, singular for count==1, custom plural when provided, default "s" suffix
- AC 2 (All named tests pass): All 5 pytest tests pass in `tests/test_text_helpers.py`
- AC 3 (No dependencies added): No imports, no dependency file changes — pure Python standard library only

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `scripts/text_helpers.py` and `tests/test_text_helpers.py` changed
- Do NOT add third-party dependencies: not violated — no dependencies added
- Do NOT refactor unrelated code: not violated — both files are new

## Notes

- Test import uses `sys.path.insert` to match the repo's existing convention (see `tests/test_slack_client.py`, `tests/test_pagerduty_client.py`).

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in scripts/text_helpers.py:pluralize()
- All named tests pass the verification command: ✓ addressed in tests/test_text_helpers.py (5/5 passing)
- No dependencies added unless absolutely required: ✓ addressed — no dependency files modified