### PR TITLE
chore(marketplace): register redis-bridge v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -339,7 +339,29 @@
         "mount-olympus"
       ],
       "category": "development"
+    },
+    {
+      "name": "redis-bridge",
+      "source": "./plugins/redis-bridge",
+      "version": "0.3.0",
+      "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
+      "author": {
+        "name": "Infiquetra",
+        "email": "hello@infiquetra.com"
+      },
+      "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+      "license": "MIT",
+      "keywords": [
+        "claude-code-channel",
+        "mcp",
+        "redis",
+        "redis-streams",
+        "hermes",
+        "voice",
+        "hands-free"
+      ],
+      "category": "development"
     }
   ],
-  "version": "2.0.0"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Summary

I forgot the marketplace entry. Phases 1+2 of redis-bridge merged in #128, #129, #130 but the plugin wasn't registered in \`.claude-plugin/marketplace.json\`, so \`/plugin install redis-bridge\` from inside Claude Code wouldn't find it.

## Changes

- Adds redis-bridge as the 16th plugin entry: v0.3.0, category \`development\`, repo + license fields matching the other entries, keywords reflecting the Redis-streams MCP / hands-free voice focus.
- Bumps marketplace metadata version 2.0.0 → 2.1.0 (additive plugin per semver convention this repo's been using).

## Validation

- \`python3 -m json.tool\` clean.
- \`marketplace/validator/validate.py\` clean: **16 plugins, 0 errors**. The 79 warnings are pre-existing (missing optional \`homepage\` / \`engines\` fields, same as the other 15 plugins).

## How Jeff uses this after merge

From Claude Code:
\`\`\`
/plugin marketplace update
/plugin install redis-bridge@infiquetra-plugins
\`\`\`

Then \`/redis-bridge-connect mimir\` once the registry config at \`~/.claude/channels/redis-bridge/registry.json\` is in place (which I already wrote during the headless integration test).