### PR TITLE
feat(redis-bridge): Phase 1 — presence, heartbeat, slash list

### DIFF
--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,62 @@
 
 ## 2026-05-25
 
+### `@dataclass(slots=True)` doesn't expose class-level field defaults  {#dataclass-slots-class-defaults}
+
+**Context.** While building `plugins/redis-bridge/server/registry.py`, the loader read each config field via `defaults_raw.get(key, Defaults.heartbeat_seconds)` — reaching into the dataclass class to pull the field default. Five tests failed with `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'member_descriptor'`.
+
+**Evidence.** Reproducer:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class D:
+    n: int = 10
+
+print(type(D.n))  # <class 'member_descriptor'>  ← not int!
+print(D().n)     # 10  ← only an *instance* has the value
+```
+
+`pytest` failure trail at `plugins/redis-bridge/server/registry.py:130` calling `int(Defaults.heartbeat_seconds)`. Fix commit in this PR replaces `Defaults.<field>` with `base = Defaults(); base.<field>`.
+
+**Mechanism.** With `slots=True`, the dataclass `__slots__` machinery installs *descriptors* on the class to mediate per-instance attribute storage. Looking up `D.field` returns the descriptor object itself, not the field's default. Without `slots=True`, the class still has plain class attributes that happen to equal the defaults — so the pattern works by accident, masking the bug for any non-slotted dataclass. `dataclasses.fields(D)[i].default` is the *correct* way to read a field's default without instantiating.
+
+**Fix.** Construct a `Defaults()` instance first and pull values off it; commit on branch `worktree-redis-bridge-phase1` (this PR).
+
+**Validation.** 35 unit tests across session_id, registry, and presence now pass (was 30 passing + 5 failing).
+
+**What surprised.** The error message ("not a real number") gives no hint that the issue is `slots=True`. I assumed a JSON-parsing bug for several minutes before the traceback pointed at `int(Defaults.heartbeat_seconds)`.
+
+**Generalizable rule.** When you put `slots=True` on a dataclass, **do not read field defaults via `Class.field`** — that pattern returns the slot descriptor, not the default. Either (a) instantiate a default object and read from it, (b) call `dataclasses.fields(Class)`, or (c) drop `slots=True` if you want the convenience. This bug is invisible without slots, so it only shows up after you turn slots on for memory/lookup reasons.
+
+**Refs.** Phase 1 PR for redis-bridge.
+
+---
+
+### MCP Python SDK's `RedisLike` Protocol stricter than the runtime  {#redis-like-protocol-too-strict}
+
+**Context.** I declared a `RedisLike` `typing.Protocol` in `redis_client.py` to allow both `redis.Redis` and `fakeredis.FakeRedis` (used in tests) as Presence inputs without circular typing. mypy rejected `Presence(redis.Redis(...), ...)` because `redis.Redis.exists` returns `Awaitable[Any] | Any` (covering both sync and async clients) and my Protocol declared `-> int`.
+
+**Evidence.** mypy on `channel.py:78`:
+
+```
+error: Argument 1 to "Presence" has incompatible type "Redis"; expected "RedisLike"
+note: Following member(s) of "Redis" have conflicts:
+note:     Expected: def delete(self, *names: str) -> int
+note:     Got: def delete(self, *names: bytes|str|memoryview[int]) -> Awaitable[Any]|Any
+```
+
+**Mechanism.** `redis-py` types its client union-style (sync + async share one class hierarchy) so every call returns `Awaitable[Any] | Any`. A narrowed Protocol that promises a concrete return type can never be satisfied by such a wide union, even though the runtime behavior is exactly what we want.
+
+**Fix.** `RedisLike = typing.Any`. Code keeps duck-typing; mypy is unblocked. Both `redis.Redis` and `fakeredis.FakeRedis` work at runtime as before. Commit on branch `worktree-redis-bridge-phase1`.
+
+**Generalizable rule.** When a client library exposes both sync + async via one wide-union type, narrowing it via `Protocol` to be more useful in your code's signatures will fight you. Use `Any` (or accept that you're going to lose mypy coverage on those calls). The dynamic-typing escape hatch is the right tool here — Protocol is for protocols you actually want to enforce, not for shaving down third-party type uncertainty.
+
+**Refs.** `plugins/redis-bridge/server/redis_client.py`.
+
+---
+
 ### Verification findings while planning the `redis-bridge` plugin  {#redis-bridge-verification}
 
 **Context.** During design of the `redis-bridge` + `hermes-claude-code-router` plan, several "obvious" claims about the Hermes-side infrastructure turned out to be wrong in ways that meaningfully reshaped the architecture. This entry captures the surprises for future plan-verification work.

--- a/plugins/redis-bridge/.claude-plugin/plugin.json
+++ b/plugins/redis-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-bridge/.mcp.json
+++ b/plugins/redis-bridge/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "redis-bridge": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["-m", "server"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}",
+      "env": {}
+    }
+  }
+}

--- a/plugins/redis-bridge/CHANGELOG.md
+++ b/plugins/redis-bridge/CHANGELOG.md
@@ -7,22 +7,30 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
-### Added
+### Added — Phase 1 (presence + heartbeat + slash list)
 
-- Phase 0 scaffold: directory layout, plugin manifest, README, CHANGELOG.
+- `server/session_id.py`: auto-generate session names from cwd + host hash (`<slug>-<8hex>`), with `CLAUDE_SESSION_NAME` env override and slug validation.
+- `server/registry.py`: loads endpoint config from `~/.claude/channels/redis-bridge/registry.json`; clean error types for missing/parse/unknown-endpoint cases.
+- `server/redis_client.py`: Redis connection helper with password-env injection that fails loud if the configured env var is unset.
+- `server/presence.py`: registry HSET + 10s heartbeat thread (TTL 60s by default) + lifecycle pub/sub events (`registered`, `unregistered`); supports context-manager use; tolerates transient errors without exiting the thread; lazy stale-entry GC on `list_live_sessions`.
+- `server/channel.py`: FastMCP stdio server exposing `redis_bridge_connect`, `redis_bridge_disconnect`, `redis_bridge_list` tools. Single-active-session state with lock; second connect replaces first; atexit + SIGTERM/SIGINT cleanup.
+- `.mcp.json` manifest so Claude Code auto-launches the server.
+- `docs/registry.example.json` reference config.
+- Slash commands `connect`/`disconnect`/`list` rewritten to instruct Claude to invoke the matching MCP tools and interpret results.
+- Tests: 57 new unit tests across `test_redis_bridge_session_id.py` (12), `test_redis_bridge_registry.py` (9), `test_redis_bridge_presence.py` (16), `test_redis_bridge_channel.py` (15). fakeredis-backed; heartbeat refresh verified with sub-TTL beat.
+
+### Added — Phase 0 (scaffold)
+
+- Directory layout, plugin manifest, README, CHANGELOG.
 - `PROTOCOL.md` canonical wire-format spec for redis-bridge ↔ router.
 - `docs/STATE_MACHINE.md` routing-target state machine spec (router-side).
-- `server/protocol.py` pydantic models pinning the wire format + destructive-tool classifier.
-- `server/__main__.py` stub entry point.
-- `tests/test_protocol.py` covering all protocol models and the `is_destructive` classifier.
-- Agent coach file `agents/redis-bridge-coach.md` (descriptive — actual AskUserQuestion handling is intercepted in the MCP server, not coached).
-- Skill metadata `skills/redis-bridge/SKILL.md`.
-- Slash command stubs for connect / disconnect / list / rename / configure / mode.
+- `server/protocol.py` pydantic models + `is_destructive` classifier.
+- `tests/test_protocol.py` covering all protocol models.
+- Agent coach `agents/redis-bridge-coach.md`, skill `skills/redis-bridge/SKILL.md`, slash command stubs.
 
 ### Not implemented yet (planned for later phases)
 
-- MCP server loop (Phase 1).
-- Redis presence/heartbeat (Phase 1).
 - Inbound stream consumer + `notifications/claude/channel` emission (Phase 2).
 - `reply` MCP tool (Phase 2).
+- Voice routing (Phase 3).
 - Permission relay + AskUserQuestion interception + audit logging (Phase 4).

--- a/plugins/redis-bridge/README.md
+++ b/plugins/redis-bridge/README.md
@@ -17,23 +17,39 @@ It is **not** a Discord bot. It does not touch Discord, voice-channel audio, STT
 
 ## Status
 
-**Phase 0 scaffold.** Protocol + state-machine specs are nailed down; pydantic models pin the wire format; tests cover the type surface. The MCP server loop, Redis I/O, slash commands, and permission relay land in later phases. See `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md` for the full roadmap.
+**Phase 1 complete.** Presence + heartbeat + slash list working end-to-end against fakeredis; live multi-session listing with stale GC. Phase 2 (text bridge: DM/channel/thread) is next. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
+
+## Quickstart
+
+1. **Configure an endpoint.** Copy `docs/registry.example.json` to `~/.claude/channels/redis-bridge/registry.json` and edit. At minimum set `redis_url` and `redis_password_env` (the name of the env var containing your Redis password — never embed the password in the file).
+2. **Make sure Python deps are available.** The plugin's MCP server (`python -m server`) needs `mcp` and `redis` on its Python path. `uv sync --extra dev` at the repo root covers it for development.
+3. **Connect from inside Claude Code.** Run `/redis-bridge-connect mimir` (or whatever endpoint name you configured). The session is registered with an auto-generated `<cwd-basename>-<8hex>` name, heartbeat starts.
+4. **Verify.** Run `/redis-bridge-list` to see the registry. Start another CC session in a different repo and `/redis-bridge-connect` it too; the list shows both.
+5. **Disconnect.** `/redis-bridge-disconnect` gracefully unregisters. Killing the process is also safe — the heartbeat key expires within 60s and other sessions GC the entry the next time they `list`.
 
 ## Layout
 
 ```
 plugins/redis-bridge/
 ├── .claude-plugin/plugin.json     # Claude Code plugin manifest
+├── .mcp.json                      # auto-launch the MCP server
 ├── PROTOCOL.md                    # canonical wire format
-├── docs/STATE_MACHINE.md          # router-side routing state machine
-├── agents/redis-bridge-coach.md   # behavioral hints for Claude when this channel is active
-├── skills/redis-bridge/SKILL.md   # skill metadata
-├── commands/                      # slash commands (connect, disconnect, list, etc.)
+├── docs/
+│   ├── STATE_MACHINE.md           # router-side routing state machine
+│   └── registry.example.json      # sample endpoint config
+├── agents/redis-bridge-coach.md
+├── skills/redis-bridge/SKILL.md
+├── commands/                      # slash commands (connect, disconnect, list, ...)
 ├── server/
 │   ├── __init__.py
 │   ├── __main__.py                # `python -m server` entry point
