### PR TITLE
coach(redis-channel): write reply text in terminal + tool (v0.4.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,25 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — coach asks Claude to write the reply text twice: terminal + tool (v0.4.5)
+
+Live testing of v0.4.4 surfaced that **Claude Code does not render MCP tool result text content as visible chat output** — even when the tool returns `CallToolResult(content=[TextContent(text="…")])`. The debug log confirms:
+```
+[ERROR] Tool mcp__plugin_redis-channel_redis-channel__reply not found in render-time tools
+```
+This is internal to Claude Code's render pipeline, not something we can change from the plugin side. The v0.4.4 tool-echo approach still works for programmatic clients (the integration test still parses the structured result correctly), but it doesn't surface anything to the human reading the terminal.
+
+So the coach is updated to ask Claude to write the reply text **in two places**:
+
+1. As the natural conversational response in the terminal turn — this is what the local user sees as the chat history.
+2. As the `text` argument to the `reply` tool — this is what the channel-side user reads (or hears via TTS).
+
+Both contain the **same words**. Composed once, rendered in both surfaces. No "I responded with…" wrappers, no double-typing of the same content in different forms. Just compose your answer naturally; output it as your turn text; call `reply` with that text.
+
+This is the closest channels can get to Remote-Control-style chat-merging without the framework's render-time pipeline doing more for us.
+
+The v0.4.4 `CallToolResult` machinery stays in place — useful for programmatic clients and harmless when Claude Code chooses not to render it.
+
 ### Changed — `reply` tool echoes sent text as natural MCP result content (v0.4.4)
 
 The reply tool's MCP wrapper now returns a `CallToolResult` with the sent `text` as the unstructured `content` element + the existing `{ok, session_name, chat_id, msg_id}` as `structuredContent`. The result: the terminal automatically renders the reply text as the tool's natural output — no model-side narration ("Reply sent on the outbound stream…", "I responded with…") needed to make the back-and-forth visible.

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -42,9 +42,24 @@ The `text` argument is **the user-facing message body**, full stop. The recipien
 - Tool-call narration ("calling reply", "I responded with…", "Reply sent on the outbound stream…")
 - Internal reasoning or chain-of-thought
 - Terminal-only commentary
-- Status updates that the user already saw via the tool result
+- Status updates the developer already saw
 
-If you have something to say to the developer watching the terminal but NOT to the user on the channel side, just don't say it — the tool's natural echo of `text` is the only thing the terminal needs to render. (The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect.)
+## How the back-and-forth renders in the terminal
+
+When a `<channel>` event arrives, the terminal shows the inbound tag automatically. The OUTBOUND side (your reply) does NOT auto-render from the tool result content — Claude Code's UI shows the tool was called, but doesn't surface its result body as chat content.
+
+To make the conversation look chat-like in the local terminal (closer to Remote Control's experience), **write the same answer in two places**:
+
+1. As your normal conversational reply in the terminal (the text that appears in your assistant turn).
+2. As the `text` argument to the `reply` tool.
+
+Both contain the **same words** — your single answer, rendered in both surfaces:
+- Terminal user sees it as your natural response.
+- Channel user (Discord/voice/etc.) sees/hears it via the reply XADD'd to the outbound stream.
+
+Do not write the same answer twice in different forms ("Replying to user: <text>" + the tool call). Just compose your one answer, type it as your terminal response, and call `reply(text=<that same answer>, chat_id=<from inbound>)`. Skip any "I responded with…" / "Sent reply…" narration entirely — the tool call + your one-time text in the terminal are enough.
+
+(The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect.)
 
 ## Other rules
 

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"


### PR DESCRIPTION
## What

Live v0.4.4 test showed Claude Code does NOT render MCP tool result text content as visible chat output. The user's debug log:

\`\`\`
[ERROR] Tool mcp__plugin_redis-channel_redis-channel__reply not found in render-time tools
\`\`\`

This is Claude Code's render pipeline being unable to surface our tool's result body as chat content — internal to CC, not fixable from the plugin side. v0.4.4's \`CallToolResult(content=[TextContent(...)])\` still works for programmatic clients (integration harness still parses the structured result), but nothing surfaces in the terminal UI.

## How

Coach updated to ask Claude to write the reply text **in two places**:

1. As the natural conversational response in the terminal turn — what the local terminal user sees in chat history.
2. As the \`text\` argument to the \`reply\` tool — what the channel-side user reads or hears via TTS.

Both contain the **same words**. Composed once, rendered in both surfaces. No "I responded with…" wrapper, no double-typing the same content in different forms — just compose the answer, type it naturally, call \`reply(text=<that same answer>)\`.

Closest channels can get to Remote-Control-style chat-merging without CC's render pipeline doing more for us.

The v0.4.4 \`CallToolResult\` machinery stays in place — useful for programmatic clients, harmless when CC doesn't render it.

## Tests

No code changes — coach + docs only. **414 tests still pass.**

## Versions

Bumped 0.4.4 → 0.4.5. Cache pre-synced — Jeff just needs \`/mcp\` Reconnect (or relaunch) to pick up the new coach.