### PR TITLE
feat(redis-channel): env-var auto-connect + /redis-channel-status (v0.4.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,24 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — env-var-driven auto-connect + `/redis-channel-status` (v0.4.12)
+
+Second slice of Phase 2.5. Together with the v0.4.13 wrapper script (next), this makes redis-channel sessions startable from outside the terminal — needed for Phase 5 (Mimir spawning CC sessions on demand) but also a UX win for humans who don't want to type `/redis-channel-connect` on every session start.
+
+**Auto-connect at MCP server startup.** When the MCP server boots with `CLAUDE_CHANNEL_AUTO_CONNECT=1` in its environment, the server eagerly registers presence + creates the inbound consumer group, then defers starting the consumer thread until the first MCP tool dispatch (when a live MCP Context is available to build the AsyncNotifier from). Because the consumer group is created at `id="$"` BEFORE presence publishes, XREADGROUP `>` on first tool dispatch picks up every message XADD'd in the gap — no silent drop.
+
+- Gate is strict: only the literal value `"1"` enables. `"0"`, `"true"`, empty, unset — all off. Avoids accidental enable from a leaky shell env.
+- Endpoint resolution: `CLAUDE_CHANNEL_ENDPOINT` env var if set, else `registry.defaults.auto_connect_endpoint` (added in v0.4.11). Both unset → log warning + continue running so the user can still `/redis-channel-connect` manually.
+- Failure modes (registry missing, endpoint not configured, Redis unreachable) → log + continue. The MCP server never crashes on auto-connect failure.
+
+Refactored `ServerState.connect()` to share code with the new `startup_register()` / `ensure_consumer_attached()` pair: `connect()` now does eager-register + immediate consumer-attach in one call; `startup_register()` only does the eager part (the deferred path); existing `connect()` tests still pass unchanged.
+
+Tool handlers for `list`, `reply`, and the new `status` (below) gained a `ctx: Context | None = None` parameter and call `_STATE.ensure_consumer_attached(_build_async_notifier(ctx))` at entry — so the FIRST tool call after auto-connect lazily attaches the consumer thread + AsyncNotifier.
+
+**`/redis-channel-status` slash command.** New MCP tool `redis_channel_status` reports current session state: `{connected, session_name, endpoint, host, uptime_seconds, consumer_attached, pending_inbound}`. New `commands/redis-channel-status.md` formats the response for terminal users. Useful for humans asking "am I still connected?" and as a programmatic probe (though the canonical readiness signal for external callers stays the `cc-sessions:hb:<name>` Redis key check).
+
+Tests: 7 new for auto-connect paths (strict gate, env-vs-registry endpoint, failure modes); 3 new for status command. 165 redis-channel tests total, all pass; ruff clean.
+
 ### Changed — router-agnostic refactor + registry resolves default endpoint (v0.4.11)
 
 First slice of Phase 2.5 (the convenience + programmatic-launch foundation). Two coupled changes:

--- a/plugins/redis-channel/commands/redis-channel-status.md
+++ b/plugins/redis-channel/commands/redis-channel-status.md
@@ -1,0 +1,21 @@
+---
+description: Show current redis-channel connection status (session, endpoint, uptime, consumer attachment, inbound backlog).
+argument-hint: ""
+---
+
+Report the current `redis-channel` session state.
+
+**Action:** Call the `redis_channel_status` MCP tool (no arguments).
+
+After the tool returns:
+
+- On `{"ok": true, "connected": false}` — say "Not connected. Use `/redis-channel-connect` to register."
+- On `{"ok": true, "connected": true, ...}` — show a compact one-line summary:
+  - `session_name` (e.g., `redis-channel-mcp-env-1a2b3c4d`)
+  - `endpoint` (e.g., `default`)
+  - `host` (e.g., `jeff-mac-studio.infiquetra.com`)
+  - `uptime_seconds` formatted as `5m 12s` or `1h 34m` for readability
+  - `consumer_attached` (`yes`/`no`) — when no, the auto-connect deferred path is still pending; will attach on next inbound or tool call
+  - `pending_inbound` count (XLEN of the inbound stream) — informational; not all of these are unconsumed (XPENDING would be more accurate, deferred for v2)
+
+If `pending_inbound > 0` and `consumer_attached == false`, mention that the next tool call will drain the backlog.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -43,9 +43,10 @@ from .presence import (
 )
 from .protocol import Outbound
 from .redis_client import connect as redis_connect
-from .redis_consumer import Consumer
+from .redis_consumer import Consumer, consumer_group, ensure_group, inbound_stream
 from .redis_producer import publish_outbound
 from .registry import (
+    DEFAULT_CONFIG_PATH,
     EndpointNotFoundError,
     RegistryError,
     RegistryNotFoundError,
@@ -71,6 +72,8 @@ class ServerState:
         self._notifier: ChannelNotifier | None = None
         self._client: Any | None = None
         self._endpoint_name: str | None = None
+        self._consumer_block_ms: int = 1000
+        self._connected_at: float | None = None
         # `debug` controls how chatty Claude should be in the terminal after
         # replying. Default off (quiet). Set via the connect tool's `debug`
         # arg; surfaced in connect's response so the slash-command markdown
@@ -109,65 +112,14 @@ class ServerState:
             with self._lock:
                 if self._presence is not None:
                     self._disconnect_locked(reason="reconnect")
-
-                registry = load_registry()
-                if endpoint is None:
-                    ep = registry.resolve_default_endpoint()
-                    endpoint = ep.name
-                else:
-                    ep = registry.get(endpoint)
-                resolved_name = resolve_session_name(session_name)
-                client = redis_connect(ep)
-                # Auto-disambiguate only when the user didn't supply an
-                # explicit name. An explicit name is treated as intent — we
-                # let the regular reconnect/replace semantics handle it.
-                if session_name is None:
-                    resolved_name = disambiguate_if_collision(
-                        client,
-                        resolved_name,
-                        host=socket.gethostname(),
-                        pid=os.getpid(),
-                    )
-                metadata = build_metadata(
-                    session_name=resolved_name,
-                    endpoint=endpoint,
+                result = self._register_locked(
+                    endpoint=endpoint, session_name=session_name, debug=debug
                 )
-                presence = Presence(
-                    client,
-                    metadata,
-                    heartbeat_seconds=registry.defaults.heartbeat_seconds,
-                    ttl_seconds=registry.defaults.registry_ttl_seconds,
-                )
-                presence.start()
-
                 resolved_notifier: ChannelNotifier = notifier or NoopNotifier()
-                consumer = Consumer(
-                    client,
-                    resolved_name,
-                    on_message=resolved_notifier.emit,
-                    block_ms=registry.defaults.consumer_block_ms,
-                )
-                consumer.start()
-
-                self._presence = presence
-                self._consumer = consumer
-                self._notifier = resolved_notifier
-                self._client = client
-                self._endpoint_name = endpoint
-                self._debug = bool(debug)
-                return {
-                    "ok": True,
-                    "session_name": metadata.session_name,
-                    "endpoint": endpoint,
-                    "endpoint_display": ep.display_name,
-                    "debug": self._debug,
-                    "host": metadata.host,
-                    "cwd": metadata.cwd,
-                    "heartbeat_seconds": registry.defaults.heartbeat_seconds,
-                    "registry_ttl_seconds": registry.defaults.registry_ttl_seconds,
-                    "consumer_attached": True,
-                    "notifier_kind": type(resolved_notifier).__name__,
-                }
+                self._attach_consumer_locked(resolved_notifier)
+                result["consumer_attached"] = True
+                result["notifier_kind"] = type(resolved_notifier).__name__
+                return result
         except RegistryError as e:
             return _format_registry_error(e)
         except ValueError as e:
@@ -177,6 +129,131 @@ class ServerState:
         except Exception as e:  # noqa: BLE001
             log.exception("connect failed")
             return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def startup_register(self, *, endpoint: str | None) -> dict[str, Any]:
+        """Eager-only auto-connect path: open client, create consumer group,
+        start presence — but do NOT start the consumer thread yet.
+
+        Called from `run()` at MCP startup when CLAUDE_CHANNEL_AUTO_CONNECT=1.
+        At that point there's no MCP Context to build an AsyncNotifier from,
+        so we defer the consumer thread until the first tool dispatch (when
+        a ctx is available). The consumer group IS created eagerly so
+        XREADGROUP `>` later picks up anything XADD'd between presence
+        publish and consumer-thread start — no silent drop.
+        """
+        try:
+            with self._lock:
+                if self._presence is not None:
+                    return {"ok": True, "was_already_connected": True}
+                result = self._register_locked(
+                    endpoint=endpoint, session_name=None, debug=False
+                )
+                result["consumer_attached"] = False
+                result["notifier_kind"] = None
+                return result
+        except RegistryError as e:
+            return _format_registry_error(e)
+        except Exception as e:  # noqa: BLE001
+            log.exception("startup_register failed")
+            return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def ensure_consumer_attached(self, notifier: ChannelNotifier) -> bool:
+        """Idempotently start the consumer thread + wire notifier.
+
+        Called from MCP tool handlers to finish the auto-connect setup
+        on first use. Returns True if the consumer was just attached;
+        False if no attachment needed (already attached or no presence).
+        """
+        with self._lock:
+            if self._presence is None or self._client is None:
+                return False
+            if self._consumer is not None:
+                return False
+            self._attach_consumer_locked(notifier)
+            return True
+
+    def _register_locked(
+        self,
+        *,
+        endpoint: str | None,
+        session_name: str | None,
+        debug: bool,
+    ) -> dict[str, Any]:
+        """Caller holds self._lock. Resolves endpoint, opens client, creates
+        consumer group, starts presence. Does NOT start consumer thread."""
+        registry = load_registry()
+        if endpoint is None:
+            ep = registry.resolve_default_endpoint()
+            endpoint = ep.name
+        else:
+            ep = registry.get(endpoint)
+        resolved_name = resolve_session_name(session_name)
+        client = redis_connect(ep)
+        # Auto-disambiguate only when the user didn't supply an explicit name.
+        # An explicit name is treated as intent — let the regular
+        # reconnect/replace semantics handle it.
+        if session_name is None:
+            resolved_name = disambiguate_if_collision(
+                client,
+                resolved_name,
+                host=socket.gethostname(),
+                pid=os.getpid(),
+            )
+        # Create the consumer group BEFORE presence publishes so XREADGROUP `>`
+        # on first tool dispatch (or `connect`'s own consumer start) picks up
+        # any messages XADD'd in the gap. ensure_group is idempotent
+        # (BUSYGROUP = success).
+        ensure_group(
+            client,
+            stream=inbound_stream(resolved_name),
+            group=consumer_group(resolved_name),
+        )
+        metadata = build_metadata(session_name=resolved_name, endpoint=endpoint)
+        presence = Presence(
+            client,
+            metadata,
+            heartbeat_seconds=registry.defaults.heartbeat_seconds,
+            ttl_seconds=registry.defaults.registry_ttl_seconds,
+        )
+        presence.start()
+
+        self._presence = presence
+        self._client = client
+        self._endpoint_name = endpoint
+        self._consumer_block_ms = registry.defaults.consumer_block_ms
+        self._connected_at = time.time()
+        self._debug = bool(debug)
+        return {
+            "ok": True,
+            "session_name": metadata.session_name,
+            "endpoint": endpoint,
+            "endpoint_display": ep.display_name,
+            "debug": self._debug,
+            "host": metadata.host,
+            "cwd": metadata.cwd,
+            "heartbeat_seconds": registry.defaults.heartbeat_seconds,
+            "registry_ttl_seconds": registry.defaults.registry_ttl_seconds,
+        }
+
+    def _attach_consumer_locked(self, notifier: ChannelNotifier) -> None:
+        """Caller holds self._lock. Starts consumer thread with the given
+        notifier; requires presence + client to already be set."""
+        if self._presence is None or self._client is None:
+            raise RuntimeError(
+                "cannot attach consumer: presence not started; call connect "
+                "or startup_register first"
+            )
+        if self._consumer is not None:
+            return  # idempotent
+        consumer = Consumer(
+            self._client,
+            self._presence.session_name,
+            on_message=notifier.emit,
+            block_ms=self._consumer_block_ms,
+        )
+        consumer.start()
+        self._consumer = consumer
+        self._notifier = notifier
 
     def disconnect(self) -> dict[str, Any]:
         try:
@@ -273,6 +350,45 @@ class ServerState:
         except Exception as e:  # noqa: BLE001
             log.exception("reply failed")
             return {"ok": False, "error": type(e).__name__, "detail": str(e)}
+
+    def status(self) -> dict[str, Any]:
+        """Snapshot of current connection state. Used by /redis-channel-status."""
+        with self._lock:
+            if self._presence is None:
+                return {
+                    "ok": True,
+                    "connected": False,
+                }
+            session_name = self._presence.session_name
+            uptime = (
+                int(time.time() - self._connected_at)
+                if self._connected_at is not None
+                else None
+            )
+            # Count pending inbound messages on the consumer group via XLEN-
+            # like introspection. XPENDING gives unacked count for the group;
+            # XLEN gives total. We want "messages waiting to be processed,"
+            # which is approximately XLEN minus already-acked. Cheapest
+            # approximation: XLEN of the stream. Good enough for "is there
+            # backlog?" UX.
+            pending: int | None = None
+            try:
+                if self._client is not None:
+                    pending = int(
+                        self._client.xlen(inbound_stream(session_name))
+                    )
+            except Exception:  # noqa: BLE001
+                pending = None
+            return {
+                "ok": True,
+                "connected": True,
+                "session_name": session_name,
+                "endpoint": self._endpoint_name,
+                "host": self._presence.metadata.host,
+                "uptime_seconds": uptime,
+                "consumer_attached": self._consumer is not None,
+                "pending_inbound": pending,
+            }
 
     def shutdown(self) -> None:
         """Best-effort cleanup on process exit."""
@@ -449,8 +565,27 @@ def build_app() -> FastMCP:
             "lazily GCs them from the registry. Requires a prior connect."
         ),
     )
-    async def redis_channel_list() -> dict[str, Any]:
+    async def redis_channel_list(ctx: Context | None = None) -> dict[str, Any]:
+        # If auto-connect ran at startup, the consumer thread is still
+        # deferred — attach it now that we have a live MCP context.
+        _STATE.ensure_consumer_attached(_build_async_notifier(ctx))
         return _STATE.list_sessions()
+
+    @app.tool(
+        name="redis_channel_status",
+        description=(
+            "Report this session's current redis-channel state: "
+            "connected/not, session_name, endpoint, host, uptime in "
+            "seconds, whether the consumer thread is attached, and the "
+            "approximate count of messages on the inbound stream. Useful "
+            "for humans asking 'am I still connected?' and as a probe "
+            "before sending inbound (though hb-key existence is the "
+            "canonical readiness signal for external callers)."
+        ),
+    )
+    async def redis_channel_status(ctx: Context | None = None) -> dict[str, Any]:
+        _STATE.ensure_consumer_attached(_build_async_notifier(ctx))
+        return _STATE.status()
 
     @app.tool(
         name="reply",
@@ -473,7 +608,11 @@ def build_app() -> FastMCP:
         text: str,
         voice: bool = False,
         in_reply_to: str | None = None,
+        ctx: Context | None = None,
     ) -> CallToolResult:
+        # If auto-connect ran at startup, the consumer thread is still
+        # deferred — attach it now that we have a live MCP context.
+        _STATE.ensure_consumer_attached(_build_async_notifier(ctx))
         result = _STATE.reply(
             chat_id=chat_id,
             text=text,
@@ -544,6 +683,73 @@ def _enable_channel_capability(app: FastMCP) -> None:
     server.create_initialization_options = patched  # type: ignore[method-assign]
 
 
+_AUTO_CONNECT_ENV = "CLAUDE_CHANNEL_AUTO_CONNECT"
+_AUTO_CONNECT_ENDPOINT_ENV = "CLAUDE_CHANNEL_ENDPOINT"
+
+
+def _maybe_auto_connect() -> None:
+    """If CLAUDE_CHANNEL_AUTO_CONNECT=1, eager-register at startup.
+
+    The gate is strict: only the literal value "1" enables. Empty, unset,
+    "0", "true" — all treated as off. This avoids accidental enable from
+    a leaky env or "auto_connect=true" string-typo.
+
+    Endpoint resolution: CLAUDE_CHANNEL_ENDPOINT env var if set, else
+    registry's `defaults.auto_connect_endpoint`. If both unset, no
+    auto-connect happens (log warning, continue running so the user can
+    still `/redis-channel-connect` manually).
+
+    Failure modes (registry missing, endpoint not in registry, Redis
+    unreachable) are caught and logged — the MCP server keeps running so
+    the user can investigate from the live session.
+
+    The consumer thread is NOT started here (no MCP Context yet for
+    AsyncNotifier). The consumer group IS created (via _register_locked's
+    ensure_group) so messages XADD'd between presence-publish and
+    first-tool-dispatch are not lost — XREADGROUP `>` will pick them up.
+    """
+    gate = os.environ.get(_AUTO_CONNECT_ENV)
+    if gate != "1":
+        return
+    endpoint = os.environ.get(_AUTO_CONNECT_ENDPOINT_ENV)
+    # Fall back to registry.defaults.auto_connect_endpoint if env unset.
+    if not endpoint:
+        try:
+            registry = load_registry()
+            endpoint = registry.defaults.auto_connect_endpoint
+        except RegistryError as e:
+            log.warning(
+                "auto-connect skipped: registry error (%s). Set "
+                "CLAUDE_CHANNEL_ENDPOINT or fix %s — server continuing.",
+                e,
+                DEFAULT_CONFIG_PATH,
+            )
+            return
+    if not endpoint:
+        log.warning(
+            "auto-connect requested via %s=1 but no endpoint resolvable "
+            "(set %s or registry.defaults.auto_connect_endpoint). Server "
+            "continuing; use /redis-channel-connect manually.",
+            _AUTO_CONNECT_ENV,
+            _AUTO_CONNECT_ENDPOINT_ENV,
+        )
+        return
+    log.info("auto-connect: registering at endpoint=%s", endpoint)
+    result = _STATE.startup_register(endpoint=endpoint)
+    if result.get("ok"):
+        log.info(
+            "auto-connect: session_name=%s presence registered (consumer "
+            "deferred to first tool dispatch)",
+            result.get("session_name"),
+        )
+    else:
+        log.warning(
+            "auto-connect failed: %s. Server continuing; use "
+            "/redis-channel-connect manually.",
+            result,
+        )
+
+
 def run() -> int:
     logging.basicConfig(
         level=logging.INFO,
@@ -555,5 +761,6 @@ def run() -> int:
     _install_signal_handlers()
     app = build_app()
     _enable_channel_capability(app)
+    _maybe_auto_connect()
     app.run()  # blocks until stdio closes
     return 0

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -521,3 +521,204 @@ def test_reply_validates_empty_chat_id(patched_state: channel.ServerState, fr: A
         assert "chat_id" in out["detail"]
     finally:
         patched_state.disconnect()
+
+
+# ─── Phase 2.5: auto-connect at MCP startup ─────────────────────────────────
+
+
+def test_startup_register_eager_no_consumer(
+    patched_state: channel.ServerState, fr: Any
+) -> None:
+    """startup_register publishes presence + creates consumer group but
+    does NOT start consumer thread (no MCP ctx yet at startup time)."""
+    out = patched_state.startup_register(endpoint="mimir")
+    try:
+        assert out["ok"] is True
+        assert out["consumer_attached"] is False
+        assert out["notifier_kind"] is None
+        # Presence (hb key) should be live
+        assert fr.exists(presence.hb_key(out["session_name"])) == 1
+        # Internal state: consumer is None until ensure_consumer_attached
+        assert patched_state._consumer is None  # noqa: SLF001
+        assert patched_state._notifier is None  # noqa: SLF001
+        # Consumer group should already exist on the inbound stream so
+        # XREADGROUP > later picks up anything XADD'd in the gap.
+        from server.redis_consumer import (  # type: ignore[import-not-found]
+            consumer_group,
+            inbound_stream,
+        )
+
+        groups = fr.xinfo_groups(inbound_stream(out["session_name"]))
+        group_names = {g["name"] for g in groups}
+        assert consumer_group(out["session_name"]) in group_names
+    finally:
+        patched_state.disconnect()
+
+
+def test_startup_register_idempotent_when_already_connected(
+    patched_state: channel.ServerState, fr: Any
+) -> None:
+    """Calling startup_register a second time while connected is a no-op."""
+    patched_state.connect(endpoint="mimir", session_name="sr-idem")
+    try:
+        out = patched_state.startup_register(endpoint="mimir")
+        assert out["ok"] is True
+        assert out.get("was_already_connected") is True
+    finally:
+        patched_state.disconnect()
+
+
+def test_ensure_consumer_attached_lazy_starts_thread(
+    patched_state: channel.ServerState, fr: Any
+) -> None:
+    """After startup_register, calling ensure_consumer_attached with a real
+    notifier starts the consumer thread and wires the notifier in."""
+    from server.notifier import NoopNotifier  # type: ignore[import-not-found]
+
+    out = patched_state.startup_register(endpoint="mimir")
+    try:
+        assert patched_state._consumer is None  # noqa: SLF001
+        attached = patched_state.ensure_consumer_attached(NoopNotifier())
+        assert attached is True
+        assert patched_state._consumer is not None  # noqa: SLF001
+        # Second call is a no-op
+        attached2 = patched_state.ensure_consumer_attached(NoopNotifier())
+        assert attached2 is False
+    finally:
+        patched_state.disconnect()
+        _ = out
+
+
+def test_ensure_consumer_attached_noop_when_no_presence(
+    patched_state: channel.ServerState,
+) -> None:
+    """ensure_consumer_attached without prior startup_register/connect is a
+    no-op (returns False), not an error."""
+    from server.notifier import NoopNotifier  # type: ignore[import-not-found]
+
+    attached = patched_state.ensure_consumer_attached(NoopNotifier())
+    assert attached is False
+    assert patched_state._consumer is None  # noqa: SLF001
+
+
+def test_maybe_auto_connect_gate_strict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_maybe_auto_connect only fires on literal '1'. 'true', 'yes', '0',
+    empty, missing — all treated as off."""
+    calls: list[str] = []
+
+    def fake_startup_register(*, endpoint: str) -> dict[str, Any]:
+        calls.append(endpoint)
+        return {"ok": True, "session_name": "x"}
+
+    monkeypatch.setattr(channel._STATE, "startup_register", fake_startup_register)
+    monkeypatch.delenv("CLAUDE_CHANNEL_AUTO_CONNECT", raising=False)
+    monkeypatch.delenv("CLAUDE_CHANNEL_ENDPOINT", raising=False)
+
+    # missing → no call
+    channel._maybe_auto_connect()
+    assert calls == []
+
+    # empty → no call
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "")
+    channel._maybe_auto_connect()
+    assert calls == []
+
+    # "0" → no call
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "0")
+    channel._maybe_auto_connect()
+    assert calls == []
+
+    # "true" → no call (strict; only "1")
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "true")
+    channel._maybe_auto_connect()
+    assert calls == []
+
+    # "1" + endpoint via env → call
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "1")
+    monkeypatch.setenv("CLAUDE_CHANNEL_ENDPOINT", "mimir")
+    channel._maybe_auto_connect()
+    assert calls == ["mimir"]
+
+
+def test_maybe_auto_connect_no_endpoint_resolvable_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When AUTO_CONNECT=1 but no endpoint resolvable (env unset, registry
+    missing auto_connect_endpoint), log warning and continue without raising."""
+
+    def fake_load_registry() -> Any:
+        from server import registry as registry_mod  # type: ignore[import-not-found]
+
+        return registry_mod.Registry(
+            endpoints={},
+            defaults=registry_mod.Defaults(),  # auto_connect_endpoint=None
+            source=Path("/dev/null"),
+        )
+
+    monkeypatch.setattr(channel, "load_registry", fake_load_registry)
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "1")
+    monkeypatch.delenv("CLAUDE_CHANNEL_ENDPOINT", raising=False)
+    with caplog.at_level("WARNING", logger="redis_channel.channel"):
+        channel._maybe_auto_connect()  # should not raise
+    assert any("no endpoint resolvable" in r.message for r in caplog.records)
+
+
+def test_maybe_auto_connect_registry_missing_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When AUTO_CONNECT=1, endpoint not in env, AND registry file missing,
+    log warning and continue (don't crash the MCP server)."""
+    from server import registry as registry_mod  # type: ignore[import-not-found]
+
+    def raising_load() -> Any:
+        raise registry_mod.RegistryNotFoundError("test-no-file")
+
+    monkeypatch.setattr(channel, "load_registry", raising_load)
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "1")
+    monkeypatch.delenv("CLAUDE_CHANNEL_ENDPOINT", raising=False)
+    with caplog.at_level("WARNING", logger="redis_channel.channel"):
+        channel._maybe_auto_connect()  # should not raise
+    assert any("registry error" in r.message for r in caplog.records)
+
+
+# ─── Phase 2.5: /redis-channel-status ───────────────────────────────────────
+
+
+def test_status_disconnected(patched_state: channel.ServerState) -> None:
+    out = patched_state.status()
+    assert out == {"ok": True, "connected": False}
+
+
+def test_status_connected_shape(patched_state: channel.ServerState, fr: Any) -> None:
+    patched_state.connect(endpoint="mimir", session_name="status-test")
+    try:
+        out = patched_state.status()
+        assert out["ok"] is True
+        assert out["connected"] is True
+        assert out["session_name"] == "status-test"
+        assert out["endpoint"] == "mimir"
+        assert "host" in out
+        assert isinstance(out["uptime_seconds"], int)
+        assert out["uptime_seconds"] >= 0
+        assert out["consumer_attached"] is True
+        # No inbound XADD'd yet → pending_inbound == 0
+        assert out["pending_inbound"] == 0
+    finally:
+        patched_state.disconnect()
+
+
+def test_status_after_startup_register_consumer_not_attached(
+    patched_state: channel.ServerState, fr: Any
+) -> None:
+    """When auto-connect ran but no tool dispatch has happened, status
+    should report consumer_attached=False."""
+    out = patched_state.startup_register(endpoint="mimir")
+    try:
+        s = patched_state.status()
+        assert s["connected"] is True
+        assert s["consumer_attached"] is False
+        assert s["session_name"] == out["session_name"]
+    finally:
+        patched_state.disconnect()


### PR DESCRIPTION
## Summary

Second slice of Phase 2.5. Together with the upcoming wrapper script, this makes redis-channel sessions startable from outside the terminal (Phase 5 prerequisite + human convenience win).

**Auto-connect at MCP server startup.** When the server boots with `CLAUDE_CHANNEL_AUTO_CONNECT=1`, eagerly registers presence + creates the inbound consumer group, defers consumer thread + AsyncNotifier wiring until first MCP tool dispatch. Consumer group at `id="$"` BEFORE presence publishes — so XREADGROUP `>` on first tool call picks up everything XADD'd in the gap. No silent drop.

- Strict gate (`"1"` only). Endpoint from `CLAUDE_CHANNEL_ENDPOINT` env, else `registry.defaults.auto_connect_endpoint`. Both unset → log + continue running.
- Failure modes (registry missing, endpoint unknown, Redis unreachable) → log + continue. Server never crashes on auto-connect failure.

**`/redis-channel-status` slash command + `redis_channel_status` MCP tool.** Returns `{connected, session_name, endpoint, host, uptime_seconds, consumer_attached, pending_inbound}`. Useful for "am I still connected?" and as a probe.

**Refactor.** `ServerState.connect()` now wraps `_register_locked + _attach_consumer_locked` so the new `startup_register()` / `ensure_consumer_attached()` pair can share code with the existing path. Tool handlers (list, reply, status) call `ensure_consumer_attached(...)` at entry to lazily complete setup post-auto-connect.

## Test plan
- [x] 10 new tests (7 auto-connect + 3 status); 165 redis-channel tests total
- [x] ruff clean
- [x] JSON valid; versions consistent (0.4.12)
- [ ] After merge + reinstall: confirm new MCP server starts cleanly even without CLAUDE_CHANNEL_AUTO_CONNECT set (backward compat); confirm `/redis-channel-status` works