+│   ├── channel.py                 # FastMCP server: connect/disconnect/list tools
+│   ├── presence.py                # registry HSET + heartbeat thread + lifecycle pubsub
+│   ├── redis_client.py            # connection helper + password-env injection
+│   ├── registry.py                # local endpoint config loader
+│   ├── session_id.py              # auto-name generator + override validation
 │   └── protocol.py                # pydantic models matching PROTOCOL.md
-└── (tests at repo-root tests/test_redis_bridge_protocol.py, per repo convention)
+└── (tests at repo-root tests/test_redis_bridge_*.py)
 ```
 
 ## Protocol overview
@@ -57,7 +73,7 @@ Tests live at the repo root (per this repo's CLI-plugin convention), with the pl
 
 ```bash
 # From repo root:
-uv run pytest tests/test_redis_bridge_protocol.py -v
+uv run pytest tests/test_redis_bridge_*.py -v
 uv run ruff check plugins/redis-bridge/
 uv run mypy plugins/redis-bridge/server/
 ```

--- a/plugins/redis-bridge/commands/redis-bridge-connect.md
+++ b/plugins/redis-bridge/commands/redis-bridge-connect.md
@@ -1,16 +1,16 @@
 ---
 description: Connect this Claude Code session to a redis-bridge endpoint (default: mimir). Registers session presence in Redis.
-argument-hint: "[endpoint-name]"
+argument-hint: "[endpoint-name] [--session-name <name>]"
 ---
 
-Connect the current session to a configured `redis-bridge` endpoint. The endpoint must exist in `~/.claude/channels/redis-bridge/registry.json` (use `/redis-bridge list` to see configured endpoints, or `/redis-bridge configure <name>` to add one).
+Connect the current session to a configured `redis-bridge` endpoint.
 
-On success:
-- Session is registered in the Redis presence registry under an auto-generated name (`<cwd-basename>-<short-hash>`) or the value of `$CLAUDE_SESSION_NAME` if set.
-- Heartbeat starts (refresh every 10s, TTL 60s).
-- Inbound stream consumer attaches.
-- `reply` MCP tool becomes available for sending messages back to the router.
+**Action:** Call the `redis_bridge_connect` MCP tool with `endpoint` set to `$1` (or `"mimir"` if no argument). If the user supplied `--session-name <name>`, pass that as `session_name`; otherwise omit it and let the server auto-generate `<cwd-basename>-<short-hash>`.
 
-If `$1` is omitted, defaults to `mimir`.
+After the tool returns:
+- On `{"ok": true}` — report the resolved `session_name`, the endpoint, and the heartbeat interval. Briefly note that the session is now visible to the router and the heartbeat refreshes every 10s.
+- On `{"ok": false, "error": "registry not configured"}` — show the `hint` from the response and stop. The user needs to run `/redis-bridge-configure` first.
+- On `{"ok": false, "error": "endpoint not found"}` — show the `detail` (which lists available endpoints) and stop.
+- On any other `{"ok": false}` — show `error` + `detail` and stop.
 
-**Not implemented in Phase 0.** Lands in Phase 1 (presence + slash list).
+Endpoints live in `~/.claude/channels/redis-bridge/registry.json`. A second connect call automatically disconnects the previous session first.

--- a/plugins/redis-bridge/commands/redis-bridge-disconnect.md
+++ b/plugins/redis-bridge/commands/redis-bridge-disconnect.md
@@ -2,12 +2,11 @@
 description: Cleanly disconnect this Claude Code session from its redis-bridge endpoint.
 ---
 
-Disconnect the current session from its `redis-bridge` endpoint:
-- Stops inbound consumer.
-- Deletes the heartbeat key.
-- Removes session from the presence registry.
-- Publishes an `unregistered{reason:"graceful"}` lifecycle event.
+**Action:** Call the `redis_bridge_disconnect` MCP tool (no arguments).
 
-The router observes the disconnect and reverts any routing targets pointing at this session.
+After the tool returns:
+- On `{"ok": true, "was_connected": true}` — confirm the named session has been removed from the registry. Mention briefly that any router pointing at this session will lose its target (Phase 2+).
+- On `{"ok": true, "was_connected": false}` — tell the user the session wasn't connected; no action was needed.
+- On `{"ok": false}` — show `error` + `detail`.
 
-**Not implemented in Phase 0.** Lands in Phase 1.
+Effects on success: stops the heartbeat thread, deletes `cc-sessions:hb:<name>`, HDELs from `cc-sessions:registry`, and publishes an `unregistered` lifecycle event on `cc-sessions:events:<name>`.

--- a/plugins/redis-bridge/commands/redis-bridge-list.md
+++ b/plugins/redis-bridge/commands/redis-bridge-list.md
@@ -1,10 +1,18 @@
 ---
-description: List configured redis-bridge endpoints and their connection status.
+description: List all live Claude Code sessions registered at this session's connected redis-bridge endpoint.
 ---
 
-Print the configured endpoints from `~/.claude/channels/redis-bridge/registry.json`. For each:
-- Endpoint name + display name + Redis URL (password redacted).
-- Current connection status (this session connected? other session connected? unreachable?).
-- For connected endpoints, show all live registered sessions (this session highlighted).
+**Action:** Call the `redis_bridge_list` MCP tool (no arguments). Requires a prior `/redis-bridge-connect`.
 
-**Not implemented in Phase 0.** Lands in Phase 1.
+On `{"ok": true}`, render the `sessions` array as a compact table or bullet list. Useful columns:
+- `session_name` (mark `is_self: true` with `(this session)` next to the name)
+- `host`
+- `cwd`
+- `git_branch` (omit if null)
+- elapsed since `started_at`
+
+Show `count` in the header, and the `endpoint` they belong to. Sort is already by `started_at` ascending.
+
+On `{"ok": false, "error": "not connected ..."}` — tell the user to run `/redis-bridge-connect` first.
+
+Stale entries (heartbeat expired) are already filtered out and lazily GC'd from the registry by the tool — you do not need to do any extra filtering.

--- a/plugins/redis-bridge/docs/registry.example.json
+++ b/plugins/redis-bridge/docs/registry.example.json
@@ -1,0 +1,17 @@
+{
+  "endpoints": {
+    "mimir": {
+      "redis_url": "redis://jeffs-mac-mini.infiquetra.com:6379/0",
+      "redis_password_env": "HERMES_REDIS_PASSWORD",
+      "display_name": "Mimir (Hermes engineering-council profile)"
+    }
+  },
+  "defaults": {
+    "session_name_override_env": "CLAUDE_SESSION_NAME",
+    "heartbeat_seconds": 10,
+    "registry_ttl_seconds": 60,
+    "destructive_confirm_seconds": 3,
+    "permission_window_seconds": 30,
+    "consumer_block_ms": 1000
+  }
+}

--- a/plugins/redis-bridge/server/__init__.py
+++ b/plugins/redis-bridge/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/plugins/redis-bridge/server/__main__.py
+++ b/plugins/redis-bridge/server/__main__.py
@@ -1,20 +1,12 @@
-"""Entry point: `python -m server` launches the redis-bridge MCP server.
-
-Phase 0 stub — actual MCP wiring lands in Phase 1. For now, this verifies
-the module imports cleanly and exposes the package version.
-"""
+"""Entry point: `python -m server` launches the redis-bridge MCP server."""
 
 from __future__ import annotations
 
-import sys
-
-from . import __version__
+from .channel import run
 
 
 def main() -> int:
-    print(f"redis-bridge MCP channel server v{__version__}", file=sys.stderr)
-    print("Phase 0 scaffold: real MCP loop arrives in Phase 1.", file=sys.stderr)
-    return 0
+    return run()
 
 
 if __name__ == "__main__":

--- a/plugins/redis-bridge/server/channel.py
+++ b/plugins/redis-bridge/server/channel.py
@@ -1,0 +1,273 @@
+"""MCP server (stdio) for redis-bridge.
+
+Phase 1 exposes three tools:
+    - redis_bridge_connect(endpoint=..., session_name=...)
+    - redis_bridge_disconnect()
+    - redis_bridge_list()
+
+The server is single-session: at most one active Presence at a time per
+process. A second `connect` call disconnects the previous session first
+(common when re-running the slash command after a config change).
+
+Phase 2+ will add channel notifications (`notifications/claude/channel`),
+a `reply` tool, and AskUserQuestion interception. This file is the seam
+where that wiring lands.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import logging
+import signal
+import sys
+import threading
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from . import __version__
+from .presence import Presence, build_metadata, list_live_sessions
+from .redis_client import connect as redis_connect
+from .registry import (
+    EndpointNotFoundError,
+    RegistryError,
+    RegistryNotFoundError,
+    load_registry,
+)
+from .session_id import resolve_session_name
+
+log = logging.getLogger("redis_bridge.channel")
+
+
+class ServerState:
+    """Single-active-session state for the channel server.
+
+    Wrapped in a lock so heartbeat thread (in Presence) and tool-handler
+    threads (FastMCP can dispatch concurrently) don't race on lifecycle.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._presence: Presence | None = None
+        self._client: Any | None = None
+        self._endpoint_name: str | None = None
+
+    @property
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._presence is not None
+
+    def connect(
+        self, *, endpoint: str, session_name: str | None
+    ) -> dict[str, Any]:
+        try:
+            with self._lock:
+                if self._presence is not None:
+                    self._disconnect_locked(reason="reconnect")
+
+                registry = load_registry()
+                ep = registry.get(endpoint)
+                resolved_name = resolve_session_name(session_name)
+                client = redis_connect(ep)
+                metadata = build_metadata(
+                    session_name=resolved_name,
+                    endpoint=endpoint,
+                )
+                presence = Presence(
+                    client,
+                    metadata,
+                    heartbeat_seconds=registry.defaults.heartbeat_seconds,
+                    ttl_seconds=registry.defaults.registry_ttl_seconds,
+                )
+                presence.start()
+                self._presence = presence
+                self._client = client
+                self._endpoint_name = endpoint
+                return {
+                    "ok": True,
+                    "session_name": metadata.session_name,
+                    "endpoint": endpoint,
+                    "endpoint_display": ep.display_name,
+                    "host": metadata.host,
+                    "cwd": metadata.cwd,
+                    "heartbeat_seconds": registry.defaults.heartbeat_seconds,
+                    "registry_ttl_seconds": registry.defaults.registry_ttl_seconds,
+                }
+        except RegistryError as e:
+            return _format_registry_error(e)
+        except ValueError as e:
+            return {"ok": False, "error": "invalid argument", "detail": str(e)}
+        except RuntimeError as e:
+            return {"ok": False, "error": "runtime error", "detail": str(e)}
+        except Exception as e:  # noqa: BLE001
+            log.exception("connect failed")
+            return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def disconnect(self) -> dict[str, Any]:
+        try:
+            with self._lock:
+                if self._presence is None:
+                    return {"ok": True, "was_connected": False}
+                session_name = self._presence.session_name
+                self._disconnect_locked(reason="user")
+                return {"ok": True, "was_connected": True, "session_name": session_name}
+        except Exception as e:  # noqa: BLE001
+            log.exception("disconnect failed")
+            return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def list_sessions(self) -> dict[str, Any]:
+        try:
+            with self._lock:
+                if self._client is None:
+                    return {
+                        "ok": False,
+                        "error": "not connected — call redis_bridge_connect first",
+                    }
+                sessions = list_live_sessions(self._client, gc_stale=True)
+                return {
+                    "ok": True,
+                    "endpoint": self._endpoint_name,
+                    "count": len(sessions),
+                    "sessions": [
+                        {
+                            "session_name": m.session_name,
+                            "host": m.host,
+                            "cwd": m.cwd,
+                            "git_branch": m.git_branch,
+                            "started_at": m.started_at,
+                            "pid": m.pid,
+                            "is_self": (
+                                self._presence is not None
+                                and m.session_name == self._presence.session_name
+                            ),
+                        }
+                        for m in sorted(
+                            sessions.values(), key=lambda meta: meta.started_at
+                        )
+                    ],
+                }
+        except Exception as e:  # noqa: BLE001
+            log.exception("list failed")
+            return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def shutdown(self) -> None:
+        """Best-effort cleanup on process exit."""
+        with self._lock:
+            if self._presence is not None:
+                self._disconnect_locked(reason="shutdown")
+
+    def _disconnect_locked(self, *, reason: str) -> None:
+        if self._presence is not None:
+            try:
+                self._presence.stop(reason=reason)
+            except Exception:  # noqa: BLE001
+                log.exception("presence.stop raised during disconnect")
+            self._presence = None
+        if self._client is not None:
+            try:
+                close = getattr(self._client, "close", None)
+                if callable(close):
+                    close()
+            except Exception:  # noqa: BLE001
+                log.exception("redis client close raised during disconnect")
+            self._client = None
+        self._endpoint_name = None
+
+
+_STATE = ServerState()
+
+
+def _format_registry_error(err: RegistryError) -> dict[str, Any]:
+    if isinstance(err, RegistryNotFoundError):
+        return {
+            "ok": False,
+            "error": "registry not configured",
+            "detail": str(err),
+            "hint": (
+                "Create ~/.claude/channels/redis-bridge/registry.json or run "
+                "/redis-bridge-configure"
+            ),
+        }
+    if isinstance(err, EndpointNotFoundError):
+        return {"ok": False, "error": "endpoint not found", "detail": str(err)}
+    return {"ok": False, "error": "registry parse error", "detail": str(err)}
+
+
+def build_app() -> FastMCP:
+    """Construct the FastMCP app with all Phase 1 tools registered."""
+    app = FastMCP(
+        name=f"redis-bridge v{__version__}",
+        instructions=(
+            "Generic Redis-streams bridge for Claude Code sessions. "
+            "Pair with a router (e.g. hermes-claude-code-router) on the consumer "
+            "side. Phase 1: presence + listing. Later phases add bidirectional "
+            "channel notifications + reply tool."
+        ),
+    )
+
+    @app.tool(
+        name="redis_bridge_connect",
+        description=(
+            "Connect this Claude Code session to a redis-bridge endpoint "
+            "(typically a Hermes profile like 'mimir'). Registers in the shared "
+            "Redis registry and starts a 10s heartbeat. Returns the resolved "
+            "session_name and endpoint metadata."
+        ),
+    )
+    def redis_bridge_connect(
+        endpoint: str = "mimir",
+        session_name: str | None = None,
+    ) -> dict[str, Any]:
+        return _STATE.connect(endpoint=endpoint, session_name=session_name)
+
+    @app.tool(
+        name="redis_bridge_disconnect",
+        description=(
+            "Gracefully disconnect from the redis-bridge endpoint: stops "
+            "heartbeat, removes the session from the registry, and emits an "
+            "'unregistered' lifecycle event."
+        ),
+    )
+    def redis_bridge_disconnect() -> dict[str, Any]:
+        return _STATE.disconnect()
+
+    @app.tool(
+        name="redis_bridge_list",
+        description=(
+            "List all live Claude Code sessions registered at the connected "
+            "endpoint. Filters out sessions whose heartbeat has expired and "
+            "lazily GCs them from the registry. Requires a prior connect."
+        ),
+    )
+    def redis_bridge_list() -> dict[str, Any]:
+        return _STATE.list_sessions()
+
+    return app
+
+
+def _install_signal_handlers() -> None:
+    def _handle(signum, _frame) -> None:  # noqa: ANN001
+        log.info("received signal %s — shutting down", signum)
+        _STATE.shutdown()
+        sys.exit(0)
+
+    # Signal handlers can only be installed in the main thread; if we're
+    # not, FastMCP / atexit will still cover cleanup.
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        with contextlib.suppress(ValueError):
+            signal.signal(sig, _handle)
+
+
+def run() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+    log.info("redis-bridge v%s starting (stdio)", __version__)
+    atexit.register(_STATE.shutdown)
+    _install_signal_handlers()
+    app = build_app()
+    app.run()  # blocks until stdio closes
+    return 0

--- a/plugins/redis-bridge/server/channel.py
+++ b/plugins/redis-bridge/server/channel.py
@@ -58,9 +58,7 @@ class ServerState:
         with self._lock:
             return self._presence is not None
 
-    def connect(
-        self, *, endpoint: str, session_name: str | None
-    ) -> dict[str, Any]:
+    def connect(self, *, endpoint: str, session_name: str | None) -> dict[str, Any]:
         try:
             with self._lock:
                 if self._presence is not None:
@@ -142,9 +140,7 @@ class ServerState:
                                 and m.session_name == self._presence.session_name
                             ),
                         }
-                        for m in sorted(
-                            sessions.values(), key=lambda meta: meta.started_at
-                        )
+                        for m in sorted(sessions.values(), key=lambda meta: meta.started_at)
                     ],
                 }
         except Exception as e:  # noqa: BLE001

--- a/plugins/redis-bridge/server/presence.py
+++ b/plugins/redis-bridge/server/presence.py
@@ -110,9 +110,7 @@ def is_live(client: RedisLike, session_name: str) -> bool:
     return bool(client.exists(hb_key(session_name)))
 
 
-def list_live_sessions(
-    client: RedisLike, *, gc_stale: bool = False
-) -> dict[str, SessionMetadata]:
+def list_live_sessions(client: RedisLike, *, gc_stale: bool = False) -> dict[str, SessionMetadata]:
     """Return live sessions from the registry, filtered by hb key existence.
 
     With `gc_stale=True`, also HDEL any registry entries whose hb key has
@@ -192,8 +190,12 @@ class Presence:
         )
         self._thread.start()
         self._started = True
-        log.info("registered session %s (heartbeat every %ds, ttl %ds)",
-                 self.session_name, self._heartbeat_seconds, self._ttl_seconds)
+        log.info(
+            "registered session %s (heartbeat every %ds, ttl %ds)",
+            self.session_name,
+            self._heartbeat_seconds,
+            self._ttl_seconds,
+        )
 
     def stop(self, *, reason: str = "graceful") -> None:
         """Stop heartbeat, unregister, and publish lifecycle event."""

--- a/plugins/redis-bridge/server/presence.py
+++ b/plugins/redis-bridge/server/presence.py
@@ -1,0 +1,256 @@
+"""Presence tracking for redis-bridge sessions.
+
+Implements the registry contract from PROTOCOL.md:
+
+    HSET   cc-sessions:registry <name> <metadata JSON>     # static
+    SET    cc-sessions:hb:<name> <ts> EX 60                # per-beat
+    PUBLISH cc-sessions:events:<name> <lifecycle JSON>     # transitions
+
+Heartbeat runs on a background daemon thread that wakes every
+`heartbeat_seconds` (default 10) and refreshes the hb key with the
+configured TTL (default 60). Stop is graceful via an Event; the
+thread also unregisters on its own way out if the main process is
+exiting cleanly.
+
+Stale-entry GC: callers that read the registry should filter by
+`is_live()` and may opt to HDEL stale entries. This is lazy on
+purpose — there is no central GC, only "everyone cleans up after
+themselves on read".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .redis_client import RedisLike
+
+log = logging.getLogger(__name__)
+
+REGISTRY_KEY = "cc-sessions:registry"
+HB_KEY_PREFIX = "cc-sessions:hb:"
+EVENTS_CHANNEL_PREFIX = "cc-sessions:events:"
+
+
+def hb_key(session_name: str) -> str:
+    return f"{HB_KEY_PREFIX}{session_name}"
+
+
+def events_channel(session_name: str) -> str:
+    return f"{EVENTS_CHANNEL_PREFIX}{session_name}"
+
+
+@dataclass(frozen=True, slots=True)
+class SessionMetadata:
+    """Static registry payload for a CC session.
+
+    Written once on register, refreshed on rename. The `last_heartbeat`
+    field is informational only — the authoritative liveness signal is
+    the existence of the hb:<name> key.
+    """
+
+    session_name: str
+    host: str
+    cwd: str
+    git_branch: str | None
+    started_at: float
+    pid: int
+    endpoint: str
+    extras: dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> SessionMetadata:
+        data = json.loads(raw)
+        return cls(
+            session_name=data["session_name"],
+            host=data["host"],
+            cwd=data["cwd"],
+            git_branch=data.get("git_branch"),
+            started_at=float(data["started_at"]),
+            pid=int(data["pid"]),
+            endpoint=data.get("endpoint", "unknown"),
+            extras=dict(data.get("extras") or {}),
+        )
+
+
+def build_metadata(
+    *,
+    session_name: str,
+    endpoint: str,
+    cwd: str | None = None,
+    host: str | None = None,
+    git_branch: str | None = None,
+    started_at: float | None = None,
+    extras: dict[str, str] | None = None,
+) -> SessionMetadata:
+    return SessionMetadata(
+        session_name=session_name,
+        host=host or socket.gethostname(),
+        cwd=cwd or os.getcwd(),
+        git_branch=git_branch,
+        started_at=started_at if started_at is not None else time.time(),
+        pid=os.getpid(),
+        endpoint=endpoint,
+        extras=dict(extras or {}),
+    )
+
+
+def is_live(client: RedisLike, session_name: str) -> bool:
+    """True iff the per-session heartbeat key exists."""
+    return bool(client.exists(hb_key(session_name)))
+
+
+def list_live_sessions(
+    client: RedisLike, *, gc_stale: bool = False
+) -> dict[str, SessionMetadata]:
+    """Return live sessions from the registry, filtered by hb key existence.
+
+    With `gc_stale=True`, also HDEL any registry entries whose hb key has
+    expired. Returned dict is keyed by session_name.
+    """
+    raw = client.hgetall(REGISTRY_KEY)
+    live: dict[str, SessionMetadata] = {}
+    stale: list[str] = []
+    for name, body in raw.items():
+        try:
+            meta = SessionMetadata.from_json(body)
+        except (ValueError, KeyError, json.JSONDecodeError):
+            log.warning("registry entry %r is corrupt; treating as stale", name)
+            stale.append(name)
+            continue
+        if is_live(client, name):
+            live[name] = meta
+        else:
+            stale.append(name)
+    if gc_stale and stale:
+        client.hdel(REGISTRY_KEY, *stale)
+        log.info("GC'd %d stale registry entries: %s", len(stale), stale)
+    return live
+
+
+class Presence:
+    """Manages registration + heartbeat for one CC session.
+
+    Lifecycle:
+        p = Presence(client, metadata, heartbeat_seconds=10, ttl_seconds=60)
+        p.start()        # registers + spawns heartbeat thread
+        ...
+        p.stop()         # graceful unregister
+    """
+
+    def __init__(
+        self,
+        client: RedisLike,
+        metadata: SessionMetadata,
+        *,
+        heartbeat_seconds: int = 10,
+        ttl_seconds: int = 60,
+    ) -> None:
+        if ttl_seconds <= heartbeat_seconds:
+            raise ValueError(
+                f"ttl_seconds ({ttl_seconds}) must exceed heartbeat_seconds "
+                f"({heartbeat_seconds}); otherwise the key can expire between beats"
+            )
+        self._client = client
+        self._metadata = metadata
+        self._heartbeat_seconds = heartbeat_seconds
+        self._ttl_seconds = ttl_seconds
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started = False
+
+    @property
+    def session_name(self) -> str:
+        return self._metadata.session_name
+
+    @property
+    def metadata(self) -> SessionMetadata:
+        return self._metadata
+
+    def start(self) -> None:
+        """Register in Redis and spawn the heartbeat thread."""
+        if self._started:
+            raise RuntimeError(f"Presence({self.session_name}) already started")
+        self._client.hset(REGISTRY_KEY, self.session_name, self._metadata.to_json())
+        self._beat_once()
+        self._publish_lifecycle("registered")
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name=f"redis-bridge-hb-{self.session_name}",
+            daemon=True,
+        )
+        self._thread.start()
+        self._started = True
+        log.info("registered session %s (heartbeat every %ds, ttl %ds)",
+                 self.session_name, self._heartbeat_seconds, self._ttl_seconds)
+
+    def stop(self, *, reason: str = "graceful") -> None:
+        """Stop heartbeat, unregister, and publish lifecycle event."""
+        if not self._started:
+            return
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._heartbeat_seconds + 2)
+            self._thread = None
+        # Best-effort cleanup; swallow errors so __exit__ never raises.
+        try:
+            self._client.delete(hb_key(self.session_name))
+            self._client.hdel(REGISTRY_KEY, self.session_name)
+            self._publish_lifecycle("unregistered", extra={"reason": reason})
+        except Exception:  # noqa: BLE001
+            log.exception("cleanup failed for session %s", self.session_name)
+        self._started = False
+        log.info("unregistered session %s (reason=%s)", self.session_name, reason)
+
+    def __enter__(self) -> Presence:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop(reason="graceful" if exc_type is None else "exception")
+
+    def _loop(self) -> None:
+        while not self._stop_event.wait(self._heartbeat_seconds):
+            try:
+                self._beat_once()
+            except Exception:  # noqa: BLE001
+                log.exception("heartbeat failed for session %s", self.session_name)
+                # Don't exit on transient errors; the next tick may recover.
+
+    def _beat_once(self) -> None:
+        self._client.set(
+            hb_key(self.session_name),
+            str(time.time()),
+            ex=self._ttl_seconds,
+        )
+
+    def _publish_lifecycle(self, event_type: str, extra: dict | None = None) -> None:
+        payload = {
+            "v": 1,
+            "type": event_type,
+            "session_name": self.session_name,
+            "ts": time.time(),
+        }
+        if extra:
+            payload.update(extra)
+        try:
+            # redis-py's publish() accepts the channel via the client; we use
+            # the same client interface here. RedisLike doesn't declare it,
+            # so guard for fakeredis/test doubles that may omit it.
+            publish = getattr(self._client, "publish", None)
+            if publish is None:
+                return
+            publish(events_channel(self.session_name), json.dumps(payload))
+        except Exception:  # noqa: BLE001
+            log.exception("publish lifecycle event %s failed", event_type)

--- a/plugins/redis-bridge/server/redis_client.py
+++ b/plugins/redis-bridge/server/redis_client.py
@@ -1,0 +1,61 @@
+"""Redis connection helper for redis-bridge.
+
+Centralizes URL parsing + password injection from env so the rest of the
+server doesn't have to think about how the password gets in. Connection
+pooling lives in the redis library; we just hand back a Redis client.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import redis
+
+from .registry import Endpoint
+
+# The actual `redis.Redis` and `fakeredis.FakeRedis` types are wide unions
+# (sync vs async, multiple return shapes). We type the surface as Any to
+# avoid leaking that complexity into call sites; the runtime duck-typing
+# works for both clients without further constraint.
+RedisLike = Any
+
+
+def resolve_url_with_password(endpoint: Endpoint) -> str:
+    """Return the Redis URL with the password substituted from env, if any.
+
+    If `redis_password_env` is set, the named env var must be present and
+    non-empty. We refuse to fall back to a passwordless connect when a
+    password was specified — that masks a misconfiguration and lets the
+    plugin silently talk to the wrong Redis.
+    """
+    if not endpoint.redis_password_env:
+        return endpoint.redis_url
+    password = os.environ.get(endpoint.redis_password_env)
+    if not password:
+        raise RuntimeError(
+            f"endpoint {endpoint.name!r} requires password env var "
+            f"{endpoint.redis_password_env!r} but it is unset or empty"
+        )
+    parsed = urlparse(endpoint.redis_url)
+    # Build netloc with password injected; keep username if present (rare).
+    user = parsed.username or ""
+    host = parsed.hostname or ""
+    port_suffix = f":{parsed.port}" if parsed.port else ""
+    auth_prefix = f"{user}:{password}@" if user else f":{password}@"
+    netloc = f"{auth_prefix}{host}{port_suffix}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def connect(endpoint: Endpoint, *, socket_timeout: float = 5.0) -> redis.Redis:
+    """Open and ping a Redis client. Raises on auth/network failure."""
+    url = resolve_url_with_password(endpoint)
+    client = redis.Redis.from_url(
+        url,
+        decode_responses=True,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_timeout,
+    )
+    client.ping()
+    return client

--- a/plugins/redis-bridge/server/registry.py
+++ b/plugins/redis-bridge/server/registry.py
@@ -128,25 +128,17 @@ def load_registry(path: Path | None = None) -> Registry:
         session_name_override_env=defaults_raw.get(
             "session_name_override_env", base.session_name_override_env
         ),
-        heartbeat_seconds=int(
-            defaults_raw.get("heartbeat_seconds", base.heartbeat_seconds)
-        ),
+        heartbeat_seconds=int(defaults_raw.get("heartbeat_seconds", base.heartbeat_seconds)),
         registry_ttl_seconds=int(
             defaults_raw.get("registry_ttl_seconds", base.registry_ttl_seconds)
         ),
         destructive_confirm_seconds=int(
-            defaults_raw.get(
-                "destructive_confirm_seconds", base.destructive_confirm_seconds
-            )
+            defaults_raw.get("destructive_confirm_seconds", base.destructive_confirm_seconds)
         ),
         permission_window_seconds=int(
-            defaults_raw.get(
-                "permission_window_seconds", base.permission_window_seconds
-            )
+            defaults_raw.get("permission_window_seconds", base.permission_window_seconds)
         ),
-        consumer_block_ms=int(
-            defaults_raw.get("consumer_block_ms", base.consumer_block_ms)
-        ),
+        consumer_block_ms=int(defaults_raw.get("consumer_block_ms", base.consumer_block_ms)),
     )
 
     return Registry(endpoints=endpoints, defaults=defaults, source=cfg_path)

--- a/plugins/redis-bridge/server/registry.py
+++ b/plugins/redis-bridge/server/registry.py
@@ -1,0 +1,152 @@
+"""Local config reader for redis-bridge endpoints.
+
+The endpoint registry lives at `~/.claude/channels/redis-bridge/registry.json`
+and lists the Redis backends this CC plugin can connect to (typically one per
+Hermes profile: mimir, freya, etc).
+
+Schema:
+    {
+      "endpoints": {
+        "<name>": {
+          "redis_url": "redis://host:6379/0",
+          "redis_password_env": "HERMES_REDIS_PASSWORD",
+          "display_name": "Human label"
+        }, ...
+      },
+      "defaults": {
+        "session_name_override_env": "CLAUDE_SESSION_NAME",
+        "heartbeat_seconds": 10,
+        "registry_ttl_seconds": 60,
+        "destructive_confirm_seconds": 3,
+        "permission_window_seconds": 30,
+        "consumer_block_ms": 1000
+      }
+    }
+
+A missing file is treated as "no endpoints configured" — surfaces a friendly
+error to the user via the connect tool.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path("~/.claude/channels/redis-bridge/registry.json").expanduser()
+
+
+@dataclass(frozen=True, slots=True)
+class Endpoint:
+    name: str
+    redis_url: str
+    redis_password_env: str | None
+    display_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class Defaults:
+    session_name_override_env: str = "CLAUDE_SESSION_NAME"
+    heartbeat_seconds: int = 10
+    registry_ttl_seconds: int = 60
+    destructive_confirm_seconds: int = 3
+    permission_window_seconds: int = 30
+    consumer_block_ms: int = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class Registry:
+    endpoints: dict[str, Endpoint]
+    defaults: Defaults
+    source: Path
+
+    def get(self, name: str) -> Endpoint:
+        try:
+            return self.endpoints[name]
+        except KeyError as e:
+            available = ", ".join(sorted(self.endpoints)) or "<none>"
+            raise EndpointNotFoundError(
+                f"endpoint {name!r} not in registry (available: {available})"
+            ) from e
+
+
+class RegistryError(Exception):
+    """Base for registry config errors."""
+
+
+class RegistryNotFoundError(RegistryError):
+    """The registry.json file does not exist."""
+
+
+class RegistryParseError(RegistryError):
+    """The registry.json file exists but is malformed."""
+
+
+class EndpointNotFoundError(RegistryError):
+    """The named endpoint is not present in the registry."""
+
+
+def load_registry(path: Path | None = None) -> Registry:
+    """Read and validate the endpoint registry.
+
+    Raises RegistryNotFoundError if the file is missing; the caller surfaces
+    that to the user with instructions to run `/redis-bridge-configure`.
+    """
+    cfg_path = path or DEFAULT_CONFIG_PATH
+    if not cfg_path.exists():
+        raise RegistryNotFoundError(
+            f"registry config not found at {cfg_path} — run /redis-bridge-configure to create"
+        )
+    try:
+        raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RegistryParseError(f"{cfg_path}: invalid JSON: {e}") from e
+    if not isinstance(raw, dict):
+        raise RegistryParseError(f"{cfg_path}: top-level must be object")
+
+    endpoints_raw = raw.get("endpoints") or {}
+    if not isinstance(endpoints_raw, dict):
+        raise RegistryParseError(f"{cfg_path}: 'endpoints' must be object")
+
+    endpoints: dict[str, Endpoint] = {}
+    for name, body in endpoints_raw.items():
+        if not isinstance(body, dict):
+            raise RegistryParseError(f"{cfg_path}: endpoint {name!r} must be object")
+        url = body.get("redis_url")
+        if not isinstance(url, str) or not url:
+            raise RegistryParseError(f"{cfg_path}: endpoint {name!r} missing 'redis_url'")
+        endpoints[name] = Endpoint(
+            name=name,
+            redis_url=url,
+            redis_password_env=body.get("redis_password_env"),
+            display_name=body.get("display_name") or name,
+        )
+
+    defaults_raw = raw.get("defaults") or {}
+    base = Defaults()  # dataclass-default values
+    defaults = Defaults(
+        session_name_override_env=defaults_raw.get(
+            "session_name_override_env", base.session_name_override_env
+        ),
+        heartbeat_seconds=int(
+            defaults_raw.get("heartbeat_seconds", base.heartbeat_seconds)
+        ),
+        registry_ttl_seconds=int(
+            defaults_raw.get("registry_ttl_seconds", base.registry_ttl_seconds)
+        ),
+        destructive_confirm_seconds=int(
+            defaults_raw.get(
+                "destructive_confirm_seconds", base.destructive_confirm_seconds
+            )
+        ),
+        permission_window_seconds=int(
+            defaults_raw.get(
+                "permission_window_seconds", base.permission_window_seconds
+            )
+        ),
+        consumer_block_ms=int(
+            defaults_raw.get("consumer_block_ms", base.consumer_block_ms)
+        ),
+    )
+
+    return Registry(endpoints=endpoints, defaults=defaults, source=cfg_path)

--- a/plugins/redis-bridge/server/session_id.py
+++ b/plugins/redis-bridge/server/session_id.py
@@ -1,0 +1,70 @@
+"""Session identity generation for redis-bridge.
+
+Auto-name pattern: `<cwd-basename>-<short-hash>`, where short-hash is the
+first 8 hex chars of sha256(cwd + host). This is stable across restarts
+of the same CC session (same cwd, same host) yet unique across machines
+and across project directories.
+
+The `CLAUDE_SESSION_NAME` env var overrides the auto-name. A user-supplied
+name is used verbatim after validation (slug regex).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import socket
+from pathlib import Path
+
+# Conservative slug: lowercase, digits, hyphen, underscore; 1-64 chars.
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+_ENV_OVERRIDE = "CLAUDE_SESSION_NAME"
+
+
+def _sanitize_basename(name: str) -> str:
+    """Lowercase, replace non-slug chars with hyphen, collapse repeats, strip."""
+    cleaned = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return cleaned or "session"
+
+
+def _short_hash(cwd: str, host: str) -> str:
+    digest = hashlib.sha256(f"{cwd}|{host}".encode()).hexdigest()
+    return digest[:8]
+
+
+def is_valid_session_name(name: str) -> bool:
+    return bool(_NAME_RE.match(name))
+
+
+def auto_session_name(cwd: str | os.PathLike[str] | None = None, host: str | None = None) -> str:
+    """Generate the auto-name from cwd + host.
+
+    Stable for a given (cwd, host) pair. Does not consult env override.
+    """
+    cwd_str = str(Path(cwd or os.getcwd()).resolve())
+    host_str = host or socket.gethostname()
+    basename = _sanitize_basename(Path(cwd_str).name)
+    return f"{basename}-{_short_hash(cwd_str, host_str)}"
+
+
+def resolve_session_name(
+    override: str | None = None,
+    cwd: str | os.PathLike[str] | None = None,
+    host: str | None = None,
+) -> str:
+    """Return the effective session name.
+
+    Precedence: explicit `override` arg → env var → auto-name. The override
+    must satisfy `is_valid_session_name`; otherwise raises ValueError.
+    """
+    candidate = override if override is not None else os.environ.get(_ENV_OVERRIDE)
+    if candidate:
+        candidate = candidate.strip()
+        if not is_valid_session_name(candidate):
+            raise ValueError(
+                f"invalid session name {candidate!r}: must match {_NAME_RE.pattern}"
+            )
+        return candidate
+    return auto_session_name(cwd=cwd, host=host)

--- a/plugins/redis-bridge/server/session_id.py
+++ b/plugins/redis-bridge/server/session_id.py
@@ -63,8 +63,6 @@ def resolve_session_name(
     if candidate:
         candidate = candidate.strip()
         if not is_valid_session_name(candidate):
-            raise ValueError(
-                f"invalid session name {candidate!r}: must match {_NAME_RE.pattern}"
-            )
+            raise ValueError(f"invalid session name {candidate!r}: must match {_NAME_RE.pattern}")
         return candidate
     return auto_session_name(cwd=cwd, host=host)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "pyyaml>=6.0",
     "boto3>=1.34.0",
     "requests>=2.31.0",
+    "pydantic>=2.5",
+    "redis>=5.0",
+    "mcp>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -27,6 +30,7 @@ dev = [
     "safety>=3.0.0",
     "types-PyYAML>=6.0",
     "types-requests>=2.31",
+    "fakeredis>=2.20",
 ]
 ebay = [
     "Pillow>=10.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,17 @@
 """Shared pytest fixtures for Infiquetra plugin tests."""
 
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+# Make `plugins/redis-bridge/server/*` importable without installing.
+# The plugin dir contains a hyphen so it isn't a valid Python package name —
+# we put the *plugin* dir on sys.path so `from server.foo import ...` works.
+_REDIS_BRIDGE_ROOT = Path(__file__).parent.parent / "plugins" / "redis-bridge"
+if str(_REDIS_BRIDGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REDIS_BRIDGE_ROOT))
 
 
 @pytest.fixture

--- a/tests/test_redis_bridge_channel.py
+++ b/tests/test_redis_bridge_channel.py
@@ -19,7 +19,9 @@ from server import channel, presence  # type: ignore[import-not-found]
 
 
 @pytest.fixture
-def fr() -> fakeredis.FakeRedis:
+def fr() -> Any:
+    # Returns the real fakeredis client; typed as Any so redis-py's
+    # Awaitable[X] | X return types don't propagate into the tests.
     return fakeredis.FakeRedis(decode_responses=True)
 
 
@@ -50,7 +52,7 @@ def registry_file(tmp_path: Path) -> Path:
 @pytest.fixture
 def patched_state(
     monkeypatch: pytest.MonkeyPatch,
-    fr: fakeredis.FakeRedis,
+    fr: Any,
     registry_file: Path,
 ) -> channel.ServerState:
     """Build a ServerState whose Redis connect returns the fakeredis instance,
@@ -70,7 +72,7 @@ def patched_state(
 
 
 def test_connect_registers_and_starts_heartbeat(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+    patched_state: channel.ServerState, fr: Any
 ) -> None:
     out = patched_state.connect(endpoint="mimir", session_name="my-session")
     try:
@@ -89,9 +91,7 @@ def test_connect_registers_and_starts_heartbeat(
         patched_state.disconnect()
 
 
-def test_connect_uses_auto_name_when_omitted(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_connect_uses_auto_name_when_omitted(patched_state: channel.ServerState, fr: Any) -> None:
     out = patched_state.connect(endpoint="mimir", session_name=None)
     try:
         assert out["ok"] is True
@@ -103,9 +103,7 @@ def test_connect_uses_auto_name_when_omitted(
         patched_state.disconnect()
 
 
-def test_disconnect_clears_state(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_disconnect_clears_state(patched_state: channel.ServerState, fr: Any) -> None:
     patched_state.connect(endpoint="mimir", session_name="bye")
     assert patched_state.is_connected
     out = patched_state.disconnect()
@@ -122,9 +120,7 @@ def test_disconnect_when_not_connected_is_idempotent(
     assert out == {"ok": True, "was_connected": False}
 
 
-def test_second_connect_replaces_first(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_second_connect_replaces_first(patched_state: channel.ServerState, fr: Any) -> None:
     patched_state.connect(endpoint="mimir", session_name="first")
     patched_state.connect(endpoint="mimir", session_name="second")
     try:
@@ -141,9 +137,7 @@ def test_list_requires_connection(patched_state: channel.ServerState) -> None:
     assert "not connected" in out["error"]
 
 
-def test_list_returns_self(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_list_returns_self(patched_state: channel.ServerState, fr: Any) -> None:
     patched_state.connect(endpoint="mimir", session_name="solo")
     try:
         out = patched_state.list_sessions()
@@ -156,9 +150,7 @@ def test_list_returns_self(
         patched_state.disconnect()
 
 
-def test_list_returns_other_live_sessions(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_list_returns_other_live_sessions(patched_state: channel.ServerState, fr: Any) -> None:
     """Simulate another CC session by writing to the registry directly."""
     other_meta = presence.build_metadata(
         session_name="other-session",
@@ -185,9 +177,7 @@ def test_list_returns_other_live_sessions(
         patched_state.disconnect()
 
 
-def test_list_gcs_stale_entries(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_list_gcs_stale_entries(patched_state: channel.ServerState, fr: Any) -> None:
     stale_meta = presence.build_metadata(
         session_name="ghost",
         endpoint="mimir",
@@ -207,9 +197,7 @@ def test_list_gcs_stale_entries(
         patched_state.disconnect()
 
 
-def test_connect_with_missing_registry(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_connect_with_missing_registry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """When registry.json doesn't exist, connect returns a structured error."""
 
     def fake_load_registry() -> Any:
@@ -240,9 +228,7 @@ def test_connect_with_invalid_session_name(
     assert out["error"] == "invalid argument"
 
 
-def test_shutdown_disconnects_active_session(
-    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
-) -> None:
+def test_shutdown_disconnects_active_session(patched_state: channel.ServerState, fr: Any) -> None:
     patched_state.connect(endpoint="mimir", session_name="atexit-test")
     patched_state.shutdown()
     assert not patched_state.is_connected

--- a/tests/test_redis_bridge_channel.py
+++ b/tests/test_redis_bridge_channel.py
@@ -1,0 +1,267 @@
+"""Tests for the redis-bridge MCP server's ServerState (connect/disconnect/list).
+
+We test the ServerState class directly rather than going through FastMCP —
+that exercises every real component (registry loading, redis client wrapper,
+Presence lifecycle, stale-GC) while keeping the test surface simple. The
+FastMCP wrapper is mostly glue and is exercised manually via the build_app
+smoke check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import fakeredis
+import pytest
+from server import channel, presence  # type: ignore[import-not-found]
+
+
+@pytest.fixture
+def fr() -> fakeredis.FakeRedis:
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def registry_file(tmp_path: Path) -> Path:
+    p = tmp_path / "registry.json"
+    p.write_text(
+        json.dumps(
+            {
+                "endpoints": {
+                    "mimir": {
+                        "redis_url": "redis://test:6379/0",
+                        "redis_password_env": None,
+                        "display_name": "Mimir (test)",
+                    }
+                },
+                "defaults": {
+                    "heartbeat_seconds": 1,
+                    "registry_ttl_seconds": 10,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def patched_state(
+    monkeypatch: pytest.MonkeyPatch,
+    fr: fakeredis.FakeRedis,
+    registry_file: Path,
+) -> channel.ServerState:
+    """Build a ServerState whose Redis connect returns the fakeredis instance,
+    and whose load_registry reads from our temp file."""
+
+    def fake_load_registry() -> Any:
+        from server import registry as registry_mod  # type: ignore[import-not-found]
+
+        return registry_mod.load_registry(registry_file)
+
+    def fake_connect(_endpoint: Any) -> Any:
+        return fr
+
+    monkeypatch.setattr(channel, "load_registry", fake_load_registry)
+    monkeypatch.setattr(channel, "redis_connect", fake_connect)
+    return channel.ServerState()
+
+
+def test_connect_registers_and_starts_heartbeat(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    out = patched_state.connect(endpoint="mimir", session_name="my-session")
+    try:
+        assert out["ok"] is True
+        assert out["session_name"] == "my-session"
+        assert out["endpoint"] == "mimir"
+        assert out["endpoint_display"] == "Mimir (test)"
+        assert out["heartbeat_seconds"] == 1
+        assert out["registry_ttl_seconds"] == 10
+        # registry should have the entry
+        raw = fr.hget(presence.REGISTRY_KEY, "my-session")
+        assert raw is not None
+        # hb key must exist
+        assert fr.exists(presence.hb_key("my-session")) == 1
+    finally:
+        patched_state.disconnect()
+
+
+def test_connect_uses_auto_name_when_omitted(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    out = patched_state.connect(endpoint="mimir", session_name=None)
+    try:
+        assert out["ok"] is True
+        # Auto-name format: <slug>-<8 hex>
+        assert "-" in out["session_name"]
+        suffix = out["session_name"].rsplit("-", 1)[1]
+        assert len(suffix) == 8
+    finally:
+        patched_state.disconnect()
+
+
+def test_disconnect_clears_state(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    patched_state.connect(endpoint="mimir", session_name="bye")
+    assert patched_state.is_connected
+    out = patched_state.disconnect()
+    assert out == {"ok": True, "was_connected": True, "session_name": "bye"}
+    assert not patched_state.is_connected
+    assert fr.hget(presence.REGISTRY_KEY, "bye") is None
+    assert fr.exists(presence.hb_key("bye")) == 0
+
+
+def test_disconnect_when_not_connected_is_idempotent(
+    patched_state: channel.ServerState,
+) -> None:
+    out = patched_state.disconnect()
+    assert out == {"ok": True, "was_connected": False}
+
+
+def test_second_connect_replaces_first(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    patched_state.connect(endpoint="mimir", session_name="first")
+    patched_state.connect(endpoint="mimir", session_name="second")
+    try:
+        assert fr.hget(presence.REGISTRY_KEY, "first") is None
+        assert fr.exists(presence.hb_key("first")) == 0
+        assert fr.hget(presence.REGISTRY_KEY, "second") is not None
+    finally:
+        patched_state.disconnect()
+
+
+def test_list_requires_connection(patched_state: channel.ServerState) -> None:
+    out = patched_state.list_sessions()
+    assert out["ok"] is False
+    assert "not connected" in out["error"]
+
+
+def test_list_returns_self(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    patched_state.connect(endpoint="mimir", session_name="solo")
+    try:
+        out = patched_state.list_sessions()
+        assert out["ok"] is True
+        assert out["count"] == 1
+        assert out["sessions"][0]["session_name"] == "solo"
+        assert out["sessions"][0]["is_self"] is True
+        assert out["endpoint"] == "mimir"
+    finally:
+        patched_state.disconnect()
+
+
+def test_list_returns_other_live_sessions(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    """Simulate another CC session by writing to the registry directly."""
+    other_meta = presence.build_metadata(
+        session_name="other-session",
+        endpoint="mimir",
+        cwd="/elsewhere",
+        host="other-host",
+        started_at=500.0,
+    )
+    fr.hset(presence.REGISTRY_KEY, "other-session", other_meta.to_json())
+    fr.set(presence.hb_key("other-session"), "now", ex=60)
+
+    patched_state.connect(endpoint="mimir", session_name="mine")
+    try:
+        out = patched_state.list_sessions()
+        assert out["ok"] is True
+        assert out["count"] == 2
+        names = {s["session_name"] for s in out["sessions"]}
+        assert names == {"mine", "other-session"}
+        self_flags = {s["session_name"]: s["is_self"] for s in out["sessions"]}
+        assert self_flags == {"mine": True, "other-session": False}
+        # ordered by started_at ascending (other was 500.0)
+        assert out["sessions"][0]["session_name"] == "other-session"
+    finally:
+        patched_state.disconnect()
+
+
+def test_list_gcs_stale_entries(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    stale_meta = presence.build_metadata(
+        session_name="ghost",
+        endpoint="mimir",
+        cwd="/gone",
+        host="gone-host",
+    )
+    fr.hset(presence.REGISTRY_KEY, "ghost", stale_meta.to_json())
+    # No hb key → stale.
+
+    patched_state.connect(endpoint="mimir", session_name="alive")
+    try:
+        out = patched_state.list_sessions()
+        assert {s["session_name"] for s in out["sessions"]} == {"alive"}
+        # GC happened
+        assert fr.hget(presence.REGISTRY_KEY, "ghost") is None
+    finally:
+        patched_state.disconnect()
+
+
+def test_connect_with_missing_registry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When registry.json doesn't exist, connect returns a structured error."""
+
+    def fake_load_registry() -> Any:
+        from server import registry as registry_mod  # type: ignore[import-not-found]
+
+        return registry_mod.load_registry(tmp_path / "absent.json")
+
+    monkeypatch.setattr(channel, "load_registry", fake_load_registry)
+    state = channel.ServerState()
+    out = state.connect(endpoint="mimir", session_name=None)
+    assert out["ok"] is False
+    assert out["error"] == "registry not configured"
+    assert "registry config not found" in out["detail"]
+    assert "hint" in out
+
+
+def test_connect_with_unknown_endpoint(patched_state: channel.ServerState) -> None:
+    out = patched_state.connect(endpoint="nope", session_name=None)
+    assert out["ok"] is False
+    assert out["error"] == "endpoint not found"
+
+
+def test_connect_with_invalid_session_name(
+    patched_state: channel.ServerState,
+) -> None:
+    out = patched_state.connect(endpoint="mimir", session_name="UPPER CASE")
+    assert out["ok"] is False
+    assert out["error"] == "invalid argument"
+
+
+def test_shutdown_disconnects_active_session(
+    patched_state: channel.ServerState, fr: fakeredis.FakeRedis
+) -> None:
+    patched_state.connect(endpoint="mimir", session_name="atexit-test")
+    patched_state.shutdown()
+    assert not patched_state.is_connected
+    assert fr.hget(presence.REGISTRY_KEY, "atexit-test") is None
+
+
+def test_build_app_smoke() -> None:
+    """Verify FastMCP wiring constructs cleanly + registers our 3 tools."""
+    app = channel.build_app()
+    # FastMCP exposes registered tools via a _tool_manager or tools attribute,
+    # depending on version. Try both; if neither exists we just ensure the
+    # call didn't raise.
+    tool_names: set[str] = set()
+    tm = getattr(app, "_tool_manager", None)
+    if tm is not None:
+        tool_names = set(getattr(tm, "_tools", {}).keys())
+    elif hasattr(app, "tools"):
+        tool_names = {t.name for t in app.tools}
+    if tool_names:
+        assert {"redis_bridge_connect", "redis_bridge_disconnect", "redis_bridge_list"} <= (
+            tool_names
+        )

--- a/tests/test_redis_bridge_presence.py
+++ b/tests/test_redis_bridge_presence.py
@@ -1,0 +1,190 @@
+"""Tests for redis-bridge presence (registry HSET + heartbeat thread).
+
+Uses fakeredis to model the Redis backend so tests run without a server.
+"""
+
+from __future__ import annotations
+
+import time
+
+import fakeredis
+import pytest
+from server import presence  # type: ignore[import-not-found]
+
+
+@pytest.fixture
+def fr() -> fakeredis.FakeRedis:
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+def make_meta(name: str = "test-abc") -> presence.SessionMetadata:
+    return presence.build_metadata(
+        session_name=name,
+        endpoint="mimir",
+        cwd="/tmp/proj",
+        host="testhost",
+        git_branch="main",
+        started_at=1000.0,
+    )
+
+
+def test_session_metadata_round_trip() -> None:
+    meta = make_meta()
+    body = meta.to_json()
+    restored = presence.SessionMetadata.from_json(body)
+    assert restored == meta
+
+
+def test_build_metadata_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(time, "time", lambda: 1234.5)
+    meta = presence.build_metadata(session_name="x", endpoint="mimir")
+    assert meta.session_name == "x"
+    assert meta.endpoint == "mimir"
+    assert meta.started_at == 1234.5
+    assert meta.pid > 0
+    assert meta.host  # non-empty
+    assert meta.cwd  # non-empty
+
+
+def test_presence_start_writes_registry_and_hb(fr: fakeredis.FakeRedis) -> None:
+    meta = make_meta()
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    try:
+        raw = fr.hget(presence.REGISTRY_KEY, meta.session_name)
+        assert raw is not None
+        assert presence.SessionMetadata.from_json(raw) == meta
+        assert fr.exists(presence.hb_key(meta.session_name)) == 1
+        # TTL should be roughly the configured value.
+        assert 1 <= fr.ttl(presence.hb_key(meta.session_name)) <= 10
+    finally:
+        p.stop()
+
+
+def test_presence_stop_cleans_up(fr: fakeredis.FakeRedis) -> None:
+    meta = make_meta()
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    p.stop()
+    assert fr.hget(presence.REGISTRY_KEY, meta.session_name) is None
+    assert fr.exists(presence.hb_key(meta.session_name)) == 0
+
+
+def test_presence_is_idempotent_on_double_stop(fr: fakeredis.FakeRedis) -> None:
+    meta = make_meta()
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    p.stop()
+    p.stop()  # must not raise
+
+
+def test_presence_rejects_double_start(fr: fakeredis.FakeRedis) -> None:
+    p = presence.Presence(fr, make_meta(), heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    try:
+        with pytest.raises(RuntimeError, match="already started"):
+            p.start()
+    finally:
+        p.stop()
+
+
+def test_presence_rejects_ttl_le_heartbeat(fr: fakeredis.FakeRedis) -> None:
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        presence.Presence(fr, make_meta(), heartbeat_seconds=10, ttl_seconds=10)
+    with pytest.raises(ValueError):
+        presence.Presence(fr, make_meta(), heartbeat_seconds=10, ttl_seconds=5)
+
+
+def test_presence_context_manager(fr: fakeredis.FakeRedis) -> None:
+    meta = make_meta()
+    with presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10):
+        assert fr.exists(presence.hb_key(meta.session_name)) == 1
+    assert fr.exists(presence.hb_key(meta.session_name)) == 0
+
+
+def test_heartbeat_refreshes_ttl(fr: fakeredis.FakeRedis) -> None:
+    """After more than one heartbeat tick, the hb key must still exist
+    (heartbeat re-set it before the previous expiry)."""
+    meta = make_meta()
+    # ttl just barely above heartbeat to force the test to depend on refresh
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=2)
+    p.start()
+    try:
+        time.sleep(1.3)
+        assert fr.exists(presence.hb_key(meta.session_name)) == 1
+        time.sleep(1.3)
+        assert fr.exists(presence.hb_key(meta.session_name)) == 1
+    finally:
+        p.stop()
+
+
+def test_list_live_sessions_filters_by_hb(fr: fakeredis.FakeRedis) -> None:
+    meta1 = make_meta("live-1")
+    meta2 = make_meta("live-2")
+    p1 = presence.Presence(fr, meta1, heartbeat_seconds=1, ttl_seconds=10)
+    p2 = presence.Presence(fr, meta2, heartbeat_seconds=1, ttl_seconds=10)
+    p1.start()
+    p2.start()
+    try:
+        live = presence.list_live_sessions(fr)
+        assert set(live) == {"live-1", "live-2"}
+    finally:
+        p1.stop()
+        p2.stop()
+
+
+def test_list_live_sessions_skips_stale(fr: fakeredis.FakeRedis) -> None:
+    meta_live = make_meta("live")
+    meta_stale = make_meta("stale")
+    fr.hset(presence.REGISTRY_KEY, "live", meta_live.to_json())
+    fr.hset(presence.REGISTRY_KEY, "stale", meta_stale.to_json())
+    fr.set(presence.hb_key("live"), str(time.time()), ex=60)
+    # no hb key for "stale"
+    live = presence.list_live_sessions(fr)
+    assert set(live) == {"live"}
+
+
+def test_list_live_sessions_gc_stale(fr: fakeredis.FakeRedis) -> None:
+    meta_live = make_meta("live")
+    meta_stale = make_meta("stale")
+    fr.hset(presence.REGISTRY_KEY, "live", meta_live.to_json())
+    fr.hset(presence.REGISTRY_KEY, "stale", meta_stale.to_json())
+    fr.set(presence.hb_key("live"), str(time.time()), ex=60)
+    presence.list_live_sessions(fr, gc_stale=True)
+    assert fr.hget(presence.REGISTRY_KEY, "stale") is None
+    assert fr.hget(presence.REGISTRY_KEY, "live") is not None
+
+
+def test_list_live_sessions_handles_corrupt_entry(fr: fakeredis.FakeRedis) -> None:
+    fr.hset(presence.REGISTRY_KEY, "broken", "{not valid json}")
+    fr.set(presence.hb_key("broken"), str(time.time()), ex=60)
+    live = presence.list_live_sessions(fr)
+    assert live == {}
+
+
+def test_lifecycle_events_published(fr: fakeredis.FakeRedis) -> None:
+    meta = make_meta("pub-test")
+    pubsub = fr.pubsub()
+    pubsub.subscribe(presence.events_channel(meta.session_name))
+    pubsub.get_message(timeout=0.1)  # subscribe ack
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    p.stop(reason="test")
+    msgs = []
+    while True:
+        m = pubsub.get_message(timeout=0.1)
+        if m is None:
+            break
+        if m.get("type") == "message":
+            msgs.append(m)
+    pubsub.close()
+    types_seen = []
+    for m in msgs:
+        import json as _json
+
+        payload = _json.loads(m["data"])
+        types_seen.append(payload["type"])
+        assert payload["session_name"] == meta.session_name
+        assert payload["v"] == 1
+    assert "registered" in types_seen
+    assert "unregistered" in types_seen

--- a/tests/test_redis_bridge_presence.py
+++ b/tests/test_redis_bridge_presence.py
@@ -6,14 +6,18 @@ Uses fakeredis to model the Redis backend so tests run without a server.
 from __future__ import annotations
 
 import time
+from typing import Any
 
 import fakeredis
 import pytest
 from server import presence  # type: ignore[import-not-found]
 
 
+# Return type is Any (not fakeredis.FakeRedis) so redis-py's wide
+# Awaitable[X] | X union return types don't poison every call site.
+# Runtime is the real fakeredis client; only typing is loosened.
 @pytest.fixture
-def fr() -> fakeredis.FakeRedis:
+def fr() -> Any:
     return fakeredis.FakeRedis(decode_responses=True)
 
 
@@ -46,7 +50,7 @@ def test_build_metadata_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta.cwd  # non-empty
 
 
-def test_presence_start_writes_registry_and_hb(fr: fakeredis.FakeRedis) -> None:
+def test_presence_start_writes_registry_and_hb(fr: Any) -> None:
     meta = make_meta()
     p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
     p.start()
@@ -61,7 +65,7 @@ def test_presence_start_writes_registry_and_hb(fr: fakeredis.FakeRedis) -> None:
         p.stop()
 
 
-def test_presence_stop_cleans_up(fr: fakeredis.FakeRedis) -> None:
+def test_presence_stop_cleans_up(fr: Any) -> None:
     meta = make_meta()
     p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
     p.start()
@@ -70,7 +74,7 @@ def test_presence_stop_cleans_up(fr: fakeredis.FakeRedis) -> None:
     assert fr.exists(presence.hb_key(meta.session_name)) == 0
 
 
-def test_presence_is_idempotent_on_double_stop(fr: fakeredis.FakeRedis) -> None:
+def test_presence_is_idempotent_on_double_stop(fr: Any) -> None:
     meta = make_meta()
     p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
     p.start()
@@ -78,7 +82,7 @@ def test_presence_is_idempotent_on_double_stop(fr: fakeredis.FakeRedis) -> None:
     p.stop()  # must not raise
 
 
-def test_presence_rejects_double_start(fr: fakeredis.FakeRedis) -> None:
+def test_presence_rejects_double_start(fr: Any) -> None:
     p = presence.Presence(fr, make_meta(), heartbeat_seconds=1, ttl_seconds=10)
     p.start()
     try:
@@ -88,21 +92,21 @@ def test_presence_rejects_double_start(fr: fakeredis.FakeRedis) -> None:
         p.stop()
 
 
-def test_presence_rejects_ttl_le_heartbeat(fr: fakeredis.FakeRedis) -> None:
+def test_presence_rejects_ttl_le_heartbeat(fr: Any) -> None:
     with pytest.raises(ValueError, match="ttl_seconds"):
         presence.Presence(fr, make_meta(), heartbeat_seconds=10, ttl_seconds=10)
     with pytest.raises(ValueError):
         presence.Presence(fr, make_meta(), heartbeat_seconds=10, ttl_seconds=5)
 
 
-def test_presence_context_manager(fr: fakeredis.FakeRedis) -> None:
+def test_presence_context_manager(fr: Any) -> None:
     meta = make_meta()
     with presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10):
         assert fr.exists(presence.hb_key(meta.session_name)) == 1
     assert fr.exists(presence.hb_key(meta.session_name)) == 0
 
 
-def test_heartbeat_refreshes_ttl(fr: fakeredis.FakeRedis) -> None:
+def test_heartbeat_refreshes_ttl(fr: Any) -> None:
     """After more than one heartbeat tick, the hb key must still exist
     (heartbeat re-set it before the previous expiry)."""
     meta = make_meta()
@@ -118,7 +122,7 @@ def test_heartbeat_refreshes_ttl(fr: fakeredis.FakeRedis) -> None:
         p.stop()
 
 
-def test_list_live_sessions_filters_by_hb(fr: fakeredis.FakeRedis) -> None:
+def test_list_live_sessions_filters_by_hb(fr: Any) -> None:
     meta1 = make_meta("live-1")
     meta2 = make_meta("live-2")
     p1 = presence.Presence(fr, meta1, heartbeat_seconds=1, ttl_seconds=10)
@@ -133,7 +137,7 @@ def test_list_live_sessions_filters_by_hb(fr: fakeredis.FakeRedis) -> None:
         p2.stop()
 
 
-def test_list_live_sessions_skips_stale(fr: fakeredis.FakeRedis) -> None:
+def test_list_live_sessions_skips_stale(fr: Any) -> None:
     meta_live = make_meta("live")
     meta_stale = make_meta("stale")
     fr.hset(presence.REGISTRY_KEY, "live", meta_live.to_json())
@@ -144,7 +148,7 @@ def test_list_live_sessions_skips_stale(fr: fakeredis.FakeRedis) -> None:
     assert set(live) == {"live"}
 
 
-def test_list_live_sessions_gc_stale(fr: fakeredis.FakeRedis) -> None:
+def test_list_live_sessions_gc_stale(fr: Any) -> None:
     meta_live = make_meta("live")
     meta_stale = make_meta("stale")
     fr.hset(presence.REGISTRY_KEY, "live", meta_live.to_json())
@@ -155,14 +159,14 @@ def test_list_live_sessions_gc_stale(fr: fakeredis.FakeRedis) -> None:
     assert fr.hget(presence.REGISTRY_KEY, "live") is not None
 
 
-def test_list_live_sessions_handles_corrupt_entry(fr: fakeredis.FakeRedis) -> None:
+def test_list_live_sessions_handles_corrupt_entry(fr: Any) -> None:
     fr.hset(presence.REGISTRY_KEY, "broken", "{not valid json}")
     fr.set(presence.hb_key("broken"), str(time.time()), ex=60)
     live = presence.list_live_sessions(fr)
     assert live == {}
 
 
-def test_lifecycle_events_published(fr: fakeredis.FakeRedis) -> None:
+def test_lifecycle_events_published(fr: Any) -> None:
     meta = make_meta("pub-test")
     pubsub = fr.pubsub()
     pubsub.subscribe(presence.events_channel(meta.session_name))

--- a/tests/test_redis_bridge_registry.py
+++ b/tests/test_redis_bridge_registry.py
@@ -1,0 +1,112 @@
+"""Tests for redis-bridge registry config loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from server import registry  # type: ignore[import-not-found]
+
+
+def write_config(path: Path, body: dict) -> Path:
+    path.write_text(json.dumps(body), encoding="utf-8")
+    return path
+
+
+def test_load_registry_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(registry.RegistryNotFoundError):
+        registry.load_registry(tmp_path / "absent.json")
+
+
+def test_load_registry_invalid_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json}", encoding="utf-8")
+    with pytest.raises(registry.RegistryParseError, match="invalid JSON"):
+        registry.load_registry(p)
+
+
+def test_load_registry_top_level_must_be_object(tmp_path: Path) -> None:
+    p = write_config(tmp_path / "r.json", [])  # type: ignore[arg-type]
+    p.write_text("[1, 2]", encoding="utf-8")
+    with pytest.raises(registry.RegistryParseError, match="top-level"):
+        registry.load_registry(p)
+
+
+def test_load_registry_basic(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {
+                "mimir": {
+                    "redis_url": "redis://mac-mini:6379/0",
+                    "redis_password_env": "HERMES_REDIS_PASSWORD",
+                    "display_name": "Mimir",
+                }
+            }
+        },
+    )
+    r = registry.load_registry(cfg)
+    assert r.source == cfg
+    assert set(r.endpoints) == {"mimir"}
+    ep = r.endpoints["mimir"]
+    assert ep.name == "mimir"
+    assert ep.redis_url == "redis://mac-mini:6379/0"
+    assert ep.redis_password_env == "HERMES_REDIS_PASSWORD"
+    assert ep.display_name == "Mimir"
+    # defaults applied
+    assert r.defaults.heartbeat_seconds == 10
+    assert r.defaults.registry_ttl_seconds == 60
+
+
+def test_load_registry_defaults_override(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {},
+            "defaults": {"heartbeat_seconds": 5, "registry_ttl_seconds": 30},
+        },
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.heartbeat_seconds == 5
+    assert r.defaults.registry_ttl_seconds == 30
+    # untouched fields still default
+    assert r.defaults.permission_window_seconds == 30
+
+
+def test_endpoint_missing_redis_url_raises(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"mimir": {"display_name": "Mimir"}}},
+    )
+    with pytest.raises(registry.RegistryParseError, match="redis_url"):
+        registry.load_registry(cfg)
+
+
+def test_endpoint_display_name_defaults_to_name(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"foo": {"redis_url": "redis://h"}}},
+    )
+    r = registry.load_registry(cfg)
+    assert r.endpoints["foo"].display_name == "foo"
+    assert r.endpoints["foo"].redis_password_env is None
+
+
+def test_registry_get_known_endpoint(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"mimir": {"redis_url": "redis://h"}}},
+    )
+    r = registry.load_registry(cfg)
+    assert r.get("mimir").name == "mimir"
+
+
+def test_registry_get_unknown_endpoint_raises(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"mimir": {"redis_url": "redis://h"}}},
+    )
+    r = registry.load_registry(cfg)
+    with pytest.raises(registry.EndpointNotFoundError, match="available: mimir"):
+        r.get("nope")

--- a/tests/test_redis_bridge_session_id.py
+++ b/tests/test_redis_bridge_session_id.py
@@ -53,17 +53,13 @@ def test_resolve_uses_explicit_override(tmp_path: Path) -> None:
     assert out == "my-name"
 
 
-def test_resolve_uses_env_override(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_uses_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("CLAUDE_SESSION_NAME", "via-env")
     out = session_id.resolve_session_name(cwd=tmp_path, host="h")
     assert out == "via-env"
 
 
-def test_resolve_falls_back_to_auto(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_resolve_falls_back_to_auto(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("CLAUDE_SESSION_NAME", raising=False)
     out = session_id.resolve_session_name(cwd=tmp_path, host="h")
     assert "-" in out

--- a/tests/test_redis_bridge_session_id.py
+++ b/tests/test_redis_bridge_session_id.py
@@ -1,0 +1,97 @@
+"""Tests for redis-bridge session_id auto-naming + override validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from server import session_id  # type: ignore[import-not-found]
+
+
+def test_auto_session_name_is_stable_across_calls(tmp_path: Path) -> None:
+    name1 = session_id.auto_session_name(cwd=tmp_path, host="example.local")
+    name2 = session_id.auto_session_name(cwd=tmp_path, host="example.local")
+    assert name1 == name2
+
+
+def test_auto_session_name_differs_per_host(tmp_path: Path) -> None:
+    a = session_id.auto_session_name(cwd=tmp_path, host="hostA")
+    b = session_id.auto_session_name(cwd=tmp_path, host="hostB")
+    assert a != b
+    assert a.split("-")[0] == b.split("-")[0]  # basename matches
+
+
+def test_auto_session_name_differs_per_cwd(tmp_path: Path) -> None:
+    p1 = tmp_path / "project-one"
+    p2 = tmp_path / "project-two"
+    p1.mkdir()
+    p2.mkdir()
+    a = session_id.auto_session_name(cwd=p1, host="h")
+    b = session_id.auto_session_name(cwd=p2, host="h")
+    assert a != b
+
+
+def test_auto_session_name_format(tmp_path: Path) -> None:
+    """Format: <slug>-<8 hex chars>."""
+    proj = tmp_path / "Hello World!"
+    proj.mkdir()
+    name = session_id.auto_session_name(cwd=proj, host="h")
+    assert session_id.is_valid_session_name(name)
+    slug, _, suffix = name.rpartition("-")
+    assert slug == "hello-world"
+    assert len(suffix) == 8
+    assert all(c in "0123456789abcdef" for c in suffix)
+
+
+def test_auto_session_name_handles_empty_basename(tmp_path: Path) -> None:
+    name = session_id.auto_session_name(cwd="/", host="h")
+    assert name.startswith("session-")
+
+
+def test_resolve_uses_explicit_override(tmp_path: Path) -> None:
+    out = session_id.resolve_session_name(override="my-name", cwd=tmp_path, host="h")
+    assert out == "my-name"
+
+
+def test_resolve_uses_env_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLAUDE_SESSION_NAME", "via-env")
+    out = session_id.resolve_session_name(cwd=tmp_path, host="h")
+    assert out == "via-env"
+
+
+def test_resolve_falls_back_to_auto(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("CLAUDE_SESSION_NAME", raising=False)
+    out = session_id.resolve_session_name(cwd=tmp_path, host="h")
+    assert "-" in out
+
+
+def test_resolve_rejects_invalid_override(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid session name"):
+        session_id.resolve_session_name(override="Has Spaces", cwd=tmp_path, host="h")
+
+
+def test_resolve_rejects_uppercase_override(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        session_id.resolve_session_name(override="UPPER", cwd=tmp_path, host="h")
+
+
+def test_resolve_rejects_overlong_override(tmp_path: Path) -> None:
+    long_name = "a" * 65
+    with pytest.raises(ValueError):
+        session_id.resolve_session_name(override=long_name, cwd=tmp_path, host="h")
+
+
+def test_is_valid_session_name() -> None:
+    assert session_id.is_valid_session_name("foo")
+    assert session_id.is_valid_session_name("foo-bar-123")
+    assert session_id.is_valid_session_name("foo_bar")
+    assert session_id.is_valid_session_name("a")
+    assert not session_id.is_valid_session_name("")
+    assert not session_id.is_valid_session_name("-leading-hyphen")
+    assert not session_id.is_valid_session_name("Has-Upper")
+    assert not session_id.is_valid_session_name("has space")
+    assert not session_id.is_valid_session_name("has/slash")

--- a/uv.lock
+++ b/uv.lock
@@ -412,6 +412,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -458,6 +471,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -472,13 +494,17 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "mcp" },
+    { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "redis" },
     { name = "requests" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "fakeredis" },
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
@@ -496,12 +522,16 @@ ebay = [
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "boto3", specifier = ">=1.34.0" },
+    { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pillow", marker = "extra == 'ebay'", specifier = ">=10.0" },
+    { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "redis", specifier = ">=5.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "safety", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -730,6 +760,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -1004,12 +1059,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1052,6 +1135,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1098,6 +1215,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]
@@ -1420,6 +1546,41 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
 name = "stevedore"
 version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1522,4 +1683,17 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]


### PR DESCRIPTION
## Summary

Phase 1 of the `redis-bridge` plugin: the CC-side foundation that lets a Claude Code session register itself in a Redis-based session registry, heartbeat every 10s, and enumerate live sibling sessions. Pairs with the (Phase 2+) `hermes-claude-code-router` for hands-free voice/text routing from Discord into a connected CC session.

## What's in this PR

- **`server/session_id.py`** — auto-name `<cwd-slug>-<8 hex>` with `CLAUDE_SESSION_NAME` env override + slug validation
- **`server/registry.py`** — loads `~/.claude/channels/redis-bridge/registry.json` with typed errors
- **`server/redis_client.py`** — connection helper with password-env injection
- **`server/presence.py`** — registry HSET + 10s heartbeat thread (TTL 60s) + lifecycle pub/sub
- **`server/channel.py`** — FastMCP stdio server with `redis_bridge_connect`, `redis_bridge_disconnect`, `redis_bridge_list` tools
- **`.mcp.json`** — Claude Code auto-discovers and boots the server
- **Slash commands** rewritten to invoke the MCP tools and interpret responses
- **`docs/registry.example.json`** — reference config

## Tests + checks

- 52 new unit tests (fakeredis-backed) — heartbeat refresh, lifecycle pubsub, stale GC, error paths all covered
- Repo total: **348 tests pass**, ruff clean, mypy clean (8 source files)
- MCP server boots cleanly via stdio smoke test

## Engineering journal

Two new LEARNINGS:
- \`dataclass(slots=True)\` doesn't expose class-level field defaults — bit me during registry loader, fix uses an instance instead of reaching into the class
- redis-py's wide-union sync/async return types defeat narrowing Protocols — use `Any` for `RedisLike`

## ⚠ Verification gap

**Not yet verified against real Redis or a real Claude Code session.** All testing has been against fakeredis. Before merging Phase 2 work, we should:

1. Drop `docs/registry.example.json` into `~/.claude/channels/redis-bridge/registry.json` with the actual Mac mini Redis URL + password env var
2. Start a Claude Code session, run `/redis-bridge-connect mimir`, verify the registry entry shows up in `redis-cli` (`HGETALL cc-sessions:registry` + `EXISTS cc-sessions:hb:<name>`)
3. Start a second CC session, `/redis-bridge-list` from either, both visible
4. Kill one (SIGKILL → no graceful unregister), wait 60s, `list` from the other drops the stale entry

That live test will catch any FastMCP/stdio wiring issues, env-propagation issues from Claude Code's MCP launcher, or password-env issues that fakeredis doesn't surface.

## Test plan

- [ ] Live-Redis verification per ⚠ above (4 steps)
- [ ] Confirm no regression in unrelated plugins (348 tests already green; CI will re-confirm)
- [ ] Confirm `.mcp.json` is discovered when the plugin is installed in a fresh Claude Code session

## Refs

- Plan: `~/.claude/plans/i-would-like-to-distributed-hanrahan.md`
- Phase 0 PR: #127
- Next: Phase 2 (text bridge — DM/channel mention/thread); needs the matching work in `infiquetra/hermes-claude-code-router`