### PR TITLE
fix(redis-channel): clean up per-session streams on disconnect + stale GC (v0.4.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,19 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed — per-session stream cleanup on disconnect + lazy GC (v0.4.6)
+
+Live audit of olympus-bus Redis caught that we were leaking stream keys: every disconnected session left `cc-sessions:<name>:inbound` and `cc-sessions:<name>:outbound` behind forever. Eight orphan stream keys accumulated in one afternoon of testing.
+
+Fix in two layers:
+
+1. **Graceful disconnect** (`Presence.stop`) now DELs the inbound + outbound stream keys alongside the existing `HDEL cc-sessions:registry` + `DEL cc-sessions:hb:<name>`. Reflects the "this session is done" intent. Stream history is not preserved across disconnects — if you need durable transcripts, the router should snapshot them.
+2. **Lazy GC on stale entries** (`list_live_sessions(gc_stale=True)`) now extends its sweep to also DEL the streams of any registry entry whose hb key has expired. Catches ungraceful crash paths (process killed mid-session) that bypass graceful disconnect.
+
+New helper `presence.session_stream_keys(session_name)` enumerates all per-session keys (inbound, outbound, hb) so both code paths share one source of truth for what belongs to a session.
+
+Tests: 4 new (`test_presence_stop_drops_session_streams`, `test_session_stream_keys_layout`, `test_list_live_sessions_gc_drops_stale_streams`, `test_list_live_sessions_no_gc_when_disabled`). Repo total: 418 tests pass.
+
 ### Changed — coach asks Claude to write the reply text twice: terminal + tool (v0.4.5)
 
 Live testing of v0.4.4 surfaced that **Claude Code does not render MCP tool result text content as visible chat output** — even when the tool returns `CallToolResult(content=[TextContent(text="…")])`. The debug log confirms:

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/plugins/redis-channel/server/presence.py
+++ b/plugins/redis-channel/server/presence.py
@@ -193,11 +193,28 @@ def is_live(client: RedisLike, session_name: str) -> bool:
     return bool(client.exists(hb_key(session_name)))
 
 
+def session_stream_keys(session_name: str) -> list[str]:
+    """All session-scoped key names belonging to one session.
+
+    Currently: inbound stream + outbound stream + hb key. Single source of
+    truth for what gets deleted in graceful disconnect and stale-entry GC.
+    The channel-events pub/sub doesn't persist a key (publishes are
+    ephemeral), so it's not included.
+    """
+    return [
+        f"cc-sessions:{session_name}:inbound",
+        f"cc-sessions:{session_name}:outbound",
+        hb_key(session_name),
+    ]
+
+
 def list_live_sessions(client: RedisLike, *, gc_stale: bool = False) -> dict[str, SessionMetadata]:
     """Return live sessions from the registry, filtered by hb key existence.
 
-    With `gc_stale=True`, also HDEL any registry entries whose hb key has
-    expired. Returned dict is keyed by session_name.
+    With `gc_stale=True`, also HDEL the registry entries whose hb key has
+    expired AND DEL their per-session streams (so abandoned sessions don't
+    accumulate stream keys in Redis forever). Returned dict is keyed by
+    session_name.
     """
     raw = client.hgetall(REGISTRY_KEY)
     live: dict[str, SessionMetadata] = {}
@@ -215,7 +232,21 @@ def list_live_sessions(client: RedisLike, *, gc_stale: bool = False) -> dict[str
             stale.append(name)
     if gc_stale and stale:
         client.hdel(REGISTRY_KEY, *stale)
-        log.info("GC'd %d stale registry entries: %s", len(stale), stale)
+        # Also DEL the per-session streams. These don't auto-expire, so
+        # without this cleanup the registry HDEL would succeed but
+        # `cc-sessions:<n>:{inbound,outbound}` would accumulate one pair
+        # per ever-disconnected session.
+        stream_keys: list[str] = []
+        for name in stale:
+            stream_keys.extend(session_stream_keys(name))
+        if stream_keys:
+            client.delete(*stream_keys)
+        log.info(
+            "GC'd %d stale registry entries (+ %d stream keys): %s",
+            len(stale),
+            len(stream_keys),
+            stale,
+        )
     return live
 
 
@@ -281,7 +312,14 @@ class Presence:
         )
 
     def stop(self, *, reason: str = "graceful") -> None:
-        """Stop heartbeat, unregister, and publish lifecycle event."""
+        """Stop heartbeat, unregister, and publish lifecycle event.
+
+        Graceful disconnect intent: the session is done, so we also DEL the
+        per-session inbound/outbound stream keys (alongside the existing
+        registry HDEL + hb DEL). Without this, every disconnected session
+        leaks an orphan stream pair in Redis. Stream deletion is best-effort
+        and swallowed.
+        """
         if not self._started:
             return
         self._stop_event.set()
@@ -290,7 +328,7 @@ class Presence:
             self._thread = None
         # Best-effort cleanup; swallow errors so __exit__ never raises.
         try:
-            self._client.delete(hb_key(self.session_name))
+            self._client.delete(*session_stream_keys(self.session_name))
             self._client.hdel(REGISTRY_KEY, self.session_name)
             self._publish_lifecycle("unregistered", extra={"reason": reason})
         except Exception:  # noqa: BLE001

--- a/tests/test_redis_channel_presence.py
+++ b/tests/test_redis_channel_presence.py
@@ -301,6 +301,30 @@ def test_presence_stop_cleans_up(fr: Any) -> None:
     assert fr.exists(presence.hb_key(meta.session_name)) == 0
 
 
+def test_presence_stop_drops_session_streams(fr: Any) -> None:
+    """Graceful disconnect must DEL inbound + outbound streams so they don't
+    accumulate one pair per ever-disconnected session."""
+    meta = make_meta("with-streams")
+    p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
+    p.start()
+    fr.xadd("cc-sessions:with-streams:inbound", {"payload": "{}"})
+    fr.xadd("cc-sessions:with-streams:outbound", {"payload": "{}"})
+    assert fr.exists("cc-sessions:with-streams:inbound") == 1
+    assert fr.exists("cc-sessions:with-streams:outbound") == 1
+    p.stop()
+    assert fr.exists("cc-sessions:with-streams:inbound") == 0
+    assert fr.exists("cc-sessions:with-streams:outbound") == 0
+
+
+def test_session_stream_keys_layout() -> None:
+    """The session_stream_keys helper enumerates all per-session keys we GC."""
+    assert presence.session_stream_keys("foo") == [
+        "cc-sessions:foo:inbound",
+        "cc-sessions:foo:outbound",
+        "cc-sessions:hb:foo",
+    ]
+
+
 def test_presence_is_idempotent_on_double_stop(fr: Any) -> None:
     meta = make_meta()
     p = presence.Presence(fr, meta, heartbeat_seconds=1, ttl_seconds=10)
@@ -384,6 +408,37 @@ def test_list_live_sessions_gc_stale(fr: Any) -> None:
     presence.list_live_sessions(fr, gc_stale=True)
     assert fr.hget(presence.REGISTRY_KEY, "stale") is None
     assert fr.hget(presence.REGISTRY_KEY, "live") is not None
+
+
+def test_list_live_sessions_gc_drops_stale_streams(fr: Any) -> None:
+    """Stale-entry GC must also DEL the per-session inbound/outbound streams
+    that a crashed-mid-session would otherwise leave behind."""
+    fr.hset(presence.REGISTRY_KEY, "ghost", make_meta("ghost").to_json())
+    fr.xadd("cc-sessions:ghost:inbound", {"payload": "{}"})
+    fr.xadd("cc-sessions:ghost:outbound", {"payload": "{}"})
+    # no hb key for ghost → it's stale
+
+    fr.hset(presence.REGISTRY_KEY, "live", make_meta("live").to_json())
+    fr.set(presence.hb_key("live"), str(time.time()), ex=60)
+    fr.xadd("cc-sessions:live:inbound", {"payload": "{}"})
+
+    presence.list_live_sessions(fr, gc_stale=True)
+    # stale: registry entry + both streams gone
+    assert fr.hget(presence.REGISTRY_KEY, "ghost") is None
+    assert fr.exists("cc-sessions:ghost:inbound") == 0
+    assert fr.exists("cc-sessions:ghost:outbound") == 0
+    # live: untouched
+    assert fr.hget(presence.REGISTRY_KEY, "live") is not None
+    assert fr.exists("cc-sessions:live:inbound") == 1
+
+
+def test_list_live_sessions_no_gc_when_disabled(fr: Any) -> None:
+    """Default gc_stale=False must NOT touch streams (or registry)."""
+    fr.hset(presence.REGISTRY_KEY, "ghost", make_meta("ghost").to_json())
+    fr.xadd("cc-sessions:ghost:inbound", {"payload": "{}"})
+    presence.list_live_sessions(fr)  # gc_stale defaults to False
+    assert fr.hget(presence.REGISTRY_KEY, "ghost") is not None
+    assert fr.exists("cc-sessions:ghost:inbound") == 1
 
 
 def test_list_live_sessions_handles_corrupt_entry(fr: Any) -> None:


### PR DESCRIPTION
## What

Live Redis audit caught that disconnected sessions were leaking stream keys: every \`cc-sessions:<name>:inbound\` and \`:outbound\` stayed in Redis forever. **8 orphan stream keys after one afternoon of testing.**

## How

Two layers:

1. **Graceful disconnect** (\`Presence.stop\`): now DELs inbound + outbound stream keys alongside the existing registry HDEL + hb DEL. Reflects "this session is done" intent.
2. **Lazy GC on stale entries** (\`list_live_sessions(gc_stale=True)\`): also DELs streams of any registry entry whose hb key has expired. Catches crash paths that bypass graceful disconnect.

New helper \`presence.session_stream_keys(name)\` enumerates all per-session keys (inbound, outbound, hb) — single source of truth for both code paths.

## Tests

4 new in \`test_redis_channel_presence.py\`:
- \`test_presence_stop_drops_session_streams\` (graceful disconnect)
- \`test_session_stream_keys_layout\` (helper)
- \`test_list_live_sessions_gc_drops_stale_streams\` (lazy GC)
- \`test_list_live_sessions_no_gc_when_disabled\` (default off)

**418 tests pass; ruff, format, mypy all green.**

## Cleanup

Cleaned up the 6 existing orphan streams on olympus-bus Redis (from earlier test sessions) as part of this work. Active session preserved.

## Versions

0.4.5 → 0.4.6. Cache pre-synced.