### PR TITLE
coach(redis-channel): reframe channel as two-user conversation (v0.4.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,24 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — coach reframes channel as two-user conversation, drops anti-narration list (v0.4.9)
+
+Cheap diagnostic confirmed the previous theory: Claude itself self-reported `"no text block, only tool call"` when asked to repeat its prior turn's assistant text. The "Yes — text block is back" outbound text from v0.4.8 testing was Claude pattern-matching the question, not reporting actual output. Streaming-write debug log activity (1929 writes during a 1.4s window) was just terminal overhead — cursor, scroll, "Brewed for Xs" line — not real content.
+
+This is a **model emission problem, not a UI rendering problem**. No amount of UI investigation helps. Coaching is the only lever.
+
+Jeff caught the actual confound: the v0.4.7 coach had a "what `text` is for" anti-list explicitly banning "tool-call narration", "terminal-only commentary", "status updates the developer already saw" in the `text` arg. Claude appears to be over-generalizing those bans to the text_block too, since the MANDATORY rule required byte-identical content. Result: Claude's "don't narrate tool calls" prior wins, no text_block emitted.
+
+v0.4.9 reframes the model:
+
+- Removed the "what `text` is for" anti-narration list entirely.
+- Removed the MANDATORY skeleton + anti-pattern list.
+- Replaced with a "two users in this conversation" framing: a local terminal user (sees assistant text) and a channel user (sees `reply()`'s text arg). Two separate audiences, neither sees the other's surface. Writing assistant text is NOT narration — it's the answer for one audience; the reply tool is the answer for the other.
+
+The hypothesis is that "I have two real users to serve, each with their own surface" overrides the "don't narrate" pattern more cleanly than MANDATORY framing. Whether it works empirically is the open question.
+
+If v0.4.9 still doesn't produce reliable text_block emission, the conclusion is: Claude's training pattern around tool calls in MCP contexts is too strong to override via coaching, and the UX gap is structural. We accept and move to Phase 3.
+
 ### Changed — `reply` tool success result drops the TextContent echo (v0.4.8)
 
 v0.4.7's coach tightening did not improve text_block emission alongside the `reply` tool call. Round-2 testing isolated that even when `reply` schema is already loaded (no ToolSearch in the assistant turn), Claude still drops the text_block. So deferred-vs-eager isn't the cause.

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -36,34 +36,21 @@ the user's actual text here
 | `thread`              | `false`     | Threaded reply. Same formatting as `dm`/`channel`. Pass `in_reply_to` for proper threading.                                                                                                                                                                                                                            |
 | *(any other / unset)* | `false`     | Default to `dm`-style behavior. Future router-side surfaces (email, SMS, alerts) will document their conventions; until then treat unknown sources as text-rendered.                                                                                                                                                  |
 
-## What `text` is for
+## Two users in this conversation — answer them both
 
-The `text` argument is **the user-facing message body**, full stop. The recipient on the other side either reads it (text sources) or hears it spoken via TTS (voice). Do NOT put any of the following in `text`:
-- Tool-call narration ("calling reply", "I responded with…", "Reply sent on the outbound stream…")
-- Internal reasoning or chain-of-thought
-- Terminal-only commentary
-- Status updates the developer already saw
+When a `<channel>` event arrives, there are **two distinct users** you're responding to in the same turn:
 
-## How the back-and-forth renders in the terminal — REQUIRED OUTPUT SHAPE
+1. **The local terminal user** (the developer reading your assistant output in the CLI). They see your turn's assistant text. They do NOT see anything inside MCP tool calls or results — those render as `Called plugin:…` collapsed.
+2. **The channel user** (Discord/voice/etc. via the router). They see whatever you put in `reply()`'s `text` argument. They do NOT see your assistant text.
 
-When a `<channel>` event arrives, the terminal shows the inbound tag automatically. The OUTBOUND side (your reply) does NOT auto-render from the tool result content — Claude Code's UI shows the tool was called, but doesn't surface its result body as chat content. So the local terminal user only sees your answer if you also emit it as a plain text block in the same assistant turn.
+Both users want your answer to their question. Two separate audiences, one answer, two delivery surfaces:
 
-**MANDATORY output shape for every channel inbound:** your assistant turn that calls `reply` MUST contain a plain text block **before** the tool call, and the text block content MUST be byte-identical to the `text` argument you pass to `reply`. No exceptions.
+- **Write your answer as your normal assistant text** — that's how the local user reads it. It's your primary response, just like any other turn. Not narration, not commentary — it's the answer.
+- **Also call `reply(chat_id=…, text=<same answer>, …)`** — that's how the channel user reads it. The tool is the shipping mechanism for the remote surface.
 
-```
-<your one answer to the user, as a plain text block>
-<tool_use: reply(chat_id=<from inbound>, text=<that same answer, byte-identical>, voice=<per source>, in_reply_to=<_msg_id>)>
-```
+These are not redundant. Each user sees only their own surface. If you skip the assistant text, the local user sees nothing. If you skip the `reply` tool, the channel user sees nothing.
 
-Why both: the text block is what the local terminal user sees. The tool call is what gets XADD'd to outbound for the Discord/voice user. Same words, two surfaces.
-
-**Anti-patterns — do not do these:**
-- Tool call alone with no text block → terminal user only sees "Called plugin:…" and has to expand the tool call to read your answer. Bad UX, breaks the "look like normal chat" goal.
-- Text block + tool call with different wording → confusing; the two surfaces disagree.
-- Narrating the send ("Sent reply to user.", "Replying with: …", "I responded with…") → adds noise; the text block IS the reply, no meta-commentary needed.
-- Internal reasoning or chain-of-thought in the text block → the channel user doesn't want to see your thinking, just your answer.
-
-The text block is your one answer to the user, full stop. The tool call carries that same answer to the router.
+Format the `text` arg per the source-mode table above (voice → speakable prose; dm/channel/thread → normal markdown). Your assistant text can match exactly, or be a slightly fuller markdown version for the terminal — but easiest is byte-identical: write your answer once, use it twice.
 
 (The `debug` flag on `/redis-channel-connect` is reserved for future opt-in dev verbosity but currently has no effect.)
 

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"


### PR DESCRIPTION
## Summary

- Cheap self-report diagnostic confirmed Claude is NOT emitting a text_block (it explicitly said *'no text block, only tool call.'* when asked to repeat its prior turn). Prior 'Yes — text block is back' outbound was pattern-matching the question, not actual self-knowledge.
- Pins the problem as model emission, not UI rendering. Coaching is the only lever.
- Hypothesis (Jeff's catch): v0.4.7's 'what text is for' anti-list ('don't narrate', 'no terminal-only commentary') was over-generalizing to the text_block. Claude's 'don't narrate tool calls' prior won over the MANDATORY framing.
- v0.4.9 strips the anti-narration list + MANDATORY skeleton. Reframes as 'two users in this conversation': local terminal user sees assistant text, channel user sees reply tool's text arg. Two audiences, neither sees the other. Writing assistant text is NOT narration — it's the answer for one audience.

If this doesn't produce reliable text_block emission either, the gap is structural and we accept + move to Phase 3.

## Test plan
- [x] JSON valid; versions consistent (0.4.9)
- [ ] After merge + reinstall: send 2-3 inbounds, observe text_block frequency