### PR TITLE
feat(redis-channel): reply tool echoes text as natural MCP result content (v0.4.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -13,9 +13,20 @@ The reply tool's MCP wrapper now returns a `CallToolResult` with the sent `text`
 
 This closes the outbound-visibility gap toward the user's stated goal of "channels should feel like Remote Control" — both sides of the chat now render in terminal without meta-decoration.
 
-The agent coach was rewritten:
+The agent coach was rewritten with **per-source-mode formatting guidance**, because voice and text sources need fundamentally different reply shapes:
+
+| `source`              | `voice` arg | Formatting rules for `text`                                                                                          |
+| --------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `voice`               | `true`      | TTS will SPEAK aloud. Short. No markdown, no code blocks, no bare URLs. Speakable prose only. No visual references.  |
+| `dm`                  | `false`     | Direct message. Full markdown, code blocks, lists, links all render properly.                                        |
+| `channel`             | `false`     | Public channel. Same formatting as DM. Use `in_reply_to` to thread.                                                  |
+| `thread`              | `false`     | Threaded reply. Same formatting as DM/channel.                                                                       |
+| *(any other / unset)* | `false`     | Default to DM-style for forward-compatibility with future sources (email, SMS, alerts, etc.).                        |
+
+Also:
 - Removed the `debug=false/true` narration toggle (the tool's natural echo replaces it).
-- Added a TTS-safety reminder: when `voice=true`, the `text` arg is what gets SPOKEN aloud — Claude must not put tool-call narration, reasoning, or terminal-only commentary into `text`.
+- Kept the TTS-safety reminder explicit: when `voice=true`, the `text` arg is what gets SPOKEN aloud — Claude must not put tool-call narration, reasoning, or terminal-only commentary into `text`.
+- Added explicit "what `text` is for" section: it's the user-facing message body, full stop.
 - The `debug` flag stays on the connect tool for future opt-in dev verbosity but currently has no effect.
 
 `ServerState.reply` itself still returns a dict (unchanged) — only the MCP-tool-wrapper layer in `build_app()` was modified. Existing unit tests pass without changes.

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,19 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — `reply` tool echoes sent text as natural MCP result content (v0.4.4)
+
+The reply tool's MCP wrapper now returns a `CallToolResult` with the sent `text` as the unstructured `content` element + the existing `{ok, session_name, chat_id, msg_id}` as `structuredContent`. The result: the terminal automatically renders the reply text as the tool's natural output — no model-side narration ("Reply sent on the outbound stream…", "I responded with…") needed to make the back-and-forth visible.
+
+This closes the outbound-visibility gap toward the user's stated goal of "channels should feel like Remote Control" — both sides of the chat now render in terminal without meta-decoration.
+
+The agent coach was rewritten:
+- Removed the `debug=false/true` narration toggle (the tool's natural echo replaces it).
+- Added a TTS-safety reminder: when `voice=true`, the `text` arg is what gets SPOKEN aloud — Claude must not put tool-call narration, reasoning, or terminal-only commentary into `text`.
+- The `debug` flag stays on the connect tool for future opt-in dev verbosity but currently has no effect.
+
+`ServerState.reply` itself still returns a dict (unchanged) — only the MCP-tool-wrapper layer in `build_app()` was modified. Existing unit tests pass without changes.
+
 ### Added — `debug` flag on `/redis-channel-connect` controls reply narration (v0.4.3)
 
 Live testing surfaced that Claude narrates "Reply sent on the outbound stream — msg_id=…" in the terminal after calling the `reply` tool. That's noise when the recipient is on the channel side (Discord/voice) and only the developer is watching the terminal.

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -1,6 +1,6 @@
 ---
 name: redis-channel-coach
-description: Behavior hints for Claude when a redis-channel session is active. Reminders about reading the channel-tag attributes, voice-mode reply defaults, and the AskUserQuestion ban. Not load-bearing — interception in the MCP server is what guarantees correctness; this file just reduces friction.
+description: Behavior hints for Claude when a redis-channel session is active. Reminders about reading the channel-tag attributes, distinguishing voice vs text source modes, and the AskUserQuestion ban. Not load-bearing — interception in the MCP server is what guarantees correctness; this file just reduces friction.
 ---
 
 You may be running with a `redis-channel` session attached. After `/redis-channel-connect` succeeds, external users' messages arrive as `<channel>` tags injected into your context:
@@ -12,29 +12,42 @@ the user's actual text here
 ```
 
 **Reading the tag:**
-- `source` — `"voice"`, `"dm"`, `"channel"`, or `"thread"` (where the user is reaching you from).
+- `source` — `"voice"`, `"dm"`, `"channel"`, or `"thread"`. **Drives formatting + voice flag — see "Source-mode behavior" below.**
 - `chat_id` — opaque router-managed handle for that conversation. **Always pass this back on reply.**
 - `user_id`, `username` — who sent it.
 - `endpoint` — which redis-channel endpoint the message came from (e.g. `"mimir"`).
 - `_msg_id` — Redis stream message-id we attach for reply correlation.
-- `confidence` — float 0-1 on voice transcripts; absent for text.
+- `confidence` — float 0-1 on voice transcripts; absent for text sources.
 - `router`, `ts` — source-of-truth router id + timestamp; rarely useful for routing logic but available.
-- The body inside the tag is the user's text/transcript — treat it as the user's message.
+- The body inside the tag is the user's text or speech-transcript — treat it as the user's message.
 
 **Responding with the `reply` tool:**
 - **Always pass back the `chat_id`** from the inbound tag so the router routes your reply to the right surface.
-- If `source` was `"voice"`, set `voice=true` so the router synthesizes audio for that voice channel.
-- If `source` was `"dm"`, `"channel"`, or `"thread"`, leave `voice` at the default (false).
-- Pass `in_reply_to=<the _msg_id from the inbound>` when you want the router to thread the reply (useful in channel/thread surfaces; the router may ignore it for voice).
+- Set `voice` and format your `text` according to `source` (see table below).
+- Pass `in_reply_to=<the _msg_id from the inbound>` for threading on `channel` / `thread` sources (router may ignore it for voice/dm).
 
-**Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound `<channel>` event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
+## Source-mode behavior
 
-**Terminal visibility (no narration needed):**
+| `source`              | `voice` arg | Formatting rules for `text`                                                                                                                                                                                                                                                                                            |
+| --------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `voice`               | `true`      | **TTS will SPEAK your `text` aloud.** Keep it short (round-trip is 6-10s). NO markdown, NO code blocks, NO bare URLs (they get read letter-by-letter and sound awful). Speakable prose only. Don't reference visual elements ("see the diagram above"). If you must mention a URL, say "I'll send the link in a DM."  |
+| `dm`                  | `false`     | Direct message rendering — markdown, code blocks, lists, and inline links all render properly. Mid-length OK. No threading concept here.                                                                                                                                                                              |
+| `channel`             | `false`     | Public channel message. Same formatting as `dm`. Be aware others may see your reply. Pass `in_reply_to` to thread under the original message.                                                                                                                                                                          |
+| `thread`              | `false`     | Threaded reply. Same formatting as `dm`/`channel`. Pass `in_reply_to` for proper threading.                                                                                                                                                                                                                            |
+| *(any other / unset)* | `false`     | Default to `dm`-style behavior. Future router-side surfaces (email, SMS, alerts) will document their conventions; until then treat unknown sources as text-rendered.                                                                                                                                                  |
 
-The `reply` tool's MCP return surfaces your `text` argument as the tool's natural result content. Whoever is watching the terminal sees your reply text rendered automatically — you do NOT need to also narrate it ("Reply sent on the outbound stream…", "I responded with…", etc.). That commentary is noise on top of the tool's natural echo.
+## What `text` is for
 
-**Critical for voice mode:** when `voice=true`, the router sends your `text` to TTS. Whatever you put in `text` gets SPOKEN aloud to the user. Do NOT include tool-call narration, reasoning, or terminal-only commentary in `text` — only the actual user-facing message you want the recipient to hear/read.
+The `text` argument is **the user-facing message body**, full stop. The recipient on the other side either reads it (text sources) or hears it spoken via TTS (voice). Do NOT put any of the following in `text`:
+- Tool-call narration ("calling reply", "I responded with…", "Reply sent on the outbound stream…")
+- Internal reasoning or chain-of-thought
+- Terminal-only commentary
+- Status updates that the user already saw via the tool result
 
-The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect — the tool's natural echo is sufficient for visibility in both modes.
+If you have something to say to the developer watching the terminal but NOT to the user on the channel side, just don't say it — the tool's natural echo of `text` is the only thing the terminal needs to render. (The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect.)
 
-Latency: voice round-trips through the router take 6-10s typical. Keep replies tight when the user is hands-free; they can ask follow-ups.
+## Other rules
+
+**Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your `text` instead — "Which approach? A) … B) … C) …" — and the user will answer naturally on the next inbound. (For voice, restate the choices conversationally: "Want A, B, or C?") Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.
+
+**Latency**: voice round-trips through the router take 6-10s typical. Keep voice replies tight; the user is probably driving or jogging and they can always ask follow-ups.

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -29,12 +29,12 @@ the user's actual text here
 
 **Don't call `AskUserQuestion` during a channel session.** Inline the choices directly in your reply text instead ("Which approach? A) … B) … C) …"). A user on the other side will answer naturally and you'll get the response on the next inbound `<channel>` event. (Phase 4 will deterministically intercept any `AskUserQuestion` you do emit; until then, just inline.)
 
-**Verbosity (driven by the `debug` flag on `/redis-channel-connect`):**
+**Terminal visibility (no narration needed):**
 
-- The connect tool's response includes a `debug: bool` field. Honor it for the lifetime of this connection:
-- **`debug=false` (default)** — quiet mode. After calling the `reply` tool for a channel event, **do not narrate the reply in the local terminal**. The recipient is on the channel side (Discord/voice/etc.); your terminal narration is invisible to them and noisy for whoever is watching the terminal. Just call the tool — the tool's structured result is the only confirmation needed.
-- **`debug=true`** — verbose mode. After replying, print a one-line confirmation in the terminal (e.g. `→ replied to <chat_id> · msg_id=<x>`). This mode is for developers running live integration tests from the terminal.
+The `reply` tool's MCP return surfaces your `text` argument as the tool's natural result content. Whoever is watching the terminal sees your reply text rendered automatically — you do NOT need to also narrate it ("Reply sent on the outbound stream…", "I responded with…", etc.). That commentary is noise on top of the tool's natural echo.
 
-If you don't remember the debug flag from connect (e.g. session was resumed), default to quiet.
+**Critical for voice mode:** when `voice=true`, the router sends your `text` to TTS. Whatever you put in `text` gets SPOKEN aloud to the user. Do NOT include tool-call narration, reasoning, or terminal-only commentary in `text` — only the actual user-facing message you want the recipient to hear/read.
+
+The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect — the tool's natural echo is sufficient for visibility in both modes.
 
 Latency: voice round-trips through the router take 6-10s typical. Keep replies tight when the user is hands-free; they can ask follow-ups.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import contextlib
+import json
 import logging
 import os
 import signal
@@ -30,6 +31,7 @@ import time
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import CallToolResult, TextContent
 
 from . import __version__
 from .notifier import AsyncNotifier, ChannelNotifier, NoopNotifier
@@ -403,7 +405,10 @@ def build_app() -> FastMCP:
             "channel (router may ignore if the source wasn't voice). chat_id "
             "must match the value provided on the inbound notification. "
             "Optionally pass in_reply_to=<original message_id from the "
-            "inbound notification's _msg_id field> to thread the reply."
+            "inbound notification's _msg_id field> to thread the reply. "
+            "The `text` argument IS the user-facing message — it's what the "
+            "recipient reads or hears via TTS. Do NOT put internal reasoning, "
+            "tool-call narration, or terminal-only commentary in `text`."
         ),
     )
     async def reply(
@@ -411,12 +416,28 @@ def build_app() -> FastMCP:
         text: str,
         voice: bool = False,
         in_reply_to: str | None = None,
-    ) -> dict[str, Any]:
-        return _STATE.reply(
+    ) -> CallToolResult:
+        result = _STATE.reply(
             chat_id=chat_id,
             text=text,
             voice=voice,
             in_reply_to=in_reply_to,
+        )
+        if not result.get("ok"):
+            # Error path: surface the structured error as JSON text content so
+            # Claude can read it and the user can see what went wrong.
+            return CallToolResult(
+                content=[TextContent(type="text", text=json.dumps(result))],
+                structuredContent=result,
+                isError=True,
+            )
+        # Success: echo the actual sent text so the terminal renders it as
+        # the tool's natural result — closes the chat-loop visibility gap.
+        # Structured fields (msg_id, etc.) ride along for programmatic clients.
+        return CallToolResult(
+            content=[TextContent(type="text", text=text)],
+            structuredContent=result,
+            isError=False,
         )
 
     return app


### PR DESCRIPTION
## What

User feedback during live Phase 2 test: quiet mode "feels like a void" — terminal shows the inbound \`<channel>\` tag but nothing about Claude's reply. They want it to resemble Remote Control: both sides of the chat visible in terminal, no \`"Reply sent on the outbound stream..."\` model-side narration.

## How

The \`reply\` tool's MCP wrapper now returns a \`CallToolResult\` with:
- \`content: [TextContent(type="text", text=<sent text>)]\` — the unstructured part, which Claude Code renders as the tool's natural output
- \`structuredContent: {ok, session_name, chat_id, msg_id}\` — the existing structured dict for programmatic clients (integration test still parses fine)

Claude Code automatically renders \`content\` after a tool call. So the reply text appears in the terminal as a natural part of the tool result — no model narration required.

## Coach rewrite

- Dropped the \`debug=false/true\` narration toggle from 0.4.3 — the tool's natural echo replaces it. Both modes now read the same.
- Added a TTS-safety reminder: when \`voice=true\`, the \`text\` arg is what gets SPOKEN aloud via TTS. Claude must NOT put tool-call narration, reasoning, or terminal-only commentary into \`text\` — only the actual user-facing message.
- The \`debug\` flag on \`/redis-channel-connect\` stays as a future opt-in knob but currently has no behavioral effect.

## Tests

\`ServerState.reply\` itself still returns a dict (unchanged) — only the MCP-tool-wrapper layer in \`build_app()\` was modified. Existing unit tests pass without changes. **414 tests pass; ruff, format, mypy all green.**

## Versions

Bumped 0.4.3 → 0.4.4. Cache pre-synced for live testing — Jeff just needs \`/mcp\` → Reconnect (or relaunch claude) to pick up the new behavior.