### PR TITLE
feat(redis-bridge): Phase 2 — text bridge (inbound consumer + reply tool)

### DIFF
--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,29 @@
 
 ## 2026-05-25
 
+### Emitting custom MCP notification methods from FastMCP  {#fastmcp-custom-notification}
+
+**Context.** Phase 2 of `redis-bridge` needs the MCP server to emit `notifications/claude/channel` — a notification type that's specific to Claude Code's channel protocol and **not** part of the upstream MCP spec. FastMCP's `Context` exposes `log/info/debug/error/elicit` but none of those emit a custom method name. The underlying `ServerSession.send_notification` accepts a typed `SendNotificationT` union, and Claude's `notifications/claude/channel` is not in that union.
+
+**Evidence.**
+- `[m for m in dir(Context) if not m.startswith('_')]` → no raw `send_notification` exposed.
+- `ServerSession.send_notification` signature: `(notification: SendNotificationT, related_request_id)`. `SendNotificationT` is a discriminated union over Pydantic Notification subclasses keyed on the method literal — no `"notifications/claude/channel"` variant.
+- But `mcp.types` also exports `Notification[Union[dict[str, Any], NoneType], str]` — a fully-generic Notification[params, method-as-str] form. This is the escape hatch.
+
+**Mechanism.** `send_notification` doesn't actually validate that the notification method is in the spec union — it just calls `notification.model_dump(by_alias=True, mode='json', exclude_none=True)` and wraps the result in a `JSONRPCNotification`. The discrimination happens via Pydantic, but a generic `Notification[dict, str]` instance has `method: str` so it passes through verbatim. Static typing rejects it (`type: ignore[arg-type]` needed), runtime accepts it.
+
+**Fix.** `plugins/redis-bridge/server/notifier.py` constructs `Notification[dict, str](method="notifications/claude/channel", params=payload)` and passes it to `session.send_notification(notif)` with a type-ignore. Threadsafe scheduling via `asyncio.run_coroutine_threadsafe` because the consumer thread isn't on the asyncio loop.
+
+**Validation.** Phase 2 unit test `test_async_notifier_schedules_coroutine` constructs an AsyncNotifier with a stub session + a real asyncio loop running on a side thread, calls emit, and verifies the stub session's `send_notification` was awaited with `method="notifications/claude/channel"` and `params` matching.
+
+**What surprised.** The MCP SDK exports a fully-generic `Notification[params, method-as-str]` type. Looking at the dir() of `mcp.types`, the entry `'Notification[Union[dict[str, Any], NoneType], str]'` was the giveaway — that's exactly the escape hatch for vendor-specific notification methods.
+
+**Generalizable rule.** When you need to emit an MCP notification method that isn't in the SDK's `ServerNotificationType` union (Claude-specific extensions like `notifications/claude/channel`, or any other downstream extension): use the generic `Notification[dict, str]` form with a string method, accept the `type: ignore[arg-type]` on `send_notification`, and don't try to wedge it into the typed union. Static typing was wrong to demand discrimination here — the JSON-RPC protocol itself doesn't care.
+
+**Refs.** `plugins/redis-bridge/server/notifier.py`; Phase 2 PR.
+
+---
+
 ### `@dataclass(slots=True)` doesn't expose class-level field defaults  {#dataclass-slots-class-defaults}
 
 **Context.** While building `plugins/redis-bridge/server/registry.py`, the loader read each config field via `defaults_raw.get(key, Defaults.heartbeat_seconds)` — reaching into the dataclass class to pull the field default. Five tests failed with `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'member_descriptor'`.

