### PR TITLE
feat(redis-channel): debug flag controls reply-narration verbosity (v0.4.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,18 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — `debug` flag on `/redis-channel-connect` controls reply narration (v0.4.3)
+
+Live testing surfaced that Claude narrates "Reply sent on the outbound stream — msg_id=…" in the terminal after calling the `reply` tool. That's noise when the recipient is on the channel side (Discord/voice) and only the developer is watching the terminal.
+
+`redis_channel_connect` now accepts a `debug: bool = False` arg. Honored as follows:
+- **`debug=false` (default)**: quiet mode — coach + slash-command markdown tell Claude *not* to narrate replies in the terminal; the reply tool's structured result is the only confirmation.
+- **`debug=true`**: verbose mode — Claude is invited to print a one-line `→ replied to <chat_id> · msg_id=<x>` after each `reply`. For developers running live integration tests.
+
+CLI usage: `/redis-channel-connect mimir --debug` for verbose, plain `/redis-channel-connect mimir` for quiet.
+
+The flag is stored on `ServerState`, returned in the connect response (so the coach can key off it), and reset to `false` on disconnect.
+
 ### Fixed — channel notifications now use the correct {content, meta} schema + declare `claude/channel` capability + cd to plugin root (v0.4.2)
 
 Live install testing surfaced **three** issues that together prevented Claude Code from actually surfacing channel events end-to-end:

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -29,4 +29,12 @@ the user's actual text here
 
 **Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound `<channel>` event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
 
+**Verbosity (driven by the `debug` flag on `/redis-channel-connect`):**
+
+- The connect tool's response includes a `debug: bool` field. Honor it for the lifetime of this connection:
+- **`debug=false` (default)** — quiet mode. After calling the `reply` tool for a channel event, **do not narrate the reply in the local terminal**. The recipient is on the channel side (Discord/voice/etc.); your terminal narration is invisible to them and noisy for whoever is watching the terminal. Just call the tool — the tool's structured result is the only confirmation needed.
+- **`debug=true`** — verbose mode. After replying, print a one-line confirmation in the terminal (e.g. `→ replied to <chat_id> · msg_id=<x>`). This mode is for developers running live integration tests from the terminal.
+
+If you don't remember the debug flag from connect (e.g. session was resumed), default to quiet.
+
 Latency: voice round-trips through the router take 6-10s typical. Keep replies tight when the user is hands-free; they can ask follow-ups.

--- a/plugins/redis-channel/commands/redis-channel-connect.md
+++ b/plugins/redis-channel/commands/redis-channel-connect.md
@@ -1,16 +1,26 @@
 ---
 description: Connect this Claude Code session to a redis-channel endpoint (default: mimir). Registers session presence in Redis.
-argument-hint: "[endpoint-name] [--session-name <name>]"
+argument-hint: "[endpoint-name] [--session-name <name>] [--debug]"
 ---
 
 Connect the current session to a configured `redis-channel` endpoint.
 
-**Action:** Call the `redis_channel_connect` MCP tool with `endpoint` set to `$1` (or `"mimir"` if no argument). If the user supplied `--session-name <name>`, pass that as `session_name`; otherwise omit it and let the server auto-generate `<cwd-basename>-<short-hash>`.
+**Argument parsing:**
+- First positional arg = endpoint name (default `"mimir"`).
+- `--session-name <name>` flag (optional) — pass that as `session_name`. Otherwise omit and let the server auto-generate `<cwd-basename>-<short-hash>`.
+- `--debug` flag (optional) — pass `debug=true` to the tool. **Default `false`.** Without this flag, reply behavior is *quiet*; with it, reply behavior is *verbose* (see below).
+
+**Action:** Call the `redis_channel_connect` MCP tool with `endpoint`, `session_name`, and `debug` set per the above.
 
 After the tool returns:
-- On `{"ok": true}` — report the resolved `session_name`, the endpoint, and the heartbeat interval. Briefly note that the session is now visible to the router and the heartbeat refreshes every 10s.
+- On `{"ok": true}` — report the resolved `session_name`, the endpoint, the heartbeat interval, and the `debug` mode. Briefly note that the session is now visible to the router and the heartbeat refreshes every 10s.
 - On `{"ok": false, "error": "registry not configured"}` — show the `hint` from the response and stop. The user needs to run `/redis-channel-configure` first.
 - On `{"ok": false, "error": "endpoint not found"}` — show the `detail` (which lists available endpoints) and stop.
 - On any other `{"ok": false}` — show `error` + `detail` and stop.
+
+**Reply behavior after this connect call (read carefully):**
+
+- If `debug=false` (the default): when channel notifications arrive and you call the `reply` tool, **do NOT also narrate the reply in the local terminal**. The user is on the channel side (Discord/voice/etc.), not the terminal — your terminal narration adds noise without value. Just call the tool; the tool's structured result is enough confirmation.
+- If `debug=true`: feel free to print a one-line confirmation in the terminal after each `reply` (e.g. `→ replied to <chat_id> · msg_id=<x>`). The developer is debugging from the terminal in this mode.
 
 Endpoints live in `~/.claude/channels/redis-channel/registry.json`. A second connect call automatically disconnects the previous session first.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -69,11 +69,21 @@ class ServerState:
         self._notifier: ChannelNotifier | None = None
         self._client: Any | None = None
         self._endpoint_name: str | None = None
+        # `debug` controls how chatty Claude should be in the terminal after
+        # replying. Default off (quiet). Set via the connect tool's `debug`
+        # arg; surfaced in connect's response so the slash-command markdown
+        # + agent coach can steer Claude's reply-narration behavior.
+        self._debug: bool = False
 
     @property
     def is_connected(self) -> bool:
         with self._lock:
             return self._presence is not None
+
+    @property
+    def debug(self) -> bool:
+        with self._lock:
+            return self._debug
 
     def connect(
         self,
@@ -81,6 +91,7 @@ class ServerState:
         endpoint: str,
         session_name: str | None,
         notifier: ChannelNotifier | None = None,
+        debug: bool = False,
     ) -> dict[str, Any]:
         """Open the channel: register presence, start consumer.
 
@@ -133,11 +144,13 @@ class ServerState:
                 self._notifier = resolved_notifier
                 self._client = client
                 self._endpoint_name = endpoint
+                self._debug = bool(debug)
                 return {
                     "ok": True,
                     "session_name": metadata.session_name,
                     "endpoint": endpoint,
                     "endpoint_display": ep.display_name,
+                    "debug": self._debug,
                     "host": metadata.host,
                     "cwd": metadata.cwd,
                     "heartbeat_seconds": registry.defaults.heartbeat_seconds,
@@ -282,6 +295,7 @@ class ServerState:
             self._client = None
         self._endpoint_name = None
         self._notifier = None
+        self._debug = False
 
 
 _STATE = ServerState()
@@ -338,12 +352,15 @@ def build_app() -> FastMCP:
             "(typically a Hermes profile like 'mimir'). Registers in the shared "
             "Redis registry, starts a 10s heartbeat, and attaches an inbound "
             "consumer that emits notifications/claude/channel for each XADD'd "
-            "inbound message. Returns the resolved session_name + metadata."
+            "inbound message. Returns the resolved session_name + metadata. "
+            "Pass debug=true to opt into verbose reply narration in the local "
+            "terminal (useful for dev/test); default false = quiet."
         ),
     )
     async def redis_channel_connect(
         endpoint: str = "mimir",
         session_name: str | None = None,
+        debug: bool = False,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         notifier = _build_async_notifier(ctx)
@@ -351,6 +368,7 @@ def build_app() -> FastMCP:
             endpoint=endpoint,
             session_name=session_name,
             notifier=notifier,
+            debug=debug,
         )
 
     @app.tool(

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -82,11 +82,35 @@ def test_connect_registers_and_starts_heartbeat(
         assert out["endpoint_display"] == "Mimir (test)"
         assert out["heartbeat_seconds"] == 1
         assert out["registry_ttl_seconds"] == 10
+        # debug defaults to false; surfaced in response for slash command / coach
+        assert out["debug"] is False
         # registry should have the entry
         raw = fr.hget(presence.REGISTRY_KEY, "my-session")
         assert raw is not None
         # hb key must exist
         assert fr.exists(presence.hb_key("my-session")) == 1
+    finally:
+        patched_state.disconnect()
+
+
+def test_connect_debug_flag_propagates(patched_state: channel.ServerState, fr: Any) -> None:
+    """debug=true must round-trip through connect response and ServerState."""
+    out = patched_state.connect(endpoint="mimir", session_name="dbg", debug=True)
+    try:
+        assert out["debug"] is True
+        assert patched_state.debug is True
+    finally:
+        patched_state.disconnect()
+    # After disconnect, debug resets so a subsequent connect starts quiet.
+    assert patched_state.debug is False
+
+
+def test_connect_debug_flag_default_quiet(patched_state: channel.ServerState, fr: Any) -> None:
+    """Omitting debug (default) must keep ServerState.debug == False."""
+    out = patched_state.connect(endpoint="mimir", session_name="quiet")
+    try:
+        assert out["debug"] is False
+        assert patched_state.debug is False
     finally:
         patched_state.disconnect()
 


### PR DESCRIPTION
## What

Live Phase 2 round-trip surfaced one piece of UX noise: Claude narrates "Reply sent on the outbound stream — msg_id=…" in the terminal after calling the \`reply\` tool. That's useful when developing/debugging from the terminal, but useless noise when the recipient is on the channel side (Discord/voice) and the terminal is unwatched.

Fix: \`redis_channel_connect\` now accepts \`debug: bool = False\`.

- \`debug=false\` (default): quiet mode. Coach + slash-command markdown tell Claude *not* to narrate replies in the terminal.
- \`debug=true\`: verbose mode. Claude is invited to print a one-line \`→ replied to <chat_id> · msg_id=<x>\` after each reply.

CLI: \`/redis-channel-connect mimir --debug\` for verbose; plain \`/redis-channel-connect mimir\` for quiet (default).

## Tests

- 2 new (debug=true propagates + resets on disconnect; debug=false default)
- Existing connect test extended to assert \`debug=false\` in response
- **414 tests pass**; ruff, format, mypy all green

## Versions

Bumped 0.4.2 → 0.4.3. Cache pre-synced for Jeff's live session — no relaunch needed; just \`/redis-channel-disconnect\` + \`/redis-channel-connect mimir\` (or with \`--debug\`) to pick up the new behavior.