### PR TITLE
fix(redis-channel): MCP server bootstraps + channel-notification schema fixes (v0.4.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/.mcp.json
+++ b/plugins/redis-channel/.mcp.json
@@ -2,8 +2,11 @@
   "mcpServers": {
     "redis-channel": {
       "type": "stdio",
-      "command": "python",
-      "args": ["-m", "server"],
+      "command": "/bin/sh",
+      "args": [
+        "-c",
+        "if [ -z \"${HERMES_REDIS_PASSWORD:-}\" ] && [ -x ~/.claude/channels/redis-channel/get-redis-password.sh ]; then export HERMES_REDIS_PASSWORD=\"$(~/.claude/channels/redis-channel/get-redis-password.sh)\"; fi; exec uv run --quiet --with 'mcp>=1.0' --with 'redis>=5.0' --with 'pydantic>=2.5' python3 -m server"
+      ],
       "cwd": "${CLAUDE_PLUGIN_ROOT}",
       "env": {}
     }

--- a/plugins/redis-channel/.mcp.json
+++ b/plugins/redis-channel/.mcp.json
@@ -5,9 +5,8 @@
       "command": "/bin/sh",
       "args": [
         "-c",
-        "if [ -z \"${HERMES_REDIS_PASSWORD:-}\" ] && [ -x ~/.claude/channels/redis-channel/get-redis-password.sh ]; then export HERMES_REDIS_PASSWORD=\"$(~/.claude/channels/redis-channel/get-redis-password.sh)\"; fi; exec uv run --quiet --with 'mcp>=1.0' --with 'redis>=5.0' --with 'pydantic>=2.5' python3 -m server"
+        "cd \"$CLAUDE_PLUGIN_ROOT\" || exit 1; if [ -x \"$HOME/.claude/channels/redis-channel/get-redis-password.sh\" ]; then export HERMES_REDIS_PASSWORD=\"$(\"$HOME/.claude/channels/redis-channel/get-redis-password.sh\")\"; fi; exec uv run --quiet --with 'mcp>=1.0' --with 'redis>=5.0' --with 'pydantic>=2.5' python3 -m server"
       ],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}",
       "env": {}
     }
   }

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,28 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — `.mcp.json` runs server under `uv run` + auto-sources password (v0.4.1)
+
+Two reliability fixes to the shipped `.mcp.json` so the MCP server boots correctly out of the box:
+
+**1. Use `uv run` with inline deps instead of bare `python`.** The previous `command: python` failed in Claude Code's MCP-spawn shell because `python` is rarely on the minimal default PATH on macOS (only `python3` is, via homebrew). Even when `python3` resolves, system Python doesn't have `mcp`/`redis`/`pydantic` installed. The new command is:
+
+```
+uv run --quiet --with "mcp>=1.0" --with "redis>=5.0" --with "pydantic>=2.5" python3 -m server
+```
+
+`uv` is reliably on PATH (homebrew default), it manages a per-spec cached env, and the `--with` flags ensure deps resolve at first launch — no pre-`pip install` step required. Subsequent launches use the cached env (~50ms cold-start overhead acceptable for a long-lived MCP server).
+
+**2. Auto-source HERMES_REDIS_PASSWORD from the keychain helper.** The wrapper script now does:
+
+1. If `HERMES_REDIS_PASSWORD` is already in env (you launched claude with it set) → use that value, helper not invoked.
+2. Otherwise, if `~/.claude/channels/redis-channel/get-redis-password.sh` exists and is executable → source the value from it.
+3. Otherwise (no env, no helper) → falls through to `uv run python3 -m server`, and the existing structured "endpoint X requires password env var Y but it is unset or empty" error fires at connect time with a clear message.
+
+**Together, these mean** `/reload-plugins` is now the only thing needed to get a freshly-installed plugin connected to Redis, instead of "exit claude, set env, run pip install, relaunch claude".
+
+**Requirements** on the host: `uv` installed (homebrew or astral installer) + the keychain helper script in place (which the user creates once as part of capturing the Redis password — see README).
+
 ### Added — same-cwd disambiguation + git_branch auto-detection
 
 - `presence.detect_git_branch(cwd)`: runs `git rev-parse --abbrev-ref HEAD` with a 1s subprocess timeout. Returns `None` for non-git dirs / missing cwds / detached HEAD / git not installed / any subprocess failure. `build_metadata` calls it automatically when `git_branch` is unset, so live session metadata in `cc-sessions:registry` now carries the branch — useful for natural-language session routing later.

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,22 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed — channel notifications now use the correct {content, meta} schema + declare `claude/channel` capability + cd to plugin root (v0.4.2)
+
+Live install testing surfaced **three** issues that together prevented Claude Code from actually surfacing channel events end-to-end:
+
+**1. MCP server didn't declare `claude/channel` capability.** Claude Code's launcher reads `initialize`'s `capabilities.experimental['claude/channel']` to decide whether to register a listener for channel notifications. FastMCP's `Server` doesn't expose a constructor knob for `experimental_capabilities`, so we monkey-patch `app._mcp_server.create_initialization_options` in `channel.py:_enable_channel_capability` to inject `{"claude/channel": {}}`. Without this, claude logs `"Channel notifications skipped: server did not declare claude/channel capability"` and silently drops every event.
+
+**2. Notification params were the wrong shape.** Claude Code's [channels reference](https://code.claude.com/docs/en/channels-reference) requires `params: {content: str, meta: dict[str,str]}` — `content` becomes the body of a `<channel source="..." attr="val">…</channel>` tag in Claude's context, each `meta` key (identifiers only, no hyphens) becomes a tag attribute. We were passing the raw Inbound payload (`{v, router, source, chat_id, text, ...}`) as params, which Claude Code can't render. New `notifier.inbound_to_channel_params()` translates at the emission boundary: `content` = `text`, `meta` = the other fields stringified and filtered to identifier-safe keys. Wire format on Redis stays unchanged; only the in-process MCP frame is reshaped.
+
+**3. `cwd: ${CLAUDE_PLUGIN_ROOT}` wasn't being honored by Claude Code's MCP launcher.** The wrapper inherited claude's cwd, so `python3 -m server` couldn't find the `server` package (error: `No module named server`). Fixed by adding `cd "$CLAUDE_PLUGIN_ROOT" || exit 1;` at the start of the shell wrapper.
+
+**Agent coach rewrite.** `agents/redis-channel-coach.md` now describes the actual `<channel source="..." chat_id="..." …>body</channel>` tag format Claude sees in context, with concrete instructions for reading attributes and constructing replies.
+
+**Tests:** 8 new tests in `test_redis_channel_notifier.py` covering the translation (text-only, full payload, None values dropped, nested values dropped, non-identifier keys dropped, numeric/bool stringification, missing-text fallback). Existing channel tests updated to assert the new shape. Repo total: 412 tests pass.
+
+**Heads-up for users**: during the channels research preview, custom plugins like this one are NOT on Anthropic's approved channel allowlist. You must launch claude with `--dangerously-load-development-channels plugin:redis-channel@infiquetra-plugins` (and acknowledge the confirmation prompt) for the channel events to register. After v1 ships and Anthropic accepts the plugin onto the official allowlist, this flag becomes unnecessary.
+
 ### Changed — `.mcp.json` runs server under `uv run` + auto-sources password (v0.4.1)
 
 Two reliability fixes to the shipped `.mcp.json` so the MCP server boots correctly out of the box:

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -1,25 +1,32 @@
 ---
 name: redis-channel-coach