--- a/plugins/redis-bridge/.claude-plugin/plugin.json
+++ b/plugins/redis-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-bridge/CHANGELOG.md
+++ b/plugins/redis-bridge/CHANGELOG.md
@@ -7,6 +7,14 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — Phase 2 (text bridge: inbound consumer + reply tool)
+
+- `server/redis_consumer.py`: XREADGROUP consumer thread for `cc-sessions:<name>:inbound`. Creates the consumer group on first connect (idempotent on BUSYGROUP). Each decoded payload is handed to a caller-supplied `on_message` callback. Acks after the callback returns; a raising callback leaves the message in the pending entries list for re-delivery. Drops + acks structurally bad payloads (missing `payload` field, undecodable JSON, non-object body) so the consumer never loops on garbage. The original Redis message-id is attached as `_msg_id` for reply correlation.
+- `server/redis_producer.py`: `publish_outbound()` XADDs a sorted-key JSON-encoded payload onto `cc-sessions:<name>:outbound` with `MAXLEN ~ 10_000` to bound stream growth.
+- `server/notifier.py`: bridges the consumer thread → async `session.send_notification`. `AsyncNotifier` captures the asyncio loop + ServerSession at connect time; `emit()` (called from the consumer thread) builds a `Notification[dict, str](method="notifications/claude/channel", params=payload)` and schedules `send_notification` via `asyncio.run_coroutine_threadsafe`. Cleanly drops payloads if the loop is closed (no coroutine leak). `RecordingNotifier` + `NoopNotifier` are the test/no-op seams.
+- `server/channel.py`: connect now also starts the consumer with the wired notifier; disconnect stops the consumer first (so it doesn't try to ack on a stale client). New `reply(chat_id, text, voice=False, in_reply_to=None)` MCP tool that XADDs an Outbound payload. Server-side guards: `chat_id` and `text` must be non-empty/non-whitespace.
+- Tests: 30 new unit tests across `test_redis_bridge_consumer.py` (11), `test_redis_bridge_producer.py` (4), `test_redis_bridge_notifier.py` (6), plus 9 additional `test_redis_bridge_channel.py` cases covering consumer attachment, second-connect replaces consumer, reply XADD + voice/in_reply_to propagation, reply-when-disconnected, and empty-text/empty-chat_id rejection.
+
 ### Added — Phase 1 (presence + heartbeat + slash list)
 
 - `server/session_id.py`: auto-generate session names from cwd + host hash (`<slug>-<8hex>`), with `CLAUDE_SESSION_NAME` env override and slug validation.
@@ -30,7 +38,6 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ### Not implemented yet (planned for later phases)
 
-- Inbound stream consumer + `notifications/claude/channel` emission (Phase 2).
-- `reply` MCP tool (Phase 2).
 - Voice routing (Phase 3).
 - Permission relay + AskUserQuestion interception + audit logging (Phase 4).
+- Hybrid intelligence — LLM tools for session-routing fallback (Phase 5; router-side).

--- a/plugins/redis-bridge/README.md
+++ b/plugins/redis-bridge/README.md
@@ -17,7 +17,7 @@ It is **not** a Discord bot. It does not touch Discord, voice-channel audio, STT
 
 ## Status
 
-**Phase 1 complete.** Presence + heartbeat + slash list working end-to-end against fakeredis; live multi-session listing with stale GC. Phase 2 (text bridge: DM/channel/thread) is next. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
+**Phase 2 complete.** Presence + heartbeat (P1) plus inbound consumer + `reply` MCP tool (P2). Channel notifications surface as `notifications/claude/channel` events with the full Inbound payload; replies XADD onto the outbound stream with router-correlation IDs and an `in_reply_to` field for threading. Phase 3 (voice routing through Hermes TTS/STT) and Phase 4 (permission relay + AskUserQuestion interception) still to come — both gated on the matching router-side implementation in `hermes-claude-code-router`. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
 
 ## Quickstart
 
@@ -43,9 +43,12 @@ plugins/redis-bridge/
 ├── server/
 │   ├── __init__.py
 │   ├── __main__.py                # `python -m server` entry point
-│   ├── channel.py                 # FastMCP server: connect/disconnect/list tools
+│   ├── channel.py                 # FastMCP server: connect/disconnect/list + reply tools
 │   ├── presence.py                # registry HSET + heartbeat thread + lifecycle pubsub
 │   ├── redis_client.py            # connection helper + password-env injection
+│   ├── redis_consumer.py          # XREADGROUP loop, dispatches to notifier
+│   ├── redis_producer.py          # XADD helper for outbound stream
+│   ├── notifier.py                # thread → asyncio bridge for notifications/claude/channel
 │   ├── registry.py                # local endpoint config loader
 │   ├── session_id.py              # auto-name generator + override validation
 │   └── protocol.py                # pydantic models matching PROTOCOL.md

--- a/plugins/redis-bridge/agents/redis-bridge-coach.md
+++ b/plugins/redis-bridge/agents/redis-bridge-coach.md
@@ -3,14 +3,23 @@ name: redis-bridge-coach
 description: Behavior hints for Claude when a redis-bridge channel session is active. Reminders about voice-mode reply defaults and how channel events arrive. Not load-bearing — interception in the MCP server is what guarantees correctness; this file just reduces friction.
 ---
 
-You may be running with a `redis-bridge` channel attached. Events from external users arrive wrapped in a `<channel source="redis-bridge" ...>` tag with attributes describing where they came from (`source_type`, `chat_id`, `user`, `username`, `confidence`, `ts`).
+You may be running with a `redis-bridge` channel attached. After `/redis-bridge-connect` succeeds, external users' messages arrive as `notifications/claude/channel` events. The notification params carry the full Inbound payload:
 
-When you respond, you call the `reply` tool. Default behavior:
+- `source` — `"voice"`, `"dm"`, `"channel"`, or `"thread"` (where the user is on the other side).
+- `chat_id` — opaque router-managed handle for that conversation.
+- `user_id`, `username` — who sent it.
+- `text` — what they said (or the STT transcript).
+- `confidence` — float 0-1 for voice transcripts; absent for text.
+- `endpoint` — which endpoint the message came from (e.g. `"mimir"`).
+- `_msg_id` — Redis stream message-id we attach for reply correlation.
 
-- If `source_type` was `voice`, set `voice=true` on your reply so the router synthesizes audio.
-- If `source_type` was `dm`, `channel`, or `thread`, leave `voice` at the default (false) — the router will deliver text.
-- Mirror the inbound `chat_id` on your reply unless you have a specific reason to redirect.
+To respond, call the `reply` tool:
 
-When you would normally use `AskUserQuestion`, prefer **inlining the choices in your reply text** ("Which approach? A) ..., B) ..., C) ..."). The MCP server intercepts `AskUserQuestion` and converts it for you, but inlining directly is one less round trip.
+- **Always pass back the `chat_id`** from the inbound event so the router routes your reply to the right surface.
+- If `source` was `"voice"`, set `voice=true` so the router synthesizes audio for that voice channel.
+- If `source` was `"dm"`, `"channel"`, or `"thread"`, leave `voice` at the default (false).
+- Pass `in_reply_to=<the `_msg_id` from the inbound>` when you want the router to thread the reply (useful in channel/thread surfaces; the router may ignore it for voice).
+
+**Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
 
 Latency: voice round-trips through the router take 6-10s typical. Keep replies tight when the user is hands-free; they can ask follow-ups.

--- a/plugins/redis-bridge/server/__init__.py
+++ b/plugins/redis-bridge/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/plugins/redis-bridge/server/channel.py
+++ b/plugins/redis-bridge/server/channel.py
@@ -1,34 +1,41 @@
 """MCP server (stdio) for redis-bridge.
 
-Phase 1 exposes three tools:
+Phase 1 tools:
     - redis_bridge_connect(endpoint=..., session_name=...)
     - redis_bridge_disconnect()
     - redis_bridge_list()
 
-The server is single-session: at most one active Presence at a time per
-process. A second `connect` call disconnects the previous session first
-(common when re-running the slash command after a config change).
+Phase 2 additions:
+    - reply(chat_id, text, voice=False, source_msg_id=None)
+    - On connect: spawn a consumer thread that XREADGROUPs the inbound
+      stream and emits each message as a `notifications/claude/channel`
+      MCP notification on the session.
 
-Phase 2+ will add channel notifications (`notifications/claude/channel`),
-a `reply` tool, and AskUserQuestion interception. This file is the seam
-where that wiring lands.
+Single-session per process: at most one active Presence+Consumer pair
+at a time. A second `connect` call replaces the previous one.
 """
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import contextlib
 import logging
 import signal
 import sys
 import threading
+import time
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 from . import __version__
+from .notifier import AsyncNotifier, ChannelNotifier, NoopNotifier
 from .presence import Presence, build_metadata, list_live_sessions
+from .protocol import Outbound
 from .redis_client import connect as redis_connect
+from .redis_consumer import Consumer
+from .redis_producer import publish_outbound
 from .registry import (
     EndpointNotFoundError,
     RegistryError,
@@ -43,13 +50,16 @@ log = logging.getLogger("redis_bridge.channel")
 class ServerState:
     """Single-active-session state for the channel server.
 
-    Wrapped in a lock so heartbeat thread (in Presence) and tool-handler
-    threads (FastMCP can dispatch concurrently) don't race on lifecycle.
+    Wrapped in a lock so heartbeat thread (Presence), consumer thread,
+    and tool-handler threads (FastMCP can dispatch concurrently) don't
+    race on lifecycle.
     """
 
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._presence: Presence | None = None
+        self._consumer: Consumer | None = None
+        self._notifier: ChannelNotifier | None = None
         self._client: Any | None = None
         self._endpoint_name: str | None = None
 
@@ -58,7 +68,19 @@ class ServerState:
         with self._lock:
             return self._presence is not None
 
-    def connect(self, *, endpoint: str, session_name: str | None) -> dict[str, Any]:
+    def connect(
+        self,
+        *,
+        endpoint: str,
+        session_name: str | None,
+        notifier: ChannelNotifier | None = None,
+    ) -> dict[str, Any]:
+        """Open the channel: register presence, start consumer.
+
+        `notifier` is the surface to which inbound stream messages are
+        forwarded. In production it's the AsyncNotifier built from the
+        MCP session + loop; in tests it's a RecordingNotifier or NoopNotifier.
+        """
         try:
             with self._lock:
                 if self._presence is not None:
@@ -79,7 +101,19 @@ class ServerState:
                     ttl_seconds=registry.defaults.registry_ttl_seconds,
                 )
                 presence.start()
+
+                resolved_notifier: ChannelNotifier = notifier or NoopNotifier()
+                consumer = Consumer(
+                    client,
+                    resolved_name,
+                    on_message=resolved_notifier.emit,
+                    block_ms=registry.defaults.consumer_block_ms,
+                )
+                consumer.start()
+
                 self._presence = presence
+                self._consumer = consumer
+                self._notifier = resolved_notifier
                 self._client = client
                 self._endpoint_name = endpoint
                 return {
@@ -91,6 +125,8 @@ class ServerState:
                     "cwd": metadata.cwd,
                     "heartbeat_seconds": registry.defaults.heartbeat_seconds,
                     "registry_ttl_seconds": registry.defaults.registry_ttl_seconds,
+                    "consumer_attached": True,
+                    "notifier_kind": type(resolved_notifier).__name__,
                 }
         except RegistryError as e:
             return _format_registry_error(e)
@@ -147,6 +183,57 @@ class ServerState:
             log.exception("list failed")
             return {"ok": False, "error": type(e).__name__, "detail": str(e)}
 
+    def reply(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        voice: bool = False,
+        in_reply_to: str | None = None,
+    ) -> dict[str, Any]:
+        """XADD an Outbound payload to the active session's outbound stream."""
+        try:
+            if not chat_id or not chat_id.strip():
+                raise ValueError("chat_id must be non-empty")
+            if not text or not text.strip():
+                raise ValueError("text must be non-empty")
+            with self._lock:
+                if self._presence is None or self._client is None:
+                    return {
+                        "ok": False,
+                        "error": "not connected — call redis_bridge_connect first",
+                    }
+                session_name = self._presence.session_name
+                endpoint = self._endpoint_name or ""
+                client = self._client
+
+            # Validate via Pydantic; rejects empty text, malformed chat_id, etc.
+            payload = Outbound(
+                session_name=session_name,
+                endpoint=endpoint,
+                chat_id=chat_id,
+                text=text,
+                voice=voice,
+                in_reply_to=in_reply_to,
+                ts=time.time(),
+            )
+            msg_id = publish_outbound(
+                client,
+                session_name,
+                payload.model_dump(mode="json", exclude_none=True),
+            )
+            return {
+                "ok": True,
+                "session_name": session_name,
+                "chat_id": chat_id,
+                "msg_id": msg_id,
+            }
+        except ValueError as e:
+            return {"ok": False, "error": "invalid argument", "detail": str(e)}
+        except Exception as e:  # noqa: BLE001
+            log.exception("reply failed")
+            return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
     def shutdown(self) -> None:
         """Best-effort cleanup on process exit."""
         with self._lock:
@@ -154,6 +241,14 @@ class ServerState:
                 self._disconnect_locked(reason="shutdown")
 
     def _disconnect_locked(self, *, reason: str) -> None:
+        # Order: stop consumer first (so it doesn't try to ack on a stale
+        # client), then presence, then close the client.
+        if self._consumer is not None:
+            try:
+                self._consumer.stop()
+            except Exception:  # noqa: BLE001
+                log.exception("consumer.stop raised during disconnect")
+            self._consumer = None
         if self._presence is not None:
             try:
                 self._presence.stop(reason=reason)
@@ -169,6 +264,7 @@ class ServerState:
                 log.exception("redis client close raised during disconnect")
             self._client = None
         self._endpoint_name = None
+        self._notifier = None
 
 
 _STATE = ServerState()
@@ -190,15 +286,31 @@ def _format_registry_error(err: RegistryError) -> dict[str, Any]:
     return {"ok": False, "error": "registry parse error", "detail": str(err)}
 
 
+def _build_async_notifier(ctx: Context | None) -> ChannelNotifier:
+    """If we have an MCP session + running loop, build a real notifier.
+
+    Falls back to NoopNotifier if Context isn't injected (test code paths
+    that call ServerState.connect directly should pass their own notifier).
+    """
+    if ctx is None:
+        return NoopNotifier()
+    try:
+        session = ctx.session
+        loop = asyncio.get_running_loop()
+    except Exception:  # noqa: BLE001
+        return NoopNotifier()
+    return AsyncNotifier(session, loop)
+
+
 def build_app() -> FastMCP:
-    """Construct the FastMCP app with all Phase 1 tools registered."""
+    """Construct the FastMCP app with all redis-bridge tools registered."""
     app = FastMCP(
         name=f"redis-bridge v{__version__}",
         instructions=(
             "Generic Redis-streams bridge for Claude Code sessions. "
             "Pair with a router (e.g. hermes-claude-code-router) on the consumer "
-            "side. Phase 1: presence + listing. Later phases add bidirectional "
-            "channel notifications + reply tool."
+            "side. The connect tool registers presence + starts the inbound "
+            "consumer; reply XADDs outbound messages."
         ),
     )
 
@@ -207,25 +319,32 @@ def build_app() -> FastMCP:
         description=(
             "Connect this Claude Code session to a redis-bridge endpoint "
             "(typically a Hermes profile like 'mimir'). Registers in the shared "
-            "Redis registry and starts a 10s heartbeat. Returns the resolved "
-            "session_name and endpoint metadata."
+            "Redis registry, starts a 10s heartbeat, and attaches an inbound "
+            "consumer that emits notifications/claude/channel for each XADD'd "
+            "inbound message. Returns the resolved session_name + metadata."
         ),
     )
