### PR TITLE
coach(redis-channel): mandatory output shape for reply turns (v0.4.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,23 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — coach upgrades the two-places rule from soft guidance to mandatory output shape (v0.4.7)
+
+v0.4.5 introduced the "write the same answer in two places" coaching, but live testing of v0.4.6 caught Claude occasionally emitting just the `reply` tool call with no preceding text block. The terminal then shows only `Called plugin:redis-channel:redis-channel` — the human has to expand the tool call or scroll back through `/resume` history to read what was sent. The functional pipeline (Hermes/Discord/voice) is unaffected because the outbound stream still gets the correct `text` argument, but the local-terminal UX takes a hit.
+
+The protocol limitation is real: Claude Code's render pipeline does not surface MCP tool result content as chat (`Tool … not found in render-time tools`), and there is no notification channel that renders outbound replies. The only mechanism that puts text on the local terminal is a text block in the assistant turn — and whether Claude emits that text block alongside the tool call is inference-variant.
+
+Coach is tightened from "write the same answer in two places" (soft) to a MANDATORY output shape with a concrete skeleton:
+
+```
+<your one answer to the user, as a plain text block>
+<tool_use: reply(chat_id=…, text=<that same answer, byte-identical>, …)>
+```
+
+Plus an explicit anti-pattern list: tool call alone, text+tool with different wording, narration ("Sent reply…"), and chain-of-thought in the text. This is best-effort — coaching reduces but does not eliminate inference variance. The deterministic fix (server-side echo notification) was considered and rejected: it would double-render every reply on the local terminal, costing tokens and confusing the merged-chat illusion. Document the imperfection; accept that hands-off review may occasionally require expanding a tool call.
+
+Files: `agents/redis-channel-coach.md`. No code or test changes.
+
 ### Fixed — per-session stream cleanup on disconnect + lazy GC (v0.4.6)
 
 Live audit of olympus-bus Redis caught that we were leaking stream keys: every disconnected session left `cc-sessions:<name>:inbound` and `cc-sessions:<name>:outbound` behind forever. Eight orphan stream keys accumulated in one afternoon of testing.

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -44,20 +44,26 @@ The `text` argument is **the user-facing message body**, full stop. The recipien
 - Terminal-only commentary
 - Status updates the developer already saw
 
-## How the back-and-forth renders in the terminal
+## How the back-and-forth renders in the terminal — REQUIRED OUTPUT SHAPE
 
-When a `<channel>` event arrives, the terminal shows the inbound tag automatically. The OUTBOUND side (your reply) does NOT auto-render from the tool result content — Claude Code's UI shows the tool was called, but doesn't surface its result body as chat content.
+When a `<channel>` event arrives, the terminal shows the inbound tag automatically. The OUTBOUND side (your reply) does NOT auto-render from the tool result content — Claude Code's UI shows the tool was called, but doesn't surface its result body as chat content. So the local terminal user only sees your answer if you also emit it as a plain text block in the same assistant turn.
 
-To make the conversation look chat-like in the local terminal (closer to Remote Control's experience), **write the same answer in two places**:
+**MANDATORY output shape for every channel inbound:** your assistant turn that calls `reply` MUST contain a plain text block **before** the tool call, and the text block content MUST be byte-identical to the `text` argument you pass to `reply`. No exceptions.
 
-1. As your normal conversational reply in the terminal (the text that appears in your assistant turn).
-2. As the `text` argument to the `reply` tool.
+```
+<your one answer to the user, as a plain text block>
+<tool_use: reply(chat_id=<from inbound>, text=<that same answer, byte-identical>, voice=<per source>, in_reply_to=<_msg_id>)>
+```
 
-Both contain the **same words** — your single answer, rendered in both surfaces:
-- Terminal user sees it as your natural response.
-- Channel user (Discord/voice/etc.) sees/hears it via the reply XADD'd to the outbound stream.
+Why both: the text block is what the local terminal user sees. The tool call is what gets XADD'd to outbound for the Discord/voice user. Same words, two surfaces.
 
-Do not write the same answer twice in different forms ("Replying to user: <text>" + the tool call). Just compose your one answer, type it as your terminal response, and call `reply(text=<that same answer>, chat_id=<from inbound>)`. Skip any "I responded with…" / "Sent reply…" narration entirely — the tool call + your one-time text in the terminal are enough.
+**Anti-patterns — do not do these:**
+- Tool call alone with no text block → terminal user only sees "Called plugin:…" and has to expand the tool call to read your answer. Bad UX, breaks the "look like normal chat" goal.
+- Text block + tool call with different wording → confusing; the two surfaces disagree.
+- Narrating the send ("Sent reply to user.", "Replying with: …", "I responded with…") → adds noise; the text block IS the reply, no meta-commentary needed.
+- Internal reasoning or chain-of-thought in the text block → the channel user doesn't want to see your thinking, just your answer.
+
+The text block is your one answer to the user, full stop. The tool call carries that same answer to the router.
 
 (The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect.)
 

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"


### PR DESCRIPTION
## Summary

- Live test of v0.4.6 caught Claude emitting just `tool_use(reply)` with no preceding text block — terminal shows only `Called plugin:redis-channel:...` and the local user has to expand the tool call (or scroll back through `/resume`) to read what was sent.
- Tighten coach from soft "write the same answer in two places" guidance to a MANDATORY output skeleton: text block before tool_use, byte-identical content. Includes an explicit anti-pattern list.
- Still best-effort. Inference variance is real; coaching reduces but does not eliminate it. The deterministic alternative (server-side echo notification) was considered and rejected as token-noisy and confusing for the merged-chat illusion.

Files: only `agents/redis-channel-coach.md` + version bumps in `plugin.json`, `server/__init__.py`, `marketplace.json`, `CHANGELOG.md`. No code or test changes.

## Test plan
- [x] JSON valid (marketplace.json, plugin.json)
- [x] Version consistent across plugin.json / __init__.py / marketplace.json (0.4.7)
- [ ] After merge + reinstall: send a test inbound; Claude's reply turn should contain a text block matching the `text` argument