### PR TITLE
refactor(redis-channel): router-agnostic audit + default_endpoint resolver (v0.4.11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,8 +343,8 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.10",
-      "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with a router (e.g. hermes-claude-code-router) for hands-free Discord voice/text control of live CC sessions.",
+      "version": "0.4.11",
+      "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "redis-channel",
-  "version": "0.4.10",
-  "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Pair with hermes-claude-code-router for Discord/voice via Hermes.",
+  "version": "0.4.11",
+  "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
@@ -12,7 +12,7 @@
     "mcp",
     "redis",
     "redis-streams",
-    "hermes",
+    "router-agnostic",
     "voice",
     "hands-free"
   ]

--- a/plugins/redis-channel/.mcp.json
+++ b/plugins/redis-channel/.mcp.json
@@ -5,7 +5,7 @@
       "command": "/bin/sh",
       "args": [
         "-c",
-        "cd \"$CLAUDE_PLUGIN_ROOT\" || exit 1; if [ -x \"$HOME/.claude/channels/redis-channel/get-redis-password.sh\" ]; then export HERMES_REDIS_PASSWORD=\"$(\"$HOME/.claude/channels/redis-channel/get-redis-password.sh\")\"; fi; exec uv run --quiet --with 'mcp>=1.0' --with 'redis>=5.0' --with 'pydantic>=2.5' python3 -m server"
+        "cd \"$CLAUDE_PLUGIN_ROOT\" || exit 1; if [ -r \"$HOME/.claude/channels/redis-channel/source-env.sh\" ]; then . \"$HOME/.claude/channels/redis-channel/source-env.sh\"; fi; exec uv run --quiet --with 'mcp>=1.0' --with 'redis>=5.0' --with 'pydantic>=2.5' python3 -m server"
       ],
       "env": {}
     }

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,34 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — router-agnostic refactor + registry resolves default endpoint (v0.4.11)
+
+First slice of Phase 2.5 (the convenience + programmatic-launch foundation). Two coupled changes:
+
+**Router-agnosticism audit.** The plugin is documented as "router-agnostic by design" (any consumer that speaks the protocol can drive it), but the codebase leaked router-specific names into descriptions, defaults, and examples. Audited and genericized:
+
+- `server/registry.py` module docstring: "Hermes profile: mimir, freya" → router-agnostic framing.
+- `server/protocol.py` module docstring: "Both this repo and `hermes-claude-code-router`" → "any router implementation".
+- `server/channel.py` MCP `instructions=` text: "a router (e.g. hermes-claude-code-router)" → "any router that speaks the protocol".
+- `server/channel.py` `redis_channel_connect` tool description: "(typically a Hermes profile like 'mimir')" → "a configured router target from your registry". Tool default `endpoint: str = "mimir"` → `endpoint: str | None = None` (resolves via registry).
+- `docs/registry.example.json`: `mimir` endpoint with `HERMES_REDIS_PASSWORD` → `default` endpoint with `MY_REDIS_PASSWORD` placeholder.
+- `.mcp.json` launcher: hardcoded `export HERMES_REDIS_PASSWORD=$(get-redis-password.sh)` → sources `~/.claude/channels/redis-channel/source-env.sh` for whatever env vars the deployment needs. `docs/source-env.example.sh` provides a template.
+- `README.md`, `skills/redis-channel/SKILL.md`, `commands/redis-channel-mode.md`, `commands/redis-channel-connect.md` description copy generalized; hermes-claude-code-router downgraded from "the reference router" to "one reference router implementation".
+- `plugin.json` description + keywords: dropped `hermes` keyword; description reflects router-agnosticism.
+
+**Kept** (intentional, contextual mentions of the reference router as a worked example): PROTOCOL.md, docs/STATE_MACHINE.md, CHANGELOG.md historical entries, README's "Related" link.
+
+**Registry: `default_endpoint` + `auto_connect_endpoint` fields.** New `Defaults` fields support endpoint resolution without baking a router name into the plugin:
+
+- `default_endpoint: str = "default"` — what `/redis-channel-connect` (no args) resolves to. Falls back to single-endpoint convenience when the named endpoint isn't configured but exactly one endpoint exists (covers solo-router setups where users just configure their one router without setting `default_endpoint`).
+- `auto_connect_endpoint: str | None = None` — endpoint name to use for env-var-driven MCP-startup auto-connect (lands in v0.5.0 with the `CLAUDE_CHANNEL_AUTO_CONNECT=1` gate).
+
+`Registry.resolve_default_endpoint()` is the canonical resolver. Existing single-endpoint registries Just Work via the convenience fallback; multi-endpoint registries get a clear error message listing the configured names.
+
+**Soft-breaking migration for `.mcp.json`:** the launcher no longer hardcodes `HERMES_REDIS_PASSWORD`. Existing deployments need to rename their `~/.claude/channels/redis-channel/get-redis-password.sh` script to `source-env.sh` and change it from `echo "$pwd"` to `export <VAR>="$pwd"` (where `<VAR>` matches the registry's `redis_password_env` field). See `docs/source-env.example.sh` for the new template.
+
+Tests: 14 → 18 registry tests (4 new for default/auto-connect endpoint resolution); 155 redis-channel tests total, all pass. ruff clean.
+
 ### Fixed — move runtime coaching into MCP server `instructions=` field (v0.4.10)
 
 Major finding: the `agents/redis-channel-coach.md` file is a Claude Code **subagent definition**, not an auto-loaded context document. Subagents are invoked via the `Agent` tool — they are NOT automatically loaded into Claude's active context. So during notification-triggered turns (where no Agent invocation happens), Claude **never read our coach**.

--- a/plugins/redis-channel/README.md
+++ b/plugins/redis-channel/README.md
@@ -1,8 +1,8 @@
 # redis-channel
 
-Claude Code channel plugin that bridges a session to external systems over **Redis Streams**. Hermes-agnostic by design: it speaks a documented protocol over Redis, and any router that speaks the same protocol can drive it.
+Claude Code channel plugin that bridges a session to external systems over **Redis Streams**. Router-agnostic by design: it speaks a documented protocol over Redis, and any router (web UI, mobile app, Discord bot, CLI test harness, ...) that speaks the same protocol can drive it.
 
-The reference router is [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router), which routes Discord voice/text through Hermes/Mimir into a connected Claude Code session for hands-free workflows.
+One reference router is [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router), which routes Discord voice/text into a connected Claude Code session for hands-free workflows. Other routers can be built against the same protocol.
 
 ## What this plugin does
 
@@ -17,13 +17,13 @@ It is **not** a Discord bot. It does not touch Discord, voice-channel audio, STT
 
 ## Status
 
-**Phase 2 complete.** Presence + heartbeat (P1) plus inbound consumer + `reply` MCP tool (P2). Channel notifications surface as `notifications/claude/channel` events with the full Inbound payload; replies XADD onto the outbound stream with router-correlation IDs and an `in_reply_to` field for threading. Phase 3 (voice routing through Hermes TTS/STT) and Phase 4 (permission relay + AskUserQuestion interception) still to come — both gated on the matching router-side implementation in `hermes-claude-code-router`. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
+**Phase 2 complete.** Presence + heartbeat (P1) plus inbound consumer + `reply` MCP tool (P2). Channel notifications surface as `notifications/claude/channel` events with the full Inbound payload; replies XADD onto the outbound stream with router-correlation IDs and an `in_reply_to` field for threading. Voice routing (P3), permission relay + AskUserQuestion interception (P4), and hybrid LLM-tool intelligence (P5) still to come — each requires matching router-side implementation. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
 
 ## Quickstart
 
 1. **Configure an endpoint.** Copy `docs/registry.example.json` to `~/.claude/channels/redis-channel/registry.json` and edit. At minimum set `redis_url` and `redis_password_env` (the name of the env var containing your Redis password — never embed the password in the file).
 2. **Make sure Python deps are available.** The plugin's MCP server (`python -m server`) needs `mcp` and `redis` on its Python path. `uv sync --extra dev` at the repo root covers it for development.
-3. **Connect from inside Claude Code.** Run `/redis-channel-connect mimir` (or whatever endpoint name you configured). The session is registered with an auto-generated `<cwd-basename>-<8hex>` name, heartbeat starts.
+3. **Connect from inside Claude Code.** Run `/redis-channel-connect` (uses the registry's `default_endpoint`, or `/redis-channel-connect <endpoint-name>` to pick a specific one). The session is registered with an auto-generated `<cwd-basename>-<8hex>` name, heartbeat starts.
 4. **Verify.** Run `/redis-channel-list` to see the registry. Start another CC session in a different repo and `/redis-channel-connect` it too; the list shows both.
 5. **Disconnect.** `/redis-channel-disconnect` gracefully unregisters. Killing the process is also safe — the heartbeat key expires within 60s and other sessions GC the entry the next time they `list`.
 
@@ -83,6 +83,5 @@ uv run mypy plugins/redis-channel/server/
 
 ## Related
 
-- [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router) — reference router implementation for Hermes.
-- [`hermes-extensions`](https://github.com/infiquetra/hermes-extensions) — pattern this plugin's router was modeled on.
+- [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router) — one reference router implementation (Discord-via-Hermes).
 - [Claude Code channels reference](https://code.claude.com/docs/en/channels-reference) — upstream channel protocol Claude Code itself speaks.

--- a/plugins/redis-channel/commands/redis-channel-connect.md
+++ b/plugins/redis-channel/commands/redis-channel-connect.md
@@ -1,12 +1,12 @@
 ---
-description: Connect this Claude Code session to a redis-channel endpoint (default: mimir). Registers session presence in Redis.
+description: Connect this Claude Code session to a configured redis-channel endpoint. Registers session presence in Redis.
 argument-hint: "[endpoint-name] [--session-name <name>] [--debug]"
 ---
 
 Connect the current session to a configured `redis-channel` endpoint.
 
 **Argument parsing:**
-- First positional arg = endpoint name (default `"mimir"`).
+- First positional arg = endpoint name (optional). If omitted, the server resolves to `registry.defaults.default_endpoint`, with a single-endpoint convenience fallback when only one is configured.
 - `--session-name <name>` flag (optional) — pass that as `session_name`. Otherwise omit and let the server auto-generate `<cwd-basename>-<short-hash>`.
 - `--debug` flag (optional) — pass `debug=true` to the tool. **Default `false`.** Without this flag, reply behavior is *quiet*; with it, reply behavior is *verbose* (see below).
 

--- a/plugins/redis-channel/commands/redis-channel-mode.md
+++ b/plugins/redis-channel/commands/redis-channel-mode.md
@@ -9,6 +9,6 @@ Override the router-side routing default for inbound messages to this session:
 - `always_route` — every message from any chat with this user/endpoint forwards to this session regardless of mode-toggle phrases.
 - `never_route` — this session ignores inbound; only the router LLM responds. Useful for "pause" scenarios.
 
-The override publishes a `mode_change` lifecycle event. The router-side behavior depends on the consumer's implementation (`hermes-claude-code-router` honors all three).
+The override publishes a `mode_change` lifecycle event. Router-side behavior depends on the consumer's implementation; reference implementations (e.g. `hermes-claude-code-router`) honor all three modes.
 
 **Not implemented in Phase 0.** Lands in Phase 3 (voice routing) or later.

--- a/plugins/redis-channel/docs/registry.example.json
+++ b/plugins/redis-channel/docs/registry.example.json
@@ -1,9 +1,9 @@
 {
   "endpoints": {
-    "mimir": {
-      "redis_url": "redis://olympus-bus.infiquetra.com:6379/0",
-      "redis_password_env": "HERMES_REDIS_PASSWORD",
-      "display_name": "Mimir (Hermes engineering-council profile)"
+    "default": {
+      "redis_url": "redis://redis-host.example.com:6379/0",
+      "redis_password_env": "MY_REDIS_PASSWORD",
+      "display_name": "Default router endpoint"
     }
   },
   "defaults": {
@@ -12,6 +12,8 @@
     "registry_ttl_seconds": 60,
     "destructive_confirm_seconds": 3,
     "permission_window_seconds": 30,
-    "consumer_block_ms": 1000
+    "consumer_block_ms": 1000,
+    "default_endpoint": "default",
+    "auto_connect_endpoint": null
   }
 }

--- a/plugins/redis-channel/docs/source-env.example.sh
+++ b/plugins/redis-channel/docs/source-env.example.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Example per-deployment env file for redis-channel.
+#
+# Install at ~/.claude/channels/redis-channel/source-env.sh
+# The MCP launcher in .mcp.json sources this file (via `.`) before starting the
+# server, so any `export` here lands in the server's environment.
+#
+# The env var name MUST match your registry.json's `redis_password_env` field.
+# This file is per-deployment — the plugin itself is router-agnostic and never
+# references specific env var names.
+
+# Example: source the password from macOS keychain.
+# Replace `my-redis-password` with the keychain item name you actually use,
+# and replace `MY_REDIS_PASSWORD` with whatever name your registry expects.
+if command -v security >/dev/null 2>&1; then
+    pwd="$(security find-generic-password -s 'my-redis-password' -w 2>/dev/null)"
+    if [ -n "$pwd" ]; then
+        export MY_REDIS_PASSWORD="$pwd"
+    fi
+fi
+
+# Linux alternative: read from a chmod-600 file.
+# [ -r ~/.config/redis-channel/password ] && export MY_REDIS_PASSWORD="$(cat ~/.config/redis-channel/password)"
+
+# Other env vars worth setting here (optional):
+# export CLAUDE_CHANNEL_AUTO_CONNECT=1
+# export CLAUDE_CHANNEL_ENDPOINT=default

--- a/plugins/redis-channel/scripts/integ_test.py
+++ b/plugins/redis-channel/scripts/integ_test.py
@@ -38,12 +38,15 @@ import redis
 
 # Plugin root = parent of scripts/ dir. Works regardless of worktree location.
 PLUGIN_DIR = Path(__file__).resolve().parent.parent
-REDIS_HOST = os.environ.get("REDIS_BRIDGE_INTEG_HOST", "olympus-bus.infiquetra.com")
-REDIS_PORT = int(os.environ.get("REDIS_BRIDGE_INTEG_PORT", "6379"))
-# Caller must set HERMES_REDIS_PASSWORD in env before invoking this script:
-#   HERMES_REDIS_PASSWORD="$(security find-generic-password -s hermes-redis-password -w)" \
+REDIS_HOST = os.environ.get("REDIS_CHANNEL_INTEG_HOST", "olympus-bus.infiquetra.com")
+REDIS_PORT = int(os.environ.get("REDIS_CHANNEL_INTEG_PORT", "6379"))
+# Caller must set the Redis password in env before invoking this script.
+# The env var name is whatever your test environment uses — this harness
+# accepts REDIS_CHANNEL_INTEG_PASSWORD (preferred) or falls back to
+# HERMES_REDIS_PASSWORD for legacy compatibility. Example:
+#   REDIS_CHANNEL_INTEG_PASSWORD="$(security find-generic-password -s my-redis-password -w)" \
 #     uv run python plugins/redis-channel/scripts/integ_test.py
-REDIS_PASSWORD = os.environ["HERMES_REDIS_PASSWORD"]
+REDIS_PASSWORD = os.environ.get("REDIS_CHANNEL_INTEG_PASSWORD") or os.environ["HERMES_REDIS_PASSWORD"]
 TEST_SESSION_NAME = "integ-test-headless"
 NOTIFICATION_WAIT_S = 5.0
 SHUTDOWN_WAIT_S = 5.0
@@ -187,7 +190,13 @@ class MCPClient:
 
 def spawn_server() -> MCPClient:
     env = os.environ.copy()
-    env["HERMES_REDIS_PASSWORD"] = REDIS_PASSWORD
+    # Set the env var that the integ-test fixture's registry.json expects in
+    # its `redis_password_env` field. The default fixture uses
+    # HERMES_REDIS_PASSWORD for backward compatibility with the existing dev
+    # setup; override via REDIS_CHANNEL_INTEG_VAR if your fixture uses
+    # a different name.
+    password_var = os.environ.get("REDIS_CHANNEL_INTEG_VAR", "HERMES_REDIS_PASSWORD")
+    env[password_var] = REDIS_PASSWORD
     # The server logs to stderr; we want unbuffered so we see it live.
     env["PYTHONUNBUFFERED"] = "1"
     trace(f"spawning: uv run --project {PLUGIN_DIR.parent.parent} python -m server")

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -90,7 +90,7 @@ class ServerState:
     def connect(
         self,
         *,
-        endpoint: str,
+        endpoint: str | None,
         session_name: str | None,
         notifier: ChannelNotifier | None = None,
         debug: bool = False,
@@ -100,6 +100,10 @@ class ServerState:
         `notifier` is the surface to which inbound stream messages are
         forwarded. In production it's the AsyncNotifier built from the
         MCP session + loop; in tests it's a RecordingNotifier or NoopNotifier.
+
+        When `endpoint` is None, resolves to `registry.defaults.default_endpoint`
+        with a single-endpoint convenience fallback (see
+        `Registry.resolve_default_endpoint`).
         """
         try:
             with self._lock:
@@ -107,7 +111,11 @@ class ServerState:
                     self._disconnect_locked(reason="reconnect")
 
                 registry = load_registry()
-                ep = registry.get(endpoint)
+                if endpoint is None:
+                    ep = registry.resolve_default_endpoint()
+                    endpoint = ep.name
+                else:
+                    ep = registry.get(endpoint)
                 resolved_name = resolve_session_name(session_name)
                 client = redis_connect(ep)
                 # Auto-disambiguate only when the user didn't supply an
@@ -341,8 +349,8 @@ def build_app() -> FastMCP:
         name=f"redis-channel v{__version__}",
         instructions=(
             "Generic Redis-streams bridge for Claude Code sessions. Pair "
-            "with a router (e.g. hermes-claude-code-router) on the "
-            "consumer side.\n"
+            "with any router that speaks the protocol on the consumer "
+            "side.\n"
             "\n"
             "When a redis-channel session is active (after "
             "/redis-channel-connect), external user messages arrive as "
@@ -397,16 +405,19 @@ def build_app() -> FastMCP:
         name="redis_channel_connect",
         description=(
             "Connect this Claude Code session to a redis-channel endpoint "
-            "(typically a Hermes profile like 'mimir'). Registers in the shared "
-            "Redis registry, starts a 10s heartbeat, and attaches an inbound "
-            "consumer that emits notifications/claude/channel for each XADD'd "
-            "inbound message. Returns the resolved session_name + metadata. "
-            "Pass debug=true to opt into verbose reply narration in the local "
-            "terminal (useful for dev/test); default false = quiet."
+            "(a configured router target from your registry). Registers in "
+            "the shared Redis registry, starts a 10s heartbeat, and attaches "
+            "an inbound consumer that emits notifications/claude/channel for "
+            "each XADD'd inbound message. Returns the resolved session_name "
+            "+ metadata. If `endpoint` is omitted, resolves to "
+            "registry.defaults.default_endpoint (falling back to the sole "
+            "configured endpoint when only one exists). Pass debug=true to "
+            "opt into verbose reply narration in the local terminal (useful "
+            "for dev/test); default false = quiet."
         ),
     )
     async def redis_channel_connect(
-        endpoint: str = "mimir",
+        endpoint: str | None = None,
         session_name: str | None = None,
         debug: bool = False,
         ctx: Context | None = None,

--- a/plugins/redis-channel/server/protocol.py
+++ b/plugins/redis-channel/server/protocol.py
@@ -5,8 +5,9 @@ are the enforcement layer: every inbound payload from Redis is validated
 against them before processing; every outbound payload is serialized through
 them. Schema mismatches fail loud, not silent.
 
-Both this repo and `hermes-claude-code-router` keep these in sync. Any change
-to the protocol requires synchronized PRs.
+This repo and any router implementation (e.g., `hermes-claude-code-router` as
+the reference router) keep these in sync. Any change to the protocol requires
+coordinated updates on both sides.
 """
 
 from __future__ import annotations

--- a/plugins/redis-channel/server/registry.py
+++ b/plugins/redis-channel/server/registry.py
@@ -1,15 +1,17 @@
 """Local config reader for redis-channel endpoints.
 
 The endpoint registry lives at `~/.claude/channels/redis-channel/registry.json`
-and lists the Redis backends this CC plugin can connect to (typically one per
-Hermes profile: mimir, freya, etc).
+and lists the Redis backends this CC plugin can connect to. Each endpoint is
+one configured router target — the plugin itself is router-agnostic, so this
+could be any consumer that speaks the protocol (a Hermes profile, a custom
+router, a CLI test harness).
 
 Schema:
     {
       "endpoints": {
         "<name>": {
           "redis_url": "redis://host:6379/0",
-          "redis_password_env": "HERMES_REDIS_PASSWORD",
+          "redis_password_env": "MY_REDIS_PASSWORD",
           "display_name": "Human label"
         }, ...
       },
@@ -52,6 +54,15 @@ class Defaults:
     destructive_confirm_seconds: int = 3
     permission_window_seconds: int = 30
     consumer_block_ms: int = 1000
+    # Name of the endpoint to use when `redis_channel_connect` is called without
+    # an explicit `endpoint` arg. Falls back to single-endpoint convenience: if
+    # this name isn't in endpoints AND there's exactly one configured endpoint,
+    # that endpoint is used. Else `resolve_default_endpoint` raises.
+    default_endpoint: str = "default"
+    # Name of the endpoint to use for env-var-driven auto-connect at MCP server
+    # startup (see CLAUDE_CHANNEL_AUTO_CONNECT in server/channel.py::run). When
+    # None, auto-connect requires CLAUDE_CHANNEL_ENDPOINT to be set.
+    auto_connect_endpoint: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +79,28 @@ class Registry:
             raise EndpointNotFoundError(
                 f"endpoint {name!r} not in registry (available: {available})"
             ) from e
+
+    def resolve_default_endpoint(self) -> Endpoint:
+        """Return the endpoint to use when no explicit endpoint is passed.
+
+        Tries (in order):
+          1. `defaults.default_endpoint` if it names a configured endpoint.
+          2. The sole configured endpoint, if exactly one exists
+             (single-endpoint convenience for solo setups).
+          3. Raises EndpointNotFoundError otherwise.
+        """
+        name = self.defaults.default_endpoint
+        if name in self.endpoints:
+            return self.endpoints[name]
+        if len(self.endpoints) == 1:
+            return next(iter(self.endpoints.values()))
+        available = ", ".join(sorted(self.endpoints)) or "<none>"
+        raise EndpointNotFoundError(
+            f"no default endpoint resolvable: defaults.default_endpoint={name!r} "
+            f"not in registry, and multiple endpoints configured (available: "
+            f"{available}). Specify --endpoint explicitly or set "
+            f"defaults.default_endpoint to one of them."
+        )
 
 
 class RegistryError(Exception):
@@ -139,6 +172,12 @@ def load_registry(path: Path | None = None) -> Registry:
             defaults_raw.get("permission_window_seconds", base.permission_window_seconds)
         ),
         consumer_block_ms=int(defaults_raw.get("consumer_block_ms", base.consumer_block_ms)),
+        default_endpoint=str(defaults_raw.get("default_endpoint", base.default_endpoint)),
+        auto_connect_endpoint=(
+            str(defaults_raw["auto_connect_endpoint"])
+            if defaults_raw.get("auto_connect_endpoint") is not None
+            else base.auto_connect_endpoint
+        ),
     )
 
     return Registry(endpoints=endpoints, defaults=defaults, source=cfg_path)

--- a/plugins/redis-channel/skills/redis-channel/SKILL.md
+++ b/plugins/redis-channel/skills/redis-channel/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: redis-channel
-description: Operator-facing guide for the redis-channel Claude Code channel plugin. Use when the user wants to connect a Claude Code session to an external router over Redis Streams (e.g., for Discord/voice via Hermes), list registered sessions, change endpoints, or troubleshoot the bridge.
+description: Operator-facing guide for the redis-channel Claude Code channel plugin. Use when the user wants to connect a Claude Code session to an external router over Redis Streams, list registered sessions, change endpoints, or troubleshoot the bridge.
 ---
 
 # redis-channel — operator guide
 
 ## What it is
 
-`redis-channel` is a Claude Code channel that runs as an MCP subprocess of your session. It speaks a Redis-streams protocol (see `PROTOCOL.md`) and bridges to any consumer on the other side. The reference consumer is `hermes-claude-code-router` for Discord/voice via Hermes.
+`redis-channel` is a Claude Code channel that runs as an MCP subprocess of your session. It speaks a Redis-streams protocol (see `PROTOCOL.md`) and bridges to any consumer on the other side — any router that implements the protocol can drive it. One reference consumer is `hermes-claude-code-router` for Discord/voice hands-free workflows.
 
 ## Slash commands
 
 | Command | Effect |
 |---|---|
-| `/redis-channel connect [<endpoint>]` | Register session presence with the named Redis endpoint (default: `mimir`). |
+| `/redis-channel connect [<endpoint>]` | Register session presence with the named Redis endpoint (default: registry's `default_endpoint`, falls back to the sole configured endpoint when only one exists). |
 | `/redis-channel disconnect` | Cleanly remove session from registry; stop consuming streams. |
 | `/redis-channel list` | Show configured endpoints + current connection status. |
 | `/redis-channel rename <name>` | Change the session's name in the registry (must be unique). |
@@ -27,10 +27,10 @@ description: Operator-facing guide for the redis-channel Claude Code channel plu
 ```json
 {
   "endpoints": {
-    "mimir": {
-      "redis_url": "redis://olympus-bus.infiquetra.com:6379/0",
-      "redis_password_env": "HERMES_REDIS_PASSWORD",
-      "display_name": "Mimir (Hermes profile)"
+    "default": {
+      "redis_url": "redis://redis-host.example.com:6379/0",
+      "redis_password_env": "MY_REDIS_PASSWORD",
+      "display_name": "Default router endpoint"
     }
   },
   "defaults": {
@@ -39,18 +39,20 @@ description: Operator-facing guide for the redis-channel Claude Code channel plu
     "registry_ttl_seconds": 60,
     "destructive_confirm_seconds": 3,
     "permission_window_seconds": 30,
-    "consumer_block_ms": 1000
+    "consumer_block_ms": 1000,
+    "default_endpoint": "default",
+    "auto_connect_endpoint": null
   }
 }
 ```
 
-The password lives in an env var (referenced by name); never commit secrets to disk.
+The password lives in an env var (referenced by `redis_password_env`); never commit secrets to disk. The env var is populated by `~/.claude/channels/redis-channel/source-env.sh` — see `docs/source-env.example.sh` in the plugin for a template.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `connect` fails: `NOAUTH` | `HERMES_REDIS_PASSWORD` env var unset | export the var or change the `redis_password_env` reference |
+| `connect` fails: `NOAUTH` | env var named in `redis_password_env` is unset | edit `~/.claude/channels/redis-channel/source-env.sh` to export it |
 | `connect` fails: `Connection refused` | Redis unreachable or wrong URL | verify with `redis-cli -h <host> -p <port> ping` |
 | Session not appearing in router's `list sessions` | Heartbeat key missing | check CC plugin process is running; `cc-sessions:hb:<name>` exists in Redis |
 | Replies don't reach Discord/etc | Router not consuming outbound | check router-side consumer-group status: `XINFO GROUPS cc-sessions:<name>:outbound` |

--- a/tests/test_redis_channel_registry.py
+++ b/tests/test_redis_channel_registry.py
@@ -110,3 +110,122 @@ def test_registry_get_unknown_endpoint_raises(tmp_path: Path) -> None:
     r = registry.load_registry(cfg)
     with pytest.raises(registry.EndpointNotFoundError, match="available: mimir"):
         r.get("nope")
+
+
+# ─── New in v0.4.11: default_endpoint + auto_connect_endpoint ───────────────
+
+
+def test_defaults_default_endpoint_value(tmp_path: Path) -> None:
+    """`defaults.default_endpoint` is read from JSON when present."""
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {"alpha": {"redis_url": "redis://h"}},
+            "defaults": {"default_endpoint": "alpha"},
+        },
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.default_endpoint == "alpha"
+
+
+def test_defaults_default_endpoint_default_value(tmp_path: Path) -> None:
+    """When `default_endpoint` is omitted, falls back to dataclass default."""
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"alpha": {"redis_url": "redis://h"}}},
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.default_endpoint == "default"
+
+
+def test_defaults_auto_connect_endpoint_value(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {"alpha": {"redis_url": "redis://h"}},
+            "defaults": {"auto_connect_endpoint": "alpha"},
+        },
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.auto_connect_endpoint == "alpha"
+
+
+def test_defaults_auto_connect_endpoint_omitted_is_none(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {"endpoints": {"alpha": {"redis_url": "redis://h"}}},
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.auto_connect_endpoint is None
+
+
+def test_defaults_auto_connect_endpoint_null_explicit_is_none(tmp_path: Path) -> None:
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {"alpha": {"redis_url": "redis://h"}},
+            "defaults": {"auto_connect_endpoint": None},
+        },
+    )
+    r = registry.load_registry(cfg)
+    assert r.defaults.auto_connect_endpoint is None
+
+
+def test_resolve_default_endpoint_hits_named(tmp_path: Path) -> None:
+    """Happy path: defaults.default_endpoint names a configured endpoint."""
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {
+                "alpha": {"redis_url": "redis://h1"},
+                "beta": {"redis_url": "redis://h2"},
+            },
+            "defaults": {"default_endpoint": "beta"},
+        },
+    )
+    r = registry.load_registry(cfg)
+    ep = r.resolve_default_endpoint()
+    assert ep.name == "beta"
+
+
+def test_resolve_default_endpoint_falls_back_to_sole_endpoint(tmp_path: Path) -> None:
+    """Single-endpoint convenience: when default_endpoint isn't in endpoints
+    but there's exactly one configured endpoint, use that."""
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {"alpha": {"redis_url": "redis://h"}},
+            # default_endpoint defaults to "default" — not "alpha".
+        },
+    )
+    r = registry.load_registry(cfg)
+    ep = r.resolve_default_endpoint()
+    assert ep.name == "alpha"
+
+
+def test_resolve_default_endpoint_raises_when_multi_and_unresolvable(
+    tmp_path: Path,
+) -> None:
+    """Multi-endpoint without a resolvable default → clear error."""
+    cfg = write_config(
+        tmp_path / "r.json",
+        {
+            "endpoints": {
+                "alpha": {"redis_url": "redis://h1"},
+                "beta": {"redis_url": "redis://h2"},
+            },
+            # default_endpoint=="default" not in endpoints; >1 configured.
+        },
+    )
+    r = registry.load_registry(cfg)
+    with pytest.raises(
+        registry.EndpointNotFoundError, match="no default endpoint resolvable"
+    ):
+        r.resolve_default_endpoint()
+
+
+def test_resolve_default_endpoint_raises_on_empty_registry(tmp_path: Path) -> None:
+    cfg = write_config(tmp_path / "r.json", {"endpoints": {}})
+    r = registry.load_registry(cfg)
+    with pytest.raises(registry.EndpointNotFoundError):
+        r.resolve_default_endpoint()


### PR DESCRIPTION
## Summary

First slice of Phase 2.5 — strips router-specific names (hermes/mimir) from plugin descriptions, defaults, and examples while keeping "reference router" mentions in protocol docs and README links. Pairs with new `Defaults` fields that enable the rest of Phase 2.5 (env-var auto-connect lands next).

## What changed

**Code:**
- `redis_channel_connect` now takes `endpoint: str | None = None`; resolves via `registry.defaults.default_endpoint` with single-endpoint convenience fallback when only one endpoint is configured.
- New `Registry.resolve_default_endpoint()` method on the Registry dataclass.
- `Defaults` dataclass gains `default_endpoint: str = "default"` and `auto_connect_endpoint: str | None = None` fields.

**Docs / config:**
- README, SKILL.md, plugin.json description, command markdown all generalized.
- `docs/registry.example.json` uses neutral names (no `mimir`, no `HERMES_REDIS_PASSWORD`).
- `.mcp.json` launcher now sources `~/.claude/channels/redis-channel/source-env.sh` instead of hardcoding `HERMES_REDIS_PASSWORD`. `docs/source-env.example.sh` is the template. **Soft-breaking** for existing deployments — see CHANGELOG migration note.

**Tests:**
- 4 new registry tests covering `default_endpoint` parsing, `auto_connect_endpoint` parsing, and `resolve_default_endpoint` paths (happy, fallback, multi-endpoint error, empty registry).
- 155 redis-channel tests pass (was 146). ruff clean.

## Kept (intentional reference-router context)
PROTOCOL.md, docs/STATE_MACHINE.md, CHANGELOG history, README "Related" link, and `integ_test.py` test data — all reference hermes-claude-code-router / mimir as worked-example reference router. Per Phase 2.5 plan §6 allowlist.

## Test plan
- [x] 155 redis-channel tests pass
- [x] ruff clean
- [x] JSON valid (marketplace, plugin, registry.example, .mcp.json)
- [x] Versions consistent (0.4.11 across plugin.json, server/__init__.py, marketplace.json)
- [ ] User migrates their `~/.claude/channels/redis-channel/get-redis-password.sh` to `source-env.sh` after merge, verifies connect still works