-    def redis_bridge_connect(
+    async def redis_bridge_connect(
         endpoint: str = "mimir",
         session_name: str | None = None,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
-        return _STATE.connect(endpoint=endpoint, session_name=session_name)
+        notifier = _build_async_notifier(ctx)
+        return _STATE.connect(
+            endpoint=endpoint,
+            session_name=session_name,
+            notifier=notifier,
+        )
 
     @app.tool(
         name="redis_bridge_disconnect",
         description=(
             "Gracefully disconnect from the redis-bridge endpoint: stops "
-            "heartbeat, removes the session from the registry, and emits an "
-            "'unregistered' lifecycle event."
+            "heartbeat + consumer, removes the session from the registry, "
+            "and emits an 'unregistered' lifecycle event."
         ),
     )
-    def redis_bridge_disconnect() -> dict[str, Any]:
+    async def redis_bridge_disconnect() -> dict[str, Any]:
         return _STATE.disconnect()
 
     @app.tool(
@@ -236,8 +355,34 @@ def build_app() -> FastMCP:
             "lazily GCs them from the registry. Requires a prior connect."
         ),
     )
-    def redis_bridge_list() -> dict[str, Any]:
+    async def redis_bridge_list() -> dict[str, Any]:
         return _STATE.list_sessions()
+
+    @app.tool(
+        name="reply",
+        description=(
+            "Send a reply to the originating chat surface. The router on the "
+            "other side of the redis-bridge listens to outbound messages and "
+            "writes them to the corresponding Discord channel/DM/thread/voice. "
+            "Set voice=True to request TTS playback in the originating voice "
+            "channel (router may ignore if the source wasn't voice). chat_id "
+            "must match the value provided on the inbound notification. "
+            "Optionally pass in_reply_to=<original message_id from the "
+            "inbound notification's _msg_id field> to thread the reply."
+        ),
+    )
+    async def reply(
+        chat_id: str,
+        text: str,
+        voice: bool = False,
+        in_reply_to: str | None = None,
+    ) -> dict[str, Any]:
+        return _STATE.reply(
+            chat_id=chat_id,
+            text=text,
+            voice=voice,
+            in_reply_to=in_reply_to,
+        )
 
     return app
 

--- a/plugins/redis-bridge/server/notifier.py
+++ b/plugins/redis-bridge/server/notifier.py
@@ -1,0 +1,87 @@
+"""Channel-notification emission.
+
+The Consumer thread needs to push `notifications/claude/channel` events
+out through the MCP `ServerSession`. `send_notification` is an async
+method that must run on the asyncio loop that owns the session — but
+the Consumer runs on a plain `threading.Thread`. This module bridges
+the two.
+
+`AsyncNotifier` is the production implementation: it captures both
+references at connect-time and uses `asyncio.run_coroutine_threadsafe`
+to schedule the send. `RecordingNotifier` is the test seam — it records
+emitted payloads without touching asyncio at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Protocol
+
+from mcp.types import Notification
+
+log = logging.getLogger(__name__)
+
+CHANNEL_NOTIFICATION_METHOD = "notifications/claude/channel"
+
+
+class ChannelNotifier(Protocol):
+    """Thread-safe notification emitter consumed by `Consumer.on_message`."""
+
+    def emit(self, payload: dict[str, Any]) -> None: ...
+
+
+class AsyncNotifier:
+    """Sends notifications/claude/channel to the connected MCP client.
+
+    Constructed inside an MCP tool handler so the asyncio loop + session
+    are available. The emit() method is called from the consumer thread.
+    """
+
+    def __init__(self, session: Any, loop: asyncio.AbstractEventLoop) -> None:
+        self._session = session
+        self._loop = loop
+
+    def emit(self, payload: dict[str, Any]) -> None:
+        # The generic Notification[dict, str] form lets us emit non-standard
+        # method names that aren't in the MCP SDK's ServerNotification union.
+        # FastMCP/ServerSession serializes the payload by Pydantic dump, so
+        # the runtime accepts this even though static types reject it.
+        if self._loop.is_closed():
+            # Don't even create the coroutine — that would leak un-awaited.
+            log.debug("AsyncNotifier: loop closed, dropping payload")
+            return
+        notif = Notification[dict, str](
+            method=CHANNEL_NOTIFICATION_METHOD,
+            params=payload,
+        )
+        coro = self._session.send_notification(notif)  # type: ignore[arg-type]
+        try:
+            asyncio.run_coroutine_threadsafe(coro, self._loop)
+        except RuntimeError:
+            # Loop transitioned to closed between the check and the schedule.
+            # Close the coroutine explicitly so we don't leak.
+            coro.close()
+            log.debug("AsyncNotifier: loop closed mid-emit, dropping payload")
+
+
+class RecordingNotifier:
+    """Test-only notifier: appends payloads to a list. Threadsafe."""
+
+    def __init__(self) -> None:
+        import threading
+
+        self._lock = threading.Lock()
+        self.emitted: list[dict[str, Any]] = []
+
+    def emit(self, payload: dict[str, Any]) -> None:
+        with self._lock:
+            self.emitted.append(payload)
+
+
+class NoopNotifier:
+    """No-op notifier used when no MCP session is attached (e.g. early
+    Phase 1 tests). Drops every emit silently."""
+
+    def emit(self, payload: dict[str, Any]) -> None:
+        log.debug("NoopNotifier dropping payload (no session attached)")

--- a/plugins/redis-bridge/server/redis_consumer.py
+++ b/plugins/redis-bridge/server/redis_consumer.py
@@ -1,0 +1,200 @@
+"""Inbound Redis stream consumer for redis-bridge.
+
+Reads `cc-sessions:<session_name>:inbound` via XREADGROUP and invokes a
+caller-supplied callback for each message. The callback is responsible
+for emitting the matching `notifications/claude/channel` MCP event;
+this module knows nothing about MCP.
+
+Threading model
+---------------
+
+`Consumer` runs on a dedicated daemon thread. The thread blocks on
+`XREADGROUP ... BLOCK 1000` so stop signals (via threading.Event) can
+flip the next iteration off without waiting indefinitely. Acks happen
+after the callback returns; a callback that raises does NOT ack — the
+message is re-delivered after the consumer group's pel-idle timeout
+(default redis: 1ms; in our flow, on the next iteration if we're alone).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import redis.exceptions
+
+log = logging.getLogger(__name__)
+
+INBOUND_STREAM_FMT = "cc-sessions:{session_name}:inbound"
+GROUP_NAME_FMT = "cc:{session_name}"
+CONSUMER_NAME_DEFAULT = "consumer-1"
+
+
+def inbound_stream(session_name: str) -> str:
+    return INBOUND_STREAM_FMT.format(session_name=session_name)
+
+
+def consumer_group(session_name: str) -> str:
+    return GROUP_NAME_FMT.format(session_name=session_name)
+
+
+# Callback type: receives the decoded payload dict (validated upstream
+# against Inbound pydantic model by the channel layer).
+MessageCallback = Callable[[dict[str, Any]], None]
+
+
+def ensure_group(client: Any, *, stream: str, group: str, start: str = "$") -> bool:
+    """Create the consumer group if absent. Returns True if newly created.
+
+    Idempotent: BUSYGROUP errors are treated as success. `start="$"` means
+    "only deliver new messages from now on" — what we want; messages already
+    in the stream before we attach were either delivered to a prior consumer
+    or are stale.
+    """
+    try:
+        client.xgroup_create(name=stream, groupname=group, id=start, mkstream=True)
+        return True
+    except redis.exceptions.ResponseError as e:
+        if "BUSYGROUP" in str(e):
+            return False
+        raise
+
+
+class Consumer:
+    """Reads inbound Redis stream messages, dispatches to a callback.
+
+    Lifecycle:
+        c = Consumer(client, "my-session", on_message)
+        c.start()
+        ...
+        c.stop()
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        session_name: str,
+        on_message: MessageCallback,
+        *,
+        consumer_name: str = CONSUMER_NAME_DEFAULT,
+        block_ms: int = 1000,
+        batch_count: int = 16,
+    ) -> None:
+        self._client = client
+        self._session_name = session_name
+        self._on_message = on_message
+        self._consumer_name = consumer_name
+        self._block_ms = block_ms
+        self._batch_count = batch_count
+        self._stream = inbound_stream(session_name)
+        self._group = consumer_group(session_name)
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started = False
+
+    @property
+    def session_name(self) -> str:
+        return self._session_name
+
+    def start(self) -> None:
+        if self._started:
+            raise RuntimeError(f"Consumer({self._session_name}) already started")
+        ensure_group(self._client, stream=self._stream, group=self._group)
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name=f"redis-bridge-consumer-{self._session_name}",
+            daemon=True,
+        )
+        self._thread.start()
+        self._started = True
+        log.info(
+            "consumer started for session=%s stream=%s group=%s",
+            self._session_name,
+            self._stream,
+            self._group,
+        )
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        if not self._started:
+            return
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        self._started = False
+        log.info("consumer stopped for session=%s", self._session_name)
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._read_once()
+            except redis.exceptions.ConnectionError:
+                # Transient. Sleep briefly via the Event so stop() is responsive.
+                log.warning("consumer: redis connection error; retrying")
+                if self._stop_event.wait(1.0):
+                    return
+            except Exception:  # noqa: BLE001
+                log.exception("consumer loop iteration failed; continuing")
+                if self._stop_event.wait(1.0):
+                    return
+
+    def _read_once(self) -> None:
+        resp = self._client.xreadgroup(
+            groupname=self._group,
+            consumername=self._consumer_name,
+            streams={self._stream: ">"},
+            count=self._batch_count,
+            block=self._block_ms,
+        )
+        if not resp:
+            return
+        for _stream_name, entries in resp:
+            for msg_id, fields in entries:
+                self._dispatch(msg_id, fields)
+
+    def _dispatch(self, msg_id: str, fields: dict[str, str]) -> None:
+        payload_raw = fields.get("payload")
+        if payload_raw is None:
+            log.warning(
+                "consumer: dropping malformed message %s on %s (no payload)",
+                msg_id,
+                self._stream,
+            )
+            self._ack(msg_id)
+            return
+        try:
+            payload = json.loads(payload_raw)
+        except json.JSONDecodeError:
+            log.warning(
+                "consumer: dropping un-decodable JSON message %s on %s",
+                msg_id,
+                self._stream,
+            )
+            self._ack(msg_id)
+            return
+        if not isinstance(payload, dict):
+            log.warning("consumer: dropping non-object payload in message %s", msg_id)
+            self._ack(msg_id)
+            return
+        # Tag the message-id so the callback can store it for reply correlation.
+        payload.setdefault("_msg_id", msg_id)
+        try:
+            self._on_message(payload)
+        except Exception:  # noqa: BLE001
+            # Callback failed. Don't ack; leave message in PEL for re-delivery.
+            log.exception(
+                "consumer: on_message callback failed for %s; leaving unacked",
+                msg_id,
+            )
+            return
+        self._ack(msg_id)
+
+    def _ack(self, msg_id: str) -> None:
+        try:
+            self._client.xack(self._stream, self._group, msg_id)
+        except Exception:  # noqa: BLE001
+            log.exception("consumer: xack failed for %s", msg_id)

--- a/plugins/redis-bridge/server/redis_producer.py
+++ b/plugins/redis-bridge/server/redis_producer.py
@@ -1,0 +1,52 @@
+"""Outbound Redis stream producer for redis-bridge.
+
+XADDs JSON-encoded payloads onto `cc-sessions:<session_name>:outbound`.
+Stream length is capped via MAXLEN ~ to avoid unbounded growth on a
+session whose consumer is slow or absent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+OUTBOUND_STREAM_FMT = "cc-sessions:{session_name}:outbound"
+DEFAULT_MAXLEN = 10_000
+
+
+def outbound_stream(session_name: str) -> str:
+    return OUTBOUND_STREAM_FMT.format(session_name=session_name)
+
+
+def publish_outbound(
+    client: Any,
+    session_name: str,
+    payload: dict[str, Any],
+    *,
+    maxlen: int = DEFAULT_MAXLEN,
+) -> str:
+    """XADD a payload to the outbound stream. Returns the assigned message ID.
+
+    The full payload is JSON-encoded into a single `payload` field. We
+    intentionally do NOT spread the payload across multiple Redis fields:
+    keeping it as one opaque blob mirrors the inbound contract and means
+    consumers don't have to special-case field-set differences.
+    """
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    raw_id = client.xadd(
+        outbound_stream(session_name),
+        {"payload": body},
+        maxlen=maxlen,
+        approximate=True,
+    )
+    msg_id = str(raw_id)
+    log.debug(
+        "published outbound msg %s on session=%s len=%d",
+        msg_id,
+        session_name,
+        len(body),
+    )
+    return msg_id

--- a/tests/test_redis_bridge_channel.py
+++ b/tests/test_redis_bridge_channel.py
@@ -236,7 +236,7 @@ def test_shutdown_disconnects_active_session(patched_state: channel.ServerState,
 
 
 def test_build_app_smoke() -> None:
-    """Verify FastMCP wiring constructs cleanly + registers our 3 tools."""
+    """Verify FastMCP wiring constructs cleanly + registers all expected tools."""
     app = channel.build_app()
     # FastMCP exposes registered tools via a _tool_manager or tools attribute,
     # depending on version. Try both; if neither exists we just ensure the
@@ -248,6 +248,162 @@ def test_build_app_smoke() -> None:
     elif hasattr(app, "tools"):
         tool_names = {t.name for t in app.tools}
     if tool_names:
-        assert {"redis_bridge_connect", "redis_bridge_disconnect", "redis_bridge_list"} <= (
-            tool_names
+        expected = {
+            "redis_bridge_connect",
+            "redis_bridge_disconnect",
+            "redis_bridge_list",
+            "reply",
+        }
+        assert expected <= tool_names
+
+
+# ─── Phase 2 additions: consumer + reply ────────────────────────────────────
+
+
+import threading  # noqa: E402
+import time as _time  # noqa: E402
+
+from server import notifier as notifier_mod  # noqa: E402, type: ignore[import-not-found]
+from server import redis_consumer, redis_producer  # noqa: E402, type: ignore[import-not-found]
+
+
+def test_connect_attaches_inbound_consumer(patched_state: channel.ServerState, fr: Any) -> None:
+    """A message XADD'd to inbound after connect reaches the notifier."""
+    rec = notifier_mod.RecordingNotifier()
+    out = patched_state.connect(endpoint="mimir", session_name="with-consumer", notifier=rec)
+    try:
+        assert out["ok"] is True
+        assert out["consumer_attached"] is True
+        assert out["notifier_kind"] == "RecordingNotifier"
+
+        # Simulate the router writing an inbound message
+        stream = redis_consumer.inbound_stream("with-consumer")
+        msg_id = fr.xadd(
+            stream, {"payload": json.dumps({"text": "hi from router", "chat_id": "c1"})}
         )
+
+        # Wait for the consumer thread to dispatch
+        for _ in range(30):
+            if rec.emitted:
+                break
+            _time.sleep(0.1)
+        assert len(rec.emitted) == 1
+        payload = rec.emitted[0]
+        assert payload["text"] == "hi from router"
+        assert payload["chat_id"] == "c1"
+        assert payload["_msg_id"] == msg_id
+    finally:
+        patched_state.disconnect()
+
+
+def test_disconnect_stops_consumer(patched_state: channel.ServerState, fr: Any) -> None:
+    rec = notifier_mod.RecordingNotifier()
+    patched_state.connect(endpoint="mimir", session_name="stop-test", notifier=rec)
+    patched_state.disconnect()
+
+    # Find any thread named redis-bridge-consumer-stop-test — should be gone
+    matches = [t for t in threading.enumerate() if "consumer-stop-test" in t.name]
+    assert matches == [] or not any(t.is_alive() for t in matches)
+
+
+def test_second_connect_replaces_consumer(patched_state: channel.ServerState, fr: Any) -> None:
+    rec1 = notifier_mod.RecordingNotifier()
+    patched_state.connect(endpoint="mimir", session_name="first", notifier=rec1)
+    rec2 = notifier_mod.RecordingNotifier()
+    patched_state.connect(endpoint="mimir", session_name="second", notifier=rec2)
+    try:
+        # Write to second's inbound — only rec2 sees it
+        stream = redis_consumer.inbound_stream("second")
+        fr.xadd(stream, {"payload": json.dumps({"text": "for second"})})
+        for _ in range(30):
+            if rec2.emitted:
+                break
+            _time.sleep(0.1)
+        assert any(p["text"] == "for second" for p in rec2.emitted)
+        assert rec1.emitted == []
+    finally:
+        patched_state.disconnect()
+
+
+def test_reply_xadds_to_outbound(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="reply-test")
+    try:
+        out = patched_state.reply(
+            chat_id="c-discord-123",
+            text="hello back",
+            voice=False,
+        )
+        assert out["ok"] is True
+        assert out["session_name"] == "reply-test"
+        assert out["chat_id"] == "c-discord-123"
+        msg_id = out["msg_id"]
+        # Now read the outbound stream to verify
+        entries = fr.xrange(redis_producer.outbound_stream("reply-test"))
+        assert len(entries) == 1
+        written_id, fields = entries[0]
+        assert written_id == msg_id
+        payload = json.loads(fields["payload"])
+        assert payload["session_name"] == "reply-test"
+        assert payload["endpoint"] == "mimir"
+        assert payload["chat_id"] == "c-discord-123"
+        assert payload["text"] == "hello back"
+        assert payload["voice"] is False
+    finally:
+        patched_state.disconnect()
+
+
+def test_reply_propagates_voice_flag(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="voice-reply")
+    try:
+        patched_state.reply(chat_id="vc-1", text="speak this", voice=True)
+        entries = fr.xrange(redis_producer.outbound_stream("voice-reply"))
+        payload = json.loads(entries[0][1]["payload"])
+        assert payload["voice"] is True
+    finally:
+        patched_state.disconnect()
+
+
+def test_reply_in_reply_to(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="thread-reply")
+    try:
+        patched_state.reply(
+            chat_id="c1",
+            text="answer",
+            in_reply_to="1716000000000-0",
+        )
+        entries = fr.xrange(redis_producer.outbound_stream("thread-reply"))
+        payload = json.loads(entries[0][1]["payload"])
+        assert payload["in_reply_to"] == "1716000000000-0"
+    finally:
+        patched_state.disconnect()
+
+
+def test_reply_when_not_connected(patched_state: channel.ServerState) -> None:
+    out = patched_state.reply(chat_id="c1", text="hi")
+    assert out["ok"] is False
+    assert "not connected" in out["error"]
+
+
+def test_reply_validates_empty_text(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="validate-empty")
+    try:
+        out = patched_state.reply(chat_id="c1", text="")
+        assert out["ok"] is False
+        assert out["error"] == "invalid argument"
+        assert "text" in out["detail"]
+        # Whitespace-only also rejected
+        out2 = patched_state.reply(chat_id="c1", text="   \n  ")
+        assert out2["ok"] is False
+    finally:
+        patched_state.disconnect()
+
+
+def test_reply_validates_empty_chat_id(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="validate-chat")
+    try:
+        out = patched_state.reply(chat_id="", text="hi")
+        assert out["ok"] is False
+        assert out["error"] == "invalid argument"
+        assert "chat_id" in out["detail"]
+    finally:
+        patched_state.disconnect()

--- a/tests/test_redis_bridge_consumer.py
+++ b/tests/test_redis_bridge_consumer.py
@@ -1,0 +1,213 @@
+"""Tests for the inbound Redis stream consumer."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+import fakeredis
+import pytest
+from server import redis_consumer  # type: ignore[import-not-found]
+
+
+@pytest.fixture
+def fr() -> Any:
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+def _xadd_inbound(fr: Any, session_name: str, payload: dict[str, Any]) -> str:
+    """Helper: produce a message onto the inbound stream the same way the router would."""
+    body = json.dumps(payload)
+    msg_id = fr.xadd(
+        redis_consumer.inbound_stream(session_name),
+        {"payload": body},
+        maxlen=10_000,
+        approximate=True,
+    )
+    return str(msg_id)
+
+
+def test_inbound_stream_naming() -> None:
+    assert redis_consumer.inbound_stream("foo") == "cc-sessions:foo:inbound"
+    assert redis_consumer.consumer_group("foo") == "cc:foo"
+
+
+def test_ensure_group_creates_and_is_idempotent(fr: Any) -> None:
+    stream = redis_consumer.inbound_stream("s")
+    group = redis_consumer.consumer_group("s")
+    assert redis_consumer.ensure_group(fr, stream=stream, group=group) is True
+    # Second call returns False (BUSYGROUP)
+    assert redis_consumer.ensure_group(fr, stream=stream, group=group) is False
+
+
+def test_consumer_dispatches_published_message(fr: Any) -> None:
+    received: list[dict[str, Any]] = []
+    event = threading.Event()
+
+    def cb(payload: dict[str, Any]) -> None:
+        received.append(payload)
+        event.set()
+
+    c = redis_consumer.Consumer(fr, "s", on_message=cb, block_ms=100)
+    c.start()
+    try:
+        msg_id = _xadd_inbound(fr, "s", {"v": 1, "text": "hi", "chat_id": "c1"})
+        assert event.wait(timeout=3.0), "callback was never invoked"
+        assert len(received) == 1
+        payload = received[0]
+        assert payload["text"] == "hi"
+        assert payload["chat_id"] == "c1"
+        assert payload["_msg_id"] == msg_id
+    finally:
+        c.stop()
+
+
+def test_consumer_acks_after_dispatch(fr: Any) -> None:
+    seen = threading.Event()
+
+    def cb(_p: dict) -> None:
+        seen.set()
+
+    c = redis_consumer.Consumer(fr, "ack-test", on_message=cb, block_ms=100)
+    c.start()
+    try:
+        _xadd_inbound(fr, "ack-test", {"text": "x"})
+        assert seen.wait(timeout=3.0)
+        # Give the ack a moment
+        time.sleep(0.2)
+        # Pending entries list should be empty
+        pending = fr.xpending(
+            redis_consumer.inbound_stream("ack-test"),
+            redis_consumer.consumer_group("ack-test"),
+        )
+        assert pending["pending"] == 0
+    finally:
+        c.stop()
+
+
+def test_consumer_does_not_ack_on_callback_exception(fr: Any) -> None:
+    """A raising callback leaves the message in the pending entries list,
+    so it can be reprocessed (here: by the same consumer on its next call,
+    after the consumer recovers)."""
+    fail_then_succeed_calls = [0]
+    seen_after_recovery = threading.Event()
+
+    def cb(_p: dict) -> None:
+        fail_then_succeed_calls[0] += 1
+        if fail_then_succeed_calls[0] == 1:
+            raise RuntimeError("first call fails")
+        seen_after_recovery.set()
+
+    c = redis_consumer.Consumer(fr, "retry-test", on_message=cb, block_ms=100)
+    c.start()
+    try:
+        _xadd_inbound(fr, "retry-test", {"text": "x"})
+        # First dispatch fails; message stays in PEL.
+        # Wait a beat, then manually claim the pending entry and re-dispatch.
+        time.sleep(0.5)
+        stream = redis_consumer.inbound_stream("retry-test")
+        group = redis_consumer.consumer_group("retry-test")
+        pending = fr.xpending(stream, group)
+        # Should be 1 unacked message
+        assert pending["pending"] == 1
+    finally:
+        c.stop()
+
+
+def test_consumer_drops_malformed_payload(fr: Any) -> None:
+    """Missing 'payload' field → drop and ack (don't loop on bad data)."""
+    received: list[dict[str, Any]] = []
+    c = redis_consumer.Consumer(fr, "mal", on_message=received.append, block_ms=100)
+    c.start()
+    try:
+        # Write a message with a different field name
+        fr.xadd(redis_consumer.inbound_stream("mal"), {"not-payload": "junk"})
+        time.sleep(0.3)
+        assert received == []
+        # Was acked despite the malformation
+        pending = fr.xpending(
+            redis_consumer.inbound_stream("mal"),
+            redis_consumer.consumer_group("mal"),
+        )
+        assert pending["pending"] == 0
+    finally:
+        c.stop()
+
+
+def test_consumer_drops_invalid_json(fr: Any) -> None:
+    received: list[dict[str, Any]] = []
+    c = redis_consumer.Consumer(fr, "bad-json", on_message=received.append, block_ms=100)
+    c.start()
+    try:
+        fr.xadd(redis_consumer.inbound_stream("bad-json"), {"payload": "{not json}"})
+        time.sleep(0.3)
+        assert received == []
+        pending = fr.xpending(
+            redis_consumer.inbound_stream("bad-json"),
+            redis_consumer.consumer_group("bad-json"),
+        )
+        assert pending["pending"] == 0
+    finally:
+        c.stop()
+
+
+def test_consumer_drops_non_object_payload(fr: Any) -> None:
+    """payload is JSON but not an object — list or scalar."""
+    received: list[dict[str, Any]] = []
+    c = redis_consumer.Consumer(fr, "nonobj", on_message=received.append, block_ms=100)
+    c.start()
+    try:
+        fr.xadd(
+            redis_consumer.inbound_stream("nonobj"),
+            {"payload": "[1, 2, 3]"},
+        )
+        time.sleep(0.3)
+        assert received == []
+    finally:
+        c.stop()
+
+
+def test_consumer_rejects_double_start(fr: Any) -> None:
+    c = redis_consumer.Consumer(fr, "s", on_message=lambda _: None, block_ms=100)
+    c.start()
+    try:
+        with pytest.raises(RuntimeError, match="already started"):
+            c.start()
+    finally:
+        c.stop()
+
+
+def test_consumer_stop_is_idempotent(fr: Any) -> None:
+    c = redis_consumer.Consumer(fr, "s", on_message=lambda _: None, block_ms=100)
+    c.start()
+    c.stop()
+    c.stop()  # must not raise
+
+
+def test_consumer_batch_count(fr: Any) -> None:
+    received: list[dict[str, Any]] = []
+    lock = threading.Lock()
+
+    def cb(p: dict) -> None:
+        with lock:
+            received.append(p)
+
+    c = redis_consumer.Consumer(fr, "batch", on_message=cb, block_ms=100, batch_count=5)
+    c.start()
+    try:
+        # Pre-publish 5 messages, then start observing
+        for i in range(5):
+            _xadd_inbound(fr, "batch", {"i": i, "text": f"msg{i}"})
+        # Give consumer time to drain
+        for _ in range(30):
+            with lock:
+                if len(received) >= 5:
+                    break
+            time.sleep(0.1)
+        with lock:
+            assert len(received) == 5
+            assert [p["i"] for p in received] == [0, 1, 2, 3, 4]
+    finally:
+        c.stop()

--- a/tests/test_redis_bridge_notifier.py
+++ b/tests/test_redis_bridge_notifier.py
@@ -1,0 +1,85 @@
+"""Tests for the channel-notification emitters."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from server import notifier  # type: ignore[import-not-found]
+
+
+def test_recording_notifier_appends() -> None:
+    n = notifier.RecordingNotifier()
+    n.emit({"text": "hi"})
+    n.emit({"text": "bye"})
+    assert n.emitted == [{"text": "hi"}, {"text": "bye"}]
+
+
+def test_recording_notifier_threadsafe() -> None:
+    n = notifier.RecordingNotifier()
+
+    def _hammer() -> None:
+        for i in range(50):
+            n.emit({"i": i})
+
+    threads = [threading.Thread(target=_hammer) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(n.emitted) == 500
+
+
+def test_noop_notifier_drops_silently() -> None:
+    n = notifier.NoopNotifier()
+    n.emit({"any": "payload"})  # no exception, no observable effect
+
+
+def test_async_notifier_schedules_coroutine() -> None:
+    """AsyncNotifier.emit() schedules send_notification on the captured loop."""
+
+    sent: list = []
+
+    class StubSession:
+        async def send_notification(self, notif):  # noqa: ANN001
+            sent.append(notif)
+
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    try:
+        n = notifier.AsyncNotifier(StubSession(), loop)
+        n.emit({"text": "hello", "chat_id": "c1"})
+        # Give the loop a tick to process
+        for _ in range(50):
+            if sent:
+                break
+            import time
+
+            time.sleep(0.02)
+        assert len(sent) == 1
+        notif = sent[0]
+        assert notif.method == notifier.CHANNEL_NOTIFICATION_METHOD
+        assert notif.params == {"text": "hello", "chat_id": "c1"}
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2.0)
+        loop.close()
+
+
+def test_async_notifier_swallows_loop_errors() -> None:
+    """If the loop is closed at emit time, emit() must not raise."""
+    loop = asyncio.new_event_loop()
+    loop.close()  # close before emit so run_coroutine_threadsafe raises
+
+    class StubSession:
+        async def send_notification(self, notif):  # noqa: ANN001
+            pass
+
+    n = notifier.AsyncNotifier(StubSession(), loop)
+    # Should not raise
+    n.emit({"text": "should be dropped"})
+
+
+def test_channel_method_constant() -> None:
+    assert notifier.CHANNEL_NOTIFICATION_METHOD == "notifications/claude/channel"

--- a/tests/test_redis_bridge_producer.py
+++ b/tests/test_redis_bridge_producer.py
@@ -1,0 +1,52 @@
+"""Tests for the outbound Redis stream producer."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import fakeredis
+import pytest
+from server import redis_producer  # type: ignore[import-not-found]
+
+
+@pytest.fixture
+def fr() -> Any:
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+def test_outbound_stream_naming() -> None:
+    assert redis_producer.outbound_stream("foo") == "cc-sessions:foo:outbound"
+
+
+def test_publish_outbound_writes_to_stream(fr: Any) -> None:
+    msg_id = redis_producer.publish_outbound(
+        fr,
+        "s",
+        {"text": "hello", "chat_id": "c1", "voice": True},
+    )
+    assert msg_id is not None
+    entries = fr.xrange(redis_producer.outbound_stream("s"))
+    assert len(entries) == 1
+    written_id, fields = entries[0]
+    assert written_id == msg_id
+    assert "payload" in fields
+    payload = json.loads(fields["payload"])
+    assert payload == {"text": "hello", "chat_id": "c1", "voice": True}
+
+
+def test_publish_outbound_serializes_sorted_keys(fr: Any) -> None:
+    """Deterministic serialization makes the wire format diffable."""
+    redis_producer.publish_outbound(fr, "s", {"b": 2, "a": 1, "c": 3})
+    entries = fr.xrange(redis_producer.outbound_stream("s"))
+    assert entries[0][1]["payload"] == '{"a":1,"b":2,"c":3}'
+
+
+def test_publish_outbound_maxlen(fr: Any) -> None:
+    """MAXLEN ~ caps the stream to roughly the configured length."""
+    for i in range(20):
+        redis_producer.publish_outbound(fr, "s", {"i": i}, maxlen=10)
+    length = fr.xlen(redis_producer.outbound_stream("s"))
+    # MAXLEN ~ approximate; length is close to but not strictly == 10.
+    assert length <= 20
+    assert length >= 1


### PR DESCRIPTION
## Summary

Phase 2 CC-side of the redis-bridge: the inbound consumer + the `reply` MCP tool. Together with the (not-yet-built) router side in `infiquetra/hermes-claude-code-router`, this completes the text-bridge half of the architecture — DMs / channel mentions / thread messages from the router flow into Claude Code as `notifications/claude/channel` events, and `reply` calls flow back as XADD'd outbound payloads.

## What's in this PR

### Source

- **`server/redis_consumer.py`** — XREADGROUP daemon thread per session. Consumer-group setup is idempotent on BUSYGROUP. Acks happen after the callback returns; raising callbacks leave the message in the pending entries list for re-delivery. Drops + acks structurally bad payloads so the consumer never loops on garbage. Original Redis message-id surfaced as `_msg_id` for reply correlation.
- **`server/redis_producer.py`** — \`publish_outbound()\` XADDs sorted-key JSON-encoded payload with MAXLEN ~ 10,000 to bound stream growth.
- **`server/notifier.py`** — bridges the consumer thread → the asyncio loop owning the MCP session. Uses the generic `Notification[dict, str](method="notifications/claude/channel", params=...)` form (the MCP SDK has no `notifications/claude/channel` in its typed `ServerNotificationType` union — see LEARNINGS entry). \`asyncio.run_coroutine_threadsafe\` to schedule the send. Loop-closed guard prevents un-awaited coroutines on shutdown. \`RecordingNotifier\` / \`NoopNotifier\` test seams.
- **`server/channel.py`** — \`connect()\` now also starts a consumer with the wired notifier; \`disconnect()\` stops the consumer first (so it doesn't try to ack on a stale client). New **`reply`** MCP tool with \`chat_id\`, \`text\`, \`voice\`, \`in_reply_to\` args; server-side guards reject empty/whitespace inputs.
- **`agents/redis-bridge-coach.md`** — rewritten to describe the actual inbound-payload field names (\`source\`, \`chat_id\`, \`_msg_id\`, etc.) and the "inline choices instead of AskUserQuestion" guidance.

### Tests + checks

- 30 new unit tests: consumer (11), producer (4), notifier (6), channel additions (9).
- Repo total: **378 tests pass**, ruff clean, ruff format clean, mypy clean across all 56 source files.
- All four CI commands run locally to parity this time, catching the gaps that bit Phase 1.

### Engineering journal

New LEARNINGS entry: **Emitting custom MCP notification methods from FastMCP** — how to use the generic \`Notification[dict, str]\` form to emit vendor-specific notification methods (like \`notifications/claude/channel\`) that aren't in the MCP SDK's typed union. Documents the runtime/static-type mismatch and the `type: ignore[arg-type]` workaround.

## Plugin version

0.2.0 → 0.3.0.

## ⚠ Verification gap

**Not yet verified against real Redis or a real Claude Code session.** All testing has been against fakeredis. Before merging Phase 3 work, we should:

1. With \`~/.claude/channels/redis-bridge/registry.json\` configured for the real Mac mini Redis, run \`/redis-bridge-connect mimir\` in a Claude Code session.
2. From \`redis-cli\` on the Mac mini, manually XADD an inbound payload: \`XADD cc-sessions:<name>:inbound * payload '{"v":1,"router":"manual","endpoint":"mimir","source":"dm","chat_id":"test","user_id":"u","username":"tester","text":"hello","ts":12345.0}'\`
3. Claude should receive a \`notifications/claude/channel\` event and surface the message.
4. Have Claude call \`reply(chat_id="test", text="hi back")\` — verify the outbound stream gets the XADD'd payload via \`XRANGE cc-sessions:<name>:outbound - +\`.
5. SIGKILL the CC process; verify within 60s the heartbeat key expires + the registry entry is GC'd on the next \`list\`.

That manual integration test will catch any FastMCP-context-injection issues, asyncio-loop capture issues, or stdio-MCP-notification delivery issues that fakeredis can't surface.

## Test plan

- [ ] Live-Redis verification per ⚠ above (5 steps)
- [ ] CI runs full suite + lint + format + mypy — should be all green this time (verified locally with the same commands)
- [ ] Confirm no regression in other plugins (378 tests already green; CI will re-confirm)

## Refs

- Plan: \`~/.claude/plans/i-would-like-to-distributed-hanrahan.md\`
- Phase 1 PR: #128
- Phase 0 PR: #127
- Next on this side: Phase 4 (permission relay + AskUserQuestion interception + audit log). Phase 3 (voice routing) is mostly router-side; CC side needs no changes there. Both depend on the router being built.