### PR TITLE
feat(redis-channel): git_branch detection + same-cwd disambiguation

### DIFF
--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,13 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — same-cwd disambiguation + git_branch auto-detection
+
+- `presence.detect_git_branch(cwd)`: runs `git rev-parse --abbrev-ref HEAD` with a 1s subprocess timeout. Returns `None` for non-git dirs / missing cwds / detached HEAD / git not installed / any subprocess failure. `build_metadata` calls it automatically when `git_branch` is unset, so live session metadata in `cc-sessions:registry` now carries the branch — useful for natural-language session routing later.
+- `presence.disambiguate_if_collision(client, base_name, host, pid)`: prevents two CC sessions in the same cwd (which auto-name identically because the name's hash is `sha256(cwd + host)[:8]`) from clobbering each other in Redis. On collision with a live presence owned by a different PID on the same host, appends `-<pid_hex_4>` to the auto-name. Same-PID collision (reconnect) keeps the base name. Stale-entry (hb expired) and corrupt-entry cases pass through cleanly. Only applies when no explicit session_name was passed — user-supplied names are honored as intent and use regular replace semantics.
+- `channel.py:connect` wires disambiguation into the auto-name path.
+- Tests: 8 new presence cases (no-collision, same-PID, different-PID, different-host, short-PID zero-padding, stale, half-state, corrupt) + 2 channel cases (auto-name disambiguates on collision; explicit name does NOT).
+
 ### Added — Phase 2 (text bridge: inbound consumer + reply tool)
 
 - `server/redis_consumer.py`: XREADGROUP consumer thread for `cc-sessions:<name>:inbound`. Creates the consumer group on first connect (idempotent on BUSYGROUP). Each decoded payload is handed to a caller-supplied `on_message` callback. Acks after the callback returns; a raising callback leaves the message in the pending entries list for re-delivery. Drops + acks structurally bad payloads (missing `payload` field, undecodable JSON, non-object body) so the consumer never loops on garbage. The original Redis message-id is attached as `_msg_id` for reply correlation.

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -21,7 +21,9 @@ import asyncio
 import atexit
 import contextlib
 import logging
+import os
 import signal
+import socket
 import sys
 import threading
 import time
@@ -31,7 +33,12 @@ from mcp.server.fastmcp import Context, FastMCP
 
 from . import __version__
 from .notifier import AsyncNotifier, ChannelNotifier, NoopNotifier
-from .presence import Presence, build_metadata, list_live_sessions
+from .presence import (
+    Presence,
+    build_metadata,
+    disambiguate_if_collision,
+    list_live_sessions,
+)
 from .protocol import Outbound
 from .redis_client import connect as redis_connect
 from .redis_consumer import Consumer
@@ -90,6 +97,16 @@ class ServerState:
                 ep = registry.get(endpoint)
                 resolved_name = resolve_session_name(session_name)
                 client = redis_connect(ep)
+                # Auto-disambiguate only when the user didn't supply an
+                # explicit name. An explicit name is treated as intent — we
+                # let the regular reconnect/replace semantics handle it.
+                if session_name is None:
+                    resolved_name = disambiguate_if_collision(
+                        client,
+                        resolved_name,
+                        host=socket.gethostname(),
+                        pid=os.getpid(),
+                    )
                 metadata = build_metadata(
                     session_name=resolved_name,
                     endpoint=endpoint,

--- a/plugins/redis-channel/server/presence.py
+++ b/plugins/redis-channel/server/presence.py
@@ -47,6 +47,50 @@ def events_channel(session_name: str) -> str:
     return f"{EVENTS_CHANNEL_PREFIX}{session_name}"
 
 
+def disambiguate_if_collision(
+    client: RedisLike,
+    base_name: str,
+    *,
+    host: str,
+    pid: int,
+) -> str:
+    """Return a session name that won't collide with a live entry.
+
+    Same-cwd same-host CC sessions auto-name themselves identically (because
+    the auto-name is `sha256(cwd + host)[:8]`). Without this, two background
+    sessions in the same repo race for the same registry key, hb key, and
+    consumer-group consumer name. This helper appends a 4-hex-of-pid suffix
+    on collision.
+
+    Returns base_name unchanged if any of:
+      - no live presence at base_name (hb key absent → either never claimed
+        or stale + about to be GC'd)
+      - the live presence belongs to us (same host AND pid → reconnect from
+        the same process; channel layer handles the local reconnect)
+      - the registry entry is missing or corrupt (best-effort; we'll
+        overwrite it cleanly)
+
+    Disambiguates by appending `-<pid_hex_4>` when a different live process
+    on the same host (or a different host) already owns base_name. PIDs
+    don't actually collide within a single host at the same time, so the
+    suffix is unique enough; across hosts the underlying auto-name already
+    differs (host is in the hash input).
+    """
+    if not client.exists(hb_key(base_name)):
+        return base_name
+    raw = client.hget(REGISTRY_KEY, base_name)
+    if raw is None:
+        return base_name
+    try:
+        existing = SessionMetadata.from_json(raw)
+    except (ValueError, KeyError, json.JSONDecodeError):
+        return base_name
+    if existing.host == host and existing.pid == pid:
+        return base_name
+    suffix = f"{pid:x}"[-4:].rjust(4, "0")
+    return f"{base_name}-{suffix}"
+
+
 @dataclass(frozen=True, slots=True)
 class SessionMetadata:
     """Static registry payload for a CC session.

--- a/plugins/redis-channel/server/presence.py
+++ b/plugins/redis-channel/server/presence.py
@@ -83,6 +83,38 @@ class SessionMetadata:
         )
 
 
+def detect_git_branch(cwd: str) -> str | None:
+    """Return the current git branch for `cwd`, or None if not a git repo / git
+    is unavailable / detection fails for any reason.
+
+    Best-effort: a 1s subprocess timeout caps the cost in case the cwd is on a
+    slow/unresponsive filesystem (e.g. stale NFS mount). Returns None for
+    detached HEAD ("HEAD" is filtered to None) so the router has a clean
+    "no branch context" signal.
+    """
+    import subprocess  # noqa: PLC0415  (local import — keeps presence import-light)
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        # git not installed, cwd doesn't exist, slow FS, or other transient
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    if not branch or branch == "HEAD":
+        # Empty result or detached-HEAD state
+        return None
+    return branch
+
+
 def build_metadata(
     *,
     session_name: str,
@@ -93,10 +125,17 @@ def build_metadata(
     started_at: float | None = None,
     extras: dict[str, str] | None = None,
 ) -> SessionMetadata:
+    resolved_cwd = cwd or os.getcwd()
+    # Auto-detect git_branch when not explicitly supplied. Pass git_branch=""
+    # or an explicit value to override; the sentinel for "no detection" is
+    # `git_branch=""` which is stored verbatim (and routers can treat empty
+    # string as "no branch info").
+    if git_branch is None:
+        git_branch = detect_git_branch(resolved_cwd)
     return SessionMetadata(
         session_name=session_name,
         host=host or socket.gethostname(),
-        cwd=cwd or os.getcwd(),
+        cwd=resolved_cwd,
         git_branch=git_branch,
         started_at=started_at if started_at is not None else time.time(),
         pid=os.getpid(),

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -131,6 +131,93 @@ def test_second_connect_replaces_first(patched_state: channel.ServerState, fr: A
         patched_state.disconnect()
 
 
+def test_auto_name_disambiguates_on_collision(patched_state: channel.ServerState, fr: Any) -> None:
+    """Two processes in the same cwd → second auto-name gets a pid suffix."""
+    import os
+    import socket
+    import time as _time
+
+    # Simulate another live CC session on this host at the same auto-name.
+    other_pid = os.getpid() + 1
+    other_name_components = [
+        ("session_name", "infiquetra-claude-plugins-9f3e2c1a"),
+        ("host", socket.gethostname()),
+        ("cwd", "/Users/jefcox/workspace/infiquetra/infiquetra-claude-plugins"),
+        ("git_branch", "main"),
+        ("started_at", 1.0),
+        ("pid", other_pid),
+        ("endpoint", "mimir"),
+        ("extras", {}),
+    ]
+    other_payload = json.dumps(dict(other_name_components))
+    fr.hset(presence.REGISTRY_KEY, "infiquetra-claude-plugins-9f3e2c1a", other_payload)
+    fr.set(
+        presence.hb_key("infiquetra-claude-plugins-9f3e2c1a"),
+        str(_time.time()),
+        ex=60,
+    )
+
+    # Monkey-patch resolve_session_name to return the SAME base name the seeded
+    # entry uses — this simulates the cwd-hash collision deterministically.
+    import server.session_id as session_id_mod  # type: ignore[import-not-found]
+
+    real_resolve = session_id_mod.resolve_session_name
+
+    def fake_resolve(override=None, **kw):  # noqa: ANN001
+        if override is not None:
+            return real_resolve(override, **kw)
+        return "infiquetra-claude-plugins-9f3e2c1a"
+
+    import server.channel as channel_mod  # type: ignore[import-not-found]
+
+    monkey_target = channel_mod  # connect() imports resolve_session_name into channel
+    original = monkey_target.resolve_session_name
+    monkey_target.resolve_session_name = fake_resolve  # type: ignore[assignment]
+    try:
+        out = patched_state.connect(endpoint="mimir", session_name=None)
+        try:
+            assert out["ok"] is True, out
+            # Our session_name must NOT equal the seeded base — should be disambiguated
+            assert out["session_name"] != "infiquetra-claude-plugins-9f3e2c1a"
+            assert out["session_name"].startswith("infiquetra-claude-plugins-9f3e2c1a-")
+            suffix = out["session_name"].rsplit("-", 1)[1]
+            # Suffix is 4 hex chars of our pid
+            assert len(suffix) == 4
+            assert all(c in "0123456789abcdef" for c in suffix)
+        finally:
+            patched_state.disconnect()
+    finally:
+        monkey_target.resolve_session_name = original  # type: ignore[assignment]
+
+
+def test_explicit_name_does_not_disambiguate(patched_state: channel.ServerState, fr: Any) -> None:
+    """Explicit session_name = user intent → no disambiguation, replace semantics."""
+    import socket
+    import time as _time
+
+    seeded_name = "explicit-name"
+    other_payload = json.dumps(
+        {
+            "session_name": seeded_name,
+            "host": socket.gethostname(),
+            "cwd": "/whatever",
+            "git_branch": None,
+            "started_at": 1.0,
+            "pid": 99999,
+            "endpoint": "mimir",
+            "extras": {},
+        }
+    )
+    fr.hset(presence.REGISTRY_KEY, seeded_name, other_payload)
+    fr.set(presence.hb_key(seeded_name), str(_time.time()), ex=60)
+
+    out = patched_state.connect(endpoint="mimir", session_name=seeded_name)
+    try:
+        assert out["session_name"] == seeded_name  # exact match — no suffix
+    finally:
+        patched_state.disconnect()
+
+
 def test_list_requires_connection(patched_state: channel.ServerState) -> None:
     out = patched_state.list_sessions()
     assert out["ok"] is False

--- a/tests/test_redis_channel_presence.py
+++ b/tests/test_redis_channel_presence.py
@@ -50,6 +50,148 @@ def test_build_metadata_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta.cwd  # non-empty
 
 
+# ─── git_branch auto-detection ──────────────────────────────────────────────
+
+
+def test_detect_git_branch_non_git_dir_returns_none(tmp_path) -> None:
+    assert presence.detect_git_branch(str(tmp_path)) is None
+
+
+def test_detect_git_branch_missing_cwd_returns_none(tmp_path) -> None:
+    assert presence.detect_git_branch(str(tmp_path / "does-not-exist")) is None
+
+
+def test_detect_git_branch_real_repo(tmp_path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    assert presence.detect_git_branch(str(tmp_path)) == "main"
+
+
+def test_detect_git_branch_feature_branch(tmp_path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(["git", "checkout", "-q", "-b", "feature/x"], cwd=tmp_path, check=True)
+    assert presence.detect_git_branch(str(tmp_path)) == "feature/x"
+
+
+def test_detect_git_branch_detached_head_returns_none(tmp_path) -> None:
+    """Detached HEAD ("HEAD" string) is mapped to None — no branch context."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    # Detach HEAD by checking out the commit SHA
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    subprocess.run(["git", "checkout", "-q", "--detach", sha], cwd=tmp_path, check=True)
+    assert presence.detect_git_branch(str(tmp_path)) is None
+
+
+def test_build_metadata_auto_detects_git_branch(tmp_path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "auth-feature"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    meta = presence.build_metadata(session_name="s", endpoint="mimir", cwd=str(tmp_path))
+    assert meta.git_branch == "auth-feature"
+
+
+def test_build_metadata_explicit_git_branch_overrides_detection(tmp_path) -> None:
+    """Caller-supplied git_branch wins over detection (useful for tests + the
+    rare case where an external runner already knows the branch)."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", "-b", "actually-on-this"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "i",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    meta = presence.build_metadata(
+        session_name="s",
+        endpoint="mimir",
+        cwd=str(tmp_path),
+        git_branch="overridden",
+    )
+    assert meta.git_branch == "overridden"
+
+
 def test_presence_start_writes_registry_and_hb(fr: Any) -> None:
     meta = make_meta()
     p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)

--- a/tests/test_redis_channel_presence.py
+++ b/tests/test_redis_channel_presence.py
@@ -5,6 +5,7 @@ Uses fakeredis to model the Redis backend so tests run without a server.
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any
 
@@ -190,6 +191,90 @@ def test_build_metadata_explicit_git_branch_overrides_detection(tmp_path) -> Non
         git_branch="overridden",
     )
     assert meta.git_branch == "overridden"
+
+
+# ─── disambiguation for same-cwd collisions ─────────────────────────────────
+
+
+def _seed_other_session(
+    fr: Any, name: str, *, host: str = "other-host", pid: int = 999, ttl: int = 60
+) -> None:
+    """Helper: write a presence entry for some *other* session at `name`."""
+    other = presence.build_metadata(
+        session_name=name,
+        endpoint="mimir",
+        cwd="/somewhere",
+        host=host,
+        git_branch="other-branch",
+        started_at=500.0,
+    )
+    # build_metadata sets pid=os.getpid(); we want to fake a different pid
+    raw = json.loads(other.to_json())
+    raw["pid"] = pid
+    fr.hset(presence.REGISTRY_KEY, name, json.dumps(raw))
+    fr.set(presence.hb_key(name), str(time.time()), ex=ttl)
+
+
+def test_disambiguate_no_existing_entry(fr: Any) -> None:
+    name = presence.disambiguate_if_collision(fr, "myrepo-abc12345", host="h", pid=1234)
+    assert name == "myrepo-abc12345"
+
+
+def test_disambiguate_same_pid_same_host_returns_base(fr: Any) -> None:
+    """Reconnect scenario: same process re-registering should keep the same name."""
+    _seed_other_session(fr, "myrepo-abc12345", host="same-host", pid=1234)
+    name = presence.disambiguate_if_collision(fr, "myrepo-abc12345", host="same-host", pid=1234)
+    assert name == "myrepo-abc12345"
+
+
+def test_disambiguate_different_pid_same_host_appends_suffix(fr: Any) -> None:
+    """Same cwd, same host, different process — must disambiguate."""
+    _seed_other_session(fr, "myrepo-abc12345", host="same-host", pid=999)
+    name = presence.disambiguate_if_collision(fr, "myrepo-abc12345", host="same-host", pid=0x4321)
+    assert name == "myrepo-abc12345-4321"
+
+
+def test_disambiguate_different_host_also_appends_suffix(fr: Any) -> None:
+    """If host differs, the base auto-name shouldn't have collided in the first
+    place (host is in the hash). But if it does (manual config), still disambiguate."""
+    _seed_other_session(fr, "myrepo-abc12345", host="host-a", pid=999)
+    name = presence.disambiguate_if_collision(fr, "myrepo-abc12345", host="host-b", pid=0xABCD)
+    assert name == "myrepo-abc12345-abcd"
+
+
+def test_disambiguate_short_pid_zero_pads(fr: Any) -> None:
+    _seed_other_session(fr, "n", host="h", pid=1)
+    name = presence.disambiguate_if_collision(fr, "n", host="h", pid=0x12)
+    assert name == "n-0012"
+
+
+def test_disambiguate_stale_entry_returns_base(fr: Any) -> None:
+    """Registry has an entry but hb key expired → not a live collision."""
+    other = presence.build_metadata(
+        session_name="ghost",
+        endpoint="mimir",
+        cwd="/gone",
+        host="h",
+        started_at=1.0,
+    )
+    fr.hset(presence.REGISTRY_KEY, "ghost", other.to_json())
+    # no hb key
+    name = presence.disambiguate_if_collision(fr, "ghost", host="h", pid=1)
+    assert name == "ghost"
+
+
+def test_disambiguate_missing_registry_entry_returns_base(fr: Any) -> None:
+    """Half-state: hb key exists but registry HSET is missing. Take the name."""
+    fr.set(presence.hb_key("orphan-hb"), "12345", ex=60)
+    name = presence.disambiguate_if_collision(fr, "orphan-hb", host="h", pid=1)
+    assert name == "orphan-hb"
+
+
+def test_disambiguate_corrupt_registry_entry_returns_base(fr: Any) -> None:
+    fr.hset(presence.REGISTRY_KEY, "broken", "{ not valid json")
+    fr.set(presence.hb_key("broken"), "12345", ex=60)
+    name = presence.disambiguate_if_collision(fr, "broken", host="h", pid=1)
+    assert name == "broken"
 
 
 def test_presence_start_writes_registry_and_hb(fr: Any) -> None:


### PR DESCRIPTION
## Summary

Two related ergonomics fixes that surfaced during the session-naming Q&A:

1. **git_branch auto-detection in session metadata.** The schema had the field but the connect path was leaving it null. Now \`presence.build_metadata\` calls \`detect_git_branch(cwd)\` (1s subprocess timeout, falls back to None gracefully) by default. Router gets the live branch in the registry blob — key signal for natural-language session routing later.

2. **Same-cwd session disambiguation.** Two CC sessions launched in the same cwd (the \`claude --bg\` multi-session case) used to auto-name themselves identically (because the name's hash is \`sha256(cwd + host)[:8]\`) and race for the same registry/hb/consumer-group keys. New \`presence.disambiguate_if_collision\` appends \`-<pid_hex_4>\` on collision with a live entry owned by a different PID on the same host. Reconnect (same PID) keeps the base name. Explicit user-supplied session names skip disambiguation — user intent wins.

## Tests

- **7 new git_branch tests** (real \`git init\` in tmp_path): non-git dir, missing cwd, real repo on main, feature branch with \`/\`, detached HEAD, build_metadata auto-detects, explicit value overrides detection.
- **8 new disambiguation tests** (fakeredis-backed): no-collision, same-PID (reconnect), different-PID-same-host, different-host, short-PID zero-padding, stale entry, half-state, corrupt entry.
- **2 new channel-integration tests**: auto-name disambiguates on seeded collision; explicit name does NOT disambiguate.

**Repo total: 404 tests pass.** ruff, ruff format, mypy all green.

## User-visible effect

With this on main, \`HGETALL cc-sessions:registry\` returns entries like:

\`\`\`json
{
  "session_name": "infiquetra-claude-plugins-9f3e2c1a",
  "git_branch": "auth-feature",      ← was always null before (PR #133 part 1)
  "cwd": "/Users/jefcox/workspace/...",
  "host": "jeff-mac-studio.infiquetra.com",
  "pid": 61730,
  ...
}
\`\`\`

And a second \`claude --bg\` from the same cwd registers as e.g. \`infiquetra-claude-plugins-9f3e2c1a-f122\` — both sessions visible, distinguishable by PID-hex suffix, never racing.