### PR TITLE
refactor(redis-channel): drop TextContent echo from reply success result (v0.4.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,28 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — `reply` tool success result drops the TextContent echo (v0.4.8)
+
+v0.4.7's coach tightening did not improve text_block emission alongside the `reply` tool call. Round-2 testing isolated that even when `reply` schema is already loaded (no ToolSearch in the assistant turn), Claude still drops the text_block. So deferred-vs-eager isn't the cause.
+
+New working hypothesis: the v0.4.4 echo (returning `CallToolResult(content=[TextContent(text=text)], ...)`) signals to Claude that "the text was delivered as user-visible content from the tool" — making a redundant text_block feel wrong from Claude's POV. Even though Claude Code's renderer doesn't actually show MCP `TextContent` (`[ERROR] Tool ... not found in render-time tools`), Claude's training pattern of "tool result containing the answer means no text_block needed" appears to win.
+
+Investigation via the claude-code-guide subagent confirmed: MCP spec is silent on rendering semantics ("implementations are free to expose tools through any interface pattern that suits their needs"), and Claude Code changelog has zero mentions of MCP result content rendering in 2025-2026. There is no documented mechanism to force text_block emission alongside a tool_use.
+
+This release removes the TextContent echo from the success path:
+
+```python
+# before (v0.4.4 - v0.4.7):
+return CallToolResult(content=[TextContent(text=text)], structuredContent=result)
+
+# after (v0.4.8):
+return CallToolResult(content=[], structuredContent=result)
+```
+
+Error path keeps TextContent (Claude must be able to read why the tool failed). Programmatic clients (integ_test.py + Hermes router) read `structuredContent.msg_id` and `structuredContent.ok` — both unaffected. No tests assert on the echo so no test changes needed.
+
+If this still doesn't restore text_block emission reliably, the conclusion is: Claude Code's design intentionally skips MCP result rendering, the gap is structural, and best-effort coaching is the only available lever. We document the limitation and stop fighting it — for Phase 3 (voice routing) this UX gap is moot because TTS speaks the answer to the channel-side user.
+
 ### Changed — coach upgrades the two-places rule from soft guidance to mandatory output shape (v0.4.7)
 
 v0.4.5 introduced the "write the same answer in two places" coaching, but live testing of v0.4.6 caught Claude occasionally emitting just the `reply` tool call with no preceding text block. The terminal then shows only `Called plugin:redis-channel:redis-channel` — the human has to expand the tool call or scroll back through `/resume` history to read what was sent. The functional pipeline (Hermes/Discord/voice) is unaffected because the outbound stream still gets the correct `text` argument, but the local-terminal UX takes a hit.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -431,11 +431,18 @@ def build_app() -> FastMCP:
                 structuredContent=result,
                 isError=True,
             )
-        # Success: echo the actual sent text so the terminal renders it as
-        # the tool's natural result — closes the chat-loop visibility gap.
-        # Structured fields (msg_id, etc.) ride along for programmatic clients.
+        # Success: return ONLY structuredContent — no TextContent echo. The
+        # v0.4.4 echo was intended to make the terminal render the sent text,
+        # but Claude Code does not render MCP TextContent as chat output
+        # (debug log: "Tool ... not found in render-time tools"). Worse, the
+        # echo signals to Claude that the text was "already delivered as
+        # user-visible content," which appears to suppress text_block emission
+        # alongside the tool call — leaving only "Called plugin:..." in the
+        # terminal. Removing the echo eliminates that false signal; the
+        # text_block in Claude's assistant turn is now the only path to making
+        # the answer visible locally.
         return CallToolResult(
-            content=[TextContent(type="text", text=text)],
+            content=[],
             structuredContent=result,
             isError=False,
         )


### PR DESCRIPTION
## Summary

- v0.4.7's coach tightening didn't restore text_block emission. Round-2 testing isolated that the issue persists even when `reply` schema is loaded (no ToolSearch in the assistant turn) — so deferred status isn't the cause.
- Working hypothesis: the v0.4.4 `TextContent(text=text)` echo signals to Claude "the text was already delivered as user-visible content," suppressing the redundant-feeling text_block. Claude Code's renderer doesn't actually display MCP TextContent (`Tool ... not found in render-time tools`), so the echo helps nobody but does mislead Claude.
- Removed the echo from the success path; error path keeps TextContent so Claude can read failures. structuredContent unchanged → integ_test.py + Hermes router consumers unaffected.

If this still doesn't restore text_block emission reliably, the conclusion is Claude Code's design intentionally skips MCP result rendering — best-effort coaching is the only lever, the gap is structural, we document and move on to Phase 3.

## Test plan
- [x] 27 channel tests pass (no regression)
- [x] JSON valid; versions consistent (0.4.8)
- [ ] After merge + reinstall: send 2-3 inbounds, observe text_block frequency