-description: Behavior hints for Claude when a redis-channel channel session is active. Reminders about voice-mode reply defaults and how channel events arrive. Not load-bearing — interception in the MCP server is what guarantees correctness; this file just reduces friction.
+description: Behavior hints for Claude when a redis-channel session is active. Reminders about reading the channel-tag attributes, voice-mode reply defaults, and the AskUserQuestion ban. Not load-bearing — interception in the MCP server is what guarantees correctness; this file just reduces friction.
 ---
 
-You may be running with a `redis-channel` channel attached. After `/redis-channel-connect` succeeds, external users' messages arrive as `notifications/claude/channel` events. The notification params carry the full Inbound payload:
+You may be running with a `redis-channel` session attached. After `/redis-channel-connect` succeeds, external users' messages arrive as `<channel>` tags injected into your context:
 
-- `source` — `"voice"`, `"dm"`, `"channel"`, or `"thread"` (where the user is on the other side).
-- `chat_id` — opaque router-managed handle for that conversation.
+```
+<channel source="dm" chat_id="c-discord-123" user_id="u-456" username="jeff" endpoint="mimir" _msg_id="1779741709703-0" router="hermes-claude-code-router" ts="1779741709.5">
+the user's actual text here
+</channel>
+```
+
+**Reading the tag:**
+- `source` — `"voice"`, `"dm"`, `"channel"`, or `"thread"` (where the user is reaching you from).
+- `chat_id` — opaque router-managed handle for that conversation. **Always pass this back on reply.**
 - `user_id`, `username` — who sent it.
-- `text` — what they said (or the STT transcript).
-- `confidence` — float 0-1 for voice transcripts; absent for text.
-- `endpoint` — which endpoint the message came from (e.g. `"mimir"`).
+- `endpoint` — which redis-channel endpoint the message came from (e.g. `"mimir"`).
 - `_msg_id` — Redis stream message-id we attach for reply correlation.
+- `confidence` — float 0-1 on voice transcripts; absent for text.
+- `router`, `ts` — source-of-truth router id + timestamp; rarely useful for routing logic but available.
+- The body inside the tag is the user's text/transcript — treat it as the user's message.
 
-To respond, call the `reply` tool:
-
-- **Always pass back the `chat_id`** from the inbound event so the router routes your reply to the right surface.
+**Responding with the `reply` tool:**
+- **Always pass back the `chat_id`** from the inbound tag so the router routes your reply to the right surface.
 - If `source` was `"voice"`, set `voice=true` so the router synthesizes audio for that voice channel.
 - If `source` was `"dm"`, `"channel"`, or `"thread"`, leave `voice` at the default (false).
-- Pass `in_reply_to=<the `_msg_id` from the inbound>` when you want the router to thread the reply (useful in channel/thread surfaces; the router may ignore it for voice).
+- Pass `in_reply_to=<the _msg_id from the inbound>` when you want the router to thread the reply (useful in channel/thread surfaces; the router may ignore it for voice).
 
-**Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
+**Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound `<channel>` event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
 
 Latency: voice round-trips through the router take 6-10s typical. Keep replies tight when the user is hands-free; they can ask follow-ups.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -417,6 +417,30 @@ def _install_signal_handlers() -> None:
             signal.signal(sig, _handle)
 
 
+def _enable_channel_capability(app: FastMCP) -> None:
+    """Declare the `claude/channel` experimental capability in the initialize
+    response so Claude Code accepts our `notifications/claude/channel` events.
+
+    Without this, Claude Code logs: "Channel notifications skipped: server did
+    not declare claude/channel capability" and silently drops every channel
+    notification we emit — which makes Phase 2's text bridge a no-op from
+    Claude Code's perspective.
+
+    FastMCP doesn't expose a constructor param for experimental_capabilities,
+    so we patch the underlying server's create_initialization_options to inject
+    the capability whenever it's called (which happens once per `app.run()`).
+    """
+    server = app._mcp_server  # noqa: SLF001
+    original = server.create_initialization_options
+
+    def patched(notification_options=None, experimental_capabilities=None):  # noqa: ANN001, ANN202
+        experimental_capabilities = dict(experimental_capabilities or {})
+        experimental_capabilities.setdefault("claude/channel", {})
+        return original(notification_options, experimental_capabilities)
+
+    server.create_initialization_options = patched  # type: ignore[method-assign]
+
+
 def run() -> int:
     logging.basicConfig(
         level=logging.INFO,
@@ -427,5 +451,6 @@ def run() -> int:
     atexit.register(_STATE.shutdown)
     _install_signal_handlers()
     app = build_app()
+    _enable_channel_capability(app)
     app.run()  # blocks until stdio closes
     return 0

--- a/plugins/redis-channel/server/notifier.py
+++ b/plugins/redis-channel/server/notifier.py
@@ -10,12 +10,30 @@ the two.
 references at connect-time and uses `asyncio.run_coroutine_threadsafe`
 to schedule the send. `RecordingNotifier` is the test seam — it records
 emitted payloads without touching asyncio at all.
+
+Wire-format translation
+-----------------------
+
+Claude Code's channel reference (https://code.claude.com/docs/en/channels-reference)
+specifies the notification params as ``{content: str, meta: dict[str, str]}``.
+`content` becomes the body of a ``<channel source="..." attr="val">…</channel>``
+tag in Claude's context; each `meta` entry becomes a tag attribute. Meta keys
+must be Python-identifier-shaped (letters/digits/underscores only); keys with
+hyphens or other characters are silently dropped by Claude Code.
+
+Our Redis-side `Inbound` payload schema (router → CC) carries more structure
+(`router`, `endpoint`, `source`, `chat_id`, `user_id`, `username`, `text`,
+`confidence`, `ts`, `metadata`) plus the consumer-injected `_msg_id`. We
+translate that to the channel-notification shape here at the emission
+boundary: `content` = `text`, `meta` = the other fields stringified and
+filtered to identifier-safe keys. Wire format on Redis stays unchanged.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import Any, Protocol
 
 from mcp.types import Notification
@@ -23,6 +41,36 @@ from mcp.types import Notification
 log = logging.getLogger(__name__)
 
 CHANNEL_NOTIFICATION_METHOD = "notifications/claude/channel"
+
+# Identifier rule from the channel docs: letters, digits, underscores; must
+# start with letter or underscore. Keys that don't match get dropped.
+_META_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def inbound_to_channel_params(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate an Inbound-shaped payload to Claude Code's channel-notification
+    params (``{content, meta}``).
+
+    - `content` is taken from the `text` field (empty string if absent).
+    - `meta` is built from every other scalar field whose key matches the
+      identifier rule. Non-scalar values (dicts, lists) are dropped — `meta`
+      is a flat string map per the protocol. `None` values are dropped.
+    - The protocol `v` field is dropped from `meta`: it's an internal
+      versioning marker, not useful as a tag attribute.
+    """
+    text = str(payload.get("text", ""))
+    meta: dict[str, str] = {}
+    for key, value in payload.items():
+        if key in ("text", "v"):
+            continue
+        if value is None:
+            continue
+        if not _META_KEY_RE.match(key):
+            continue
+        if isinstance(value, (dict, list)):
+            continue
+        meta[key] = str(value)
+    return {"content": text, "meta": meta}
 
 
 class ChannelNotifier(Protocol):
@@ -51,9 +99,10 @@ class AsyncNotifier:
             # Don't even create the coroutine — that would leak un-awaited.
             log.debug("AsyncNotifier: loop closed, dropping payload")
             return
+        params = inbound_to_channel_params(payload)
         notif = Notification[dict, str](
             method=CHANNEL_NOTIFICATION_METHOD,
-            params=payload,
+            params=params,
         )
         coro = self._session.send_notification(notif)  # type: ignore[arg-type]
         try:
@@ -66,7 +115,11 @@ class AsyncNotifier:
 
 
 class RecordingNotifier:
-    """Test-only notifier: appends payloads to a list. Threadsafe."""
+    """Test-only notifier: appends *channel-shaped* params to a list. Threadsafe.
+
+    Returns the same ``{content, meta}`` shape the AsyncNotifier sends on the
+    wire, so tests can assert on the post-translation form.
+    """
 
     def __init__(self) -> None:
         import threading
@@ -75,8 +128,9 @@ class RecordingNotifier:
         self.emitted: list[dict[str, Any]] = []
 
     def emit(self, payload: dict[str, Any]) -> None:
+        params = inbound_to_channel_params(payload)
         with self._lock:
-            self.emitted.append(payload)
+            self.emitted.append(params)
 
 
 class NoopNotifier:

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -375,10 +375,12 @@ def test_connect_attaches_inbound_consumer(patched_state: channel.ServerState, f
                 break
             _time.sleep(0.1)
         assert len(rec.emitted) == 1
-        payload = rec.emitted[0]
-        assert payload["text"] == "hi from router"
-        assert payload["chat_id"] == "c1"
-        assert payload["_msg_id"] == msg_id
+        # RecordingNotifier records the post-translation channel-notification
+        # shape: {content: <text>, meta: {<identifier-safe fields...>}}
+        params = rec.emitted[0]
+        assert params["content"] == "hi from router"
+        assert params["meta"]["chat_id"] == "c1"
+        assert params["meta"]["_msg_id"] == msg_id
     finally:
         patched_state.disconnect()
 
@@ -406,7 +408,8 @@ def test_second_connect_replaces_consumer(patched_state: channel.ServerState, fr
             if rec2.emitted:
                 break
             _time.sleep(0.1)
-        assert any(p["text"] == "for second" for p in rec2.emitted)
+        # rec emits in channel-notification shape: {content, meta}
+        assert any(p["content"] == "for second" for p in rec2.emitted)
         assert rec1.emitted == []
     finally:
         patched_state.disconnect()

--- a/tests/test_redis_channel_notifier.py
+++ b/tests/test_redis_channel_notifier.py
@@ -1,4 +1,4 @@
-"""Tests for the channel-notification emitters."""
+"""Tests for the channel-notification emitters + inbound→channel translation."""
 
 from __future__ import annotations
 
@@ -7,12 +7,92 @@ import threading
 
 from server import notifier  # type: ignore[import-not-found]
 
+# ─── inbound_to_channel_params translation ─────────────────────────────────
 
-def test_recording_notifier_appends() -> None:
+
+def test_translate_minimal_text_only() -> None:
+    out = notifier.inbound_to_channel_params({"text": "hi"})
+    assert out == {"content": "hi", "meta": {}}
+
+
+def test_translate_full_inbound_payload() -> None:
+    payload = {
+        "v": 1,
+        "router": "test-router",
+        "endpoint": "mimir",
+        "source": "dm",
+        "chat_id": "c-1",
+        "user_id": "u-1",
+        "username": "jeff",
+        "text": "hello",
+        "ts": 1234.5,
+        "_msg_id": "1234567890-0",
+    }
+    out = notifier.inbound_to_channel_params(payload)
+    assert out["content"] == "hello"
+    # `v` and `text` are dropped from meta
+    assert "v" not in out["meta"]
+    assert "text" not in out["meta"]
+    # Other fields stringified
+    assert out["meta"]["router"] == "test-router"
+    assert out["meta"]["endpoint"] == "mimir"
+    assert out["meta"]["source"] == "dm"
+    assert out["meta"]["chat_id"] == "c-1"
+    assert out["meta"]["user_id"] == "u-1"
+    assert out["meta"]["username"] == "jeff"
+    assert out["meta"]["ts"] == "1234.5"
+    assert out["meta"]["_msg_id"] == "1234567890-0"
+
+
+def test_translate_drops_none_values() -> None:
+    out = notifier.inbound_to_channel_params({"text": "x", "chat_id": "c", "confidence": None})
+    assert out["meta"] == {"chat_id": "c"}
+
+
+def test_translate_drops_nested_values() -> None:
+    """meta is a flat string map; dicts and lists must not be flattened in."""
+    out = notifier.inbound_to_channel_params(
+        {"text": "x", "metadata": {"deep": "value"}, "tags": ["a", "b"]}
+    )
+    assert out["meta"] == {}
+
+
+def test_translate_drops_non_identifier_keys() -> None:
+    """Per the channel docs, keys with hyphens/other chars are silently dropped."""
+    out = notifier.inbound_to_channel_params(
+        {"text": "x", "user-id": "skipped", "user.foo": "skipped", "user_id": "kept"}
+    )
+    assert out["meta"] == {"user_id": "kept"}
+
+
+def test_translate_handles_missing_text() -> None:
+    out = notifier.inbound_to_channel_params({"chat_id": "c"})
+    assert out["content"] == ""
+    assert out["meta"] == {"chat_id": "c"}
+
+
+def test_translate_numeric_values_stringified() -> None:
+    out = notifier.inbound_to_channel_params(
+        {"text": "x", "confidence": 0.92, "ts": 1779741709.123}
+    )
+    assert out["meta"]["confidence"] == "0.92"
+    assert out["meta"]["ts"] == "1779741709.123"
+
+
+def test_translate_bool_values_stringified() -> None:
+    out = notifier.inbound_to_channel_params({"text": "x", "voice": True})
+    assert out["meta"]["voice"] == "True"
+
+
+# ─── notifiers ─────────────────────────────────────────────────────────────
+
+
+def test_recording_notifier_translates() -> None:
+    """RecordingNotifier should record the post-translation channel params,
+    so tests assert on the same shape AsyncNotifier sends on the wire."""
     n = notifier.RecordingNotifier()
-    n.emit({"text": "hi"})
-    n.emit({"text": "bye"})
-    assert n.emitted == [{"text": "hi"}, {"text": "bye"}]
+    n.emit({"text": "hi", "chat_id": "c1"})
+    assert n.emitted == [{"content": "hi", "meta": {"chat_id": "c1"}}]
 
 
 def test_recording_notifier_threadsafe() -> None:
@@ -20,7 +100,7 @@ def test_recording_notifier_threadsafe() -> None:
 
     def _hammer() -> None:
         for i in range(50):
-            n.emit({"i": i})
+            n.emit({"text": str(i), "chat_id": "c"})
 
     threads = [threading.Thread(target=_hammer) for _ in range(10)]
     for t in threads:
@@ -36,7 +116,7 @@ def test_noop_notifier_drops_silently() -> None:
 
 
 def test_async_notifier_schedules_coroutine() -> None:
-    """AsyncNotifier.emit() schedules send_notification on the captured loop."""
+    """AsyncNotifier.emit() translates + schedules send_notification."""
 
     sent: list = []
 
@@ -49,7 +129,7 @@ def test_async_notifier_schedules_coroutine() -> None:
     loop_thread.start()
     try:
         n = notifier.AsyncNotifier(StubSession(), loop)
-        n.emit({"text": "hello", "chat_id": "c1"})
+        n.emit({"text": "hello", "chat_id": "c1", "source": "dm"})
         # Give the loop a tick to process
         for _ in range(50):
             if sent:
@@ -60,7 +140,11 @@ def test_async_notifier_schedules_coroutine() -> None:
         assert len(sent) == 1
         notif = sent[0]
         assert notif.method == notifier.CHANNEL_NOTIFICATION_METHOD
-        assert notif.params == {"text": "hello", "chat_id": "c1"}
+        # Post-translation shape: {content, meta}
+        assert notif.params == {
+            "content": "hello",
+            "meta": {"chat_id": "c1", "source": "dm"},
+        }
     finally:
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join(timeout=2.0)


### PR DESCRIPTION
## What

Multiple live-install fixes in one PR. Each one was a follow-on discovery from the previous round of testing — they accumulated on this branch because they're all blockers for the same goal (get the plugin actually working end-to-end with a real Claude Code client).

### v0.4.1 — MCP server self-bootstraps

- \`.mcp.json\` now wraps the server command in \`/bin/sh\` that:
  - \`cd "\$CLAUDE_PLUGIN_ROOT"\` so \`python3 -m server\` can find the \`server\` package (turns out \`cwd: \${CLAUDE_PLUGIN_ROOT}\` in MCP config isn't being honored by Claude Code's launcher on macOS)
  - Sources \`HERMES_REDIS_PASSWORD\` from the user's keychain helper if it's not in env
  - Execs the server via \`uv run --quiet --with mcp --with redis --with pydantic python3 -m server\` (homebrew \`python\` isn't on PATH in the MCP-spawn shell on macOS; \`uv run\` resolves deps to a cached env on first launch)

Together: \`/plugin install redis-channel\` + relaunch claude is now sufficient. No parent-shell env preparation, no pre-install pip step.

### v0.4.2 — Channel-notification schema + capability declaration

Three more issues found via live testing in Jeff's CC session:

**1. Server didn't declare \`claude/channel\` capability.** Claude Code's launcher checks \`capabilities.experimental['claude/channel']\` in the \`initialize\` response. Without it, claude logs \`"Channel notifications skipped: server did not declare claude/channel capability"\` and drops every event. FastMCP doesn't expose a constructor knob for experimental capabilities, so \`channel.py:_enable_channel_capability\` monkey-patches \`create_initialization_options\` to inject the entry.

**2. Notification params were the wrong shape.** Per the [channels reference](https://code.claude.com/docs/en/channels-reference), params must be \`{content: str, meta: dict[str,str]}\`. \`content\` becomes the body of a \`<channel source="..." attr="val">…</channel>\` tag injected into Claude's context; each \`meta\` key (identifier-safe only — no hyphens) becomes a tag attribute. We were passing the raw Inbound payload as params. Fixed with \`notifier.inbound_to_channel_params()\` — translates at the emission boundary; Redis wire format stays unchanged.

**3. Agent coach rewritten** to describe the actual \`<channel source="..." chat_id="..." …>body</channel>\` tag format Claude sees, with concrete instructions for reading attributes and constructing replies.

## Tests

- 8 new on \`inbound_to_channel_params\` (text-only, full payload, None/nested/non-identifier filtering, numeric/bool stringification, missing-text fallback)
- Existing channel tests updated to assert post-translation \`{content, meta}\` shape
- **412 tests pass**; ruff, ruff format, mypy all green

## Heads-up for users

During the channels research preview, custom plugins like this aren't on Anthropic's approved channel allowlist. Launch claude with the dev flag for channel events to actually register:

\`\`\`
claude --dangerously-load-development-channels plugin:redis-channel@infiquetra-plugins
\`\`\`

(plus your usual flags). Confirm the prompt; future relaunches stick. After v1 + getting onto the official allowlist, the flag becomes unnecessary.

## Versions

\`plugin.json\` + \`marketplace.json\` + \`__init__.__version__\` all bumped 0.4.0 → 0.4.2 (skipped 0.4.1 patch since it was buggy in a follow-on way).