### PR TITLE
feat(redis-channel): claude-channel wrapper + PROTOCOL.md launch contract (v0.4.13)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,35 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — `claude-channel` wrapper + PROTOCOL.md programmatic-launch contract (v0.4.13)
+
+Third and final slice of Phase 2.5. Together with v0.4.11 (router-agnostic refactor + registry resolver) and v0.4.12 (env-var auto-connect + status command), this closes the loop on "redis-channel sessions startable from outside the terminal."
+
+**`~/bin/claude-channel` wrapper** at `plugins/redis-channel/scripts/claude-channel.sh`, installed via `install-claude-channel.sh` which symlinks the user's `~/bin/claude-channel` at the latest plugin cache version's wrapper. Flags:
+
+- `--session-name NAME` → exports `CLAUDE_SESSION_NAME`; validated with bash regex matching `session_id.py:_NAME_RE` BEFORE spawning claude (exit 2 on mismatch).
+- `--endpoint NAME` → exports `CLAUDE_CHANNEL_ENDPOINT`.
+- `--bg`/`--background` → POSIX-portable detach (subshell + nohup + redirect + disown — works on macOS without `setsid`). Log at `${XDG_CACHE_HOME:-$HOME/.cache}/claude-channel/sessions/<name>-<epoch>.log`.
+- `--cwd PATH` → cd before exec. Load-bearing for Phase 5: routers spawn in target dirs; auto-name derivation uses cwd.
+- `--print-info` → emit JSON `{session_name, endpoint, log_path, pid, cwd, mode}`. **Foreground: prints to stderr** (no stdout pollution while claude is interactive). **Background: prints to stdout** (caller capturing wrapper output gets the JSON cleanly).
+- `--help`.
+
+Env knobs:
+- `CLAUDE_BIN` override (required when claude isn't in `$PATH`, e.g. Phase 5's Hermes-runtime context).
+- `CLAUDE_CHANNEL_PRODUCTION=1` to omit dev-only `--dangerously-*` flags.
+- `CLAUDE_CHANNEL_PLUGIN_REF` to override the development-channels plugin URI.
+
+The wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1` and best-effort sources `HERMES_REDIS_PASSWORD` from macOS keychain (backward-compat for the original dev setup; future deployments should rely on `~/.claude/channels/redis-channel/source-env.sh`).
+
+**`PROTOCOL.md` programmatic-launch contract.** New section documents spawn/list/kill semantics for external consumers (Phase 5's Mimir LLM tools, future routers):
+
+- **Spawn**: `claude-channel --bg --session-name <N> --cwd <D> --print-info` → parse JSON → poll `EXISTS cc-sessions:hb:<N>` until live.
+- **List**: `HGETALL cc-sessions:registry` filtered by `EXISTS cc-sessions:hb:<name>`.
+- **Kill**: HGET PID, verify with `ps -p <pid> -o comm=` to defend against PID reuse, then SIGTERM.
+- **Collision**: spawning with an existing session-name replaces the previous session; callers SHOULD `EXISTS` check first.
+
+Manual smoke tests: `--help` works, invalid session-name rejected with exit 2 before spawn, foreground prints JSON to stderr, background prints to stdout + spawns detached process. Programmatic integ test (subprocess.run on the wrapper) deferred to a follow-up PR.
+
 ### Added — env-var-driven auto-connect + `/redis-channel-status` (v0.4.12)
 
 Second slice of Phase 2.5. Together with the v0.4.13 wrapper script (next), this makes redis-channel sessions startable from outside the terminal — needed for Phase 5 (Mimir spawning CC sessions on demand) but also a UX win for humans who don't want to type `/redis-channel-connect` on every session start.

--- a/plugins/redis-channel/PROTOCOL.md
+++ b/plugins/redis-channel/PROTOCOL.md
@@ -245,6 +245,80 @@ Event types:
 
 Both sides subscribe to relevant channels. Pub/sub is at-most-once; do not rely on it for state — use streams for durable handoffs.
 
+## Programmatic session lifecycle (consumer-side)
+
+This section documents how an external router (or any tool, e.g. a CLI test harness, a future router LLM) can spawn, observe, and tear down redis-channel-attached Claude Code sessions on the local host. The CC plugin exposes this via the `claude-channel` shell wrapper (`plugins/redis-channel/scripts/claude-channel.sh`, symlinked into `~/bin/` by the install script).
+
+### Spawn a new session
+
+```
+claude-channel --bg --session-name <NAME> --cwd <ABS_PATH> --print-info -- <claude args...>
+```
+
+- `--session-name <NAME>` — required for programmatic use. Validated against `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- `--cwd <ABS_PATH>` — sets the spawned session's working dir. Load-bearing: the auto-name and registry-recorded `cwd` field both derive from this.
+- `--bg` — detached launch. Wrapper exits immediately after spawn.
+- `--print-info` — wrapper emits one JSON line on stdout (background mode) with `{session_name, endpoint, log_path, pid, cwd, mode}`.
+
+The wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1`, so the spawned CC session auto-registers presence + creates the consumer group at startup. After parsing the JSON, the caller MUST poll `EXISTS cc-sessions:hb:<NAME>` with backoff (100ms) up to a 15s timeout before XADD'ing inbound. Once `hb` exists, the session is live; XADD-ed inbound will not be lost (the consumer group was created BEFORE presence published — XREADGROUP `>` picks up anything in the gap once the consumer thread starts on first MCP tool dispatch).
+
+### Verify session readiness
+
+The canonical readiness signal is `EXISTS cc-sessions:hb:<NAME>` returning 1. The MCP-side `redis_channel_status` tool also reports it, but external callers should use the Redis check directly — it's faster and doesn't require any MCP transport.
+
+### List live sessions
+
+```
+HGETALL cc-sessions:registry
+```
+
+For each `<NAME> -> <JSON>` pair, filter by `EXISTS cc-sessions:hb:<NAME>` to drop stale entries. See §Presence for full details.
+
+### Tear down a session
+
+```
+HGET cc-sessions:registry <NAME>  →  parse JSON  →  read `pid` and `host`
+```
+
+If `host != local hostname`: cross-host kill is **not supported in v1** — abort.
+
+If `host == local hostname`: **verify the PID still owns a CC process** before SIGTERM, to defend against PID reuse:
+
+```
+ps -p <pid> -o comm=
+# expect output containing "python3" or "server" — if neither, abort
+```
+
+Then:
+
+```
+kill <pid>             # SIGTERM; the CC plugin's signal handlers + atexit cleanly disconnect.
+# Optional: wait until cc-sessions:hb:<NAME> disappears (a few seconds typical).
+```
+
+If the CC process died ungracefully (SIGKILL, crash), the registry entry persists until either (a) the next `redis_channel_list` call's GC sweep removes it, or (b) the next `list_live_sessions(gc_stale=True)` from a different live session removes it. The `hb:<NAME>` key expires within the TTL window (60s default).
+
+### Collision handling
+
+If a wrapper is invoked with `--session-name <NAME>` where `cc-sessions:hb:<NAME>` already exists, the new CC session's `connect` logic replaces the existing session (the older one is disconnected). Programmatic callers should `EXISTS hb:<NAME>` BEFORE spawn to avoid surprise kicks; expose a `force=True` opt-in to bypass.
+
+### Environment variables the wrapper sets
+
+The wrapper exports the following into the spawned CC's environment before exec:
+
+| Var | Effect |
+|---|---|
+| `CLAUDE_SESSION_NAME` | (if `--session-name` given) override auto-name |
+| `CLAUDE_CHANNEL_ENDPOINT` | (if `--endpoint` given) pick a specific configured endpoint |
+| `CLAUDE_CHANNEL_AUTO_CONNECT=1` | always set; gates the plugin's auto-connect at MCP startup |
+| `HERMES_REDIS_PASSWORD` | (best-effort, macOS only) sourced from keychain item `hermes-redis-password` if not already in env. Backward-compat for the original dev setup; future deployments should rely on `~/.claude/channels/redis-channel/source-env.sh` instead. |
+
+### Soft requirements + assumptions
+
+- The wrapper requires `claude` in `PATH` or `CLAUDE_BIN` env override.
+- The `--dangerously-load-development-channels` flag is prepended by default (development preview); set `CLAUDE_CHANNEL_PRODUCTION=1` to omit when channels graduate from research preview.
+- Background-mode logs go to `${XDG_CACHE_HOME:-$HOME/.cache}/claude-channel/sessions/<name>-<epoch>.log`. No rotation in v1 — sweep is the user's problem (Phase 6 polish candidate).
+
 ## Versioning and compatibility
 
 - All payloads carry `v: 1`.

--- a/plugins/redis-channel/scripts/claude-channel.sh
+++ b/plugins/redis-channel/scripts/claude-channel.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# claude-channel — launch Claude Code with a redis-channel session configured.
+#
+# Provides:
+#   - --session-name <name>  → exports CLAUDE_SESSION_NAME (validated)
+#   - --endpoint <name>      → exports CLAUDE_CHANNEL_ENDPOINT
+#   - --bg / --background    → detached launch with log file
+#   - --cwd <path>           → cd before exec (load-bearing for Phase 5)
+#   - --print-info           → emit JSON metadata for programmatic callers
+#   - --help                 → usage
+#
+# Env knobs:
+#   CLAUDE_BIN                Override claude binary path. Default: `command -v claude`.
+#   CLAUDE_CHANNEL_PRODUCTION If "1", omit dev-only --dangerously-* flags.
+#   CLAUDE_CHANNEL_PLUGIN_REF Override plugin ref for --dangerously-load-development-channels.
+#                             Default: plugin:redis-channel@infiquetra-plugins.
+#
+# Designed for both human terminal use AND programmatic invocation by routers
+# (e.g., Phase 5's hermes-claude-code-router LLM tool that spawns CC sessions
+# on demand).
+#
+# Exit codes:
+#   0  success (foreground: claude's exit code; background: spawned cleanly)
+#   2  invalid argument (e.g., bad session-name regex)
+#   3  claude binary not found
+#   4  internal error (mkdir failed, etc.)
+
+set -uo pipefail
+
+# ─── Defaults ───────────────────────────────────────────────────────────────
+
+SESSION_NAME=""
+ENDPOINT=""
+BACKGROUND=0
+CWD=""
+PRINT_INFO=0
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || true)}"
+PLUGIN_REF="${CLAUDE_CHANNEL_PLUGIN_REF:-plugin:redis-channel@infiquetra-plugins}"
+PRODUCTION="${CLAUDE_CHANNEL_PRODUCTION:-0}"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-channel/sessions"
+
+# Session-name regex matches session_id.py:_NAME_RE.
+SESSION_NAME_RE='^[a-z0-9][a-z0-9_-]{0,63}$'
+
+# Collect pass-through args after --.
+PASSTHRU_ARGS=()
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+usage() {
+    cat <<'EOF'
+Usage: claude-channel [OPTIONS] [-- <claude args>]
+
+Launch Claude Code with a redis-channel session pre-configured.
+
+Options:
+  --session-name NAME    Session name (regex: ^[a-z0-9][a-z0-9_-]{0,63}$).
+                         Exports CLAUDE_SESSION_NAME. If omitted, the
+                         plugin auto-generates <cwd-basename>-<8hex>.
+  --endpoint NAME        Router endpoint name. Exports CLAUDE_CHANNEL_ENDPOINT.
+                         If omitted, plugin resolves to registry's
+                         default_endpoint.
+  --bg, --background     Detached launch. stdout+stderr go to log file under
+                         ~/.cache/claude-channel/sessions/. Wrapper exits
+                         after spawn.
+  --cwd PATH             cd to PATH before exec/spawn. Load-bearing for
+                         programmatic callers (auto-naming uses cwd).
+  --print-info           Emit JSON {session_name, endpoint, log_path, pid,
+                         cwd, mode} for programmatic callers. Foreground
+                         prints to stderr; background prints to stdout.
+  --help                 Show this help and exit.
+  --                     Everything after is passed verbatim to claude.
+
+Env knobs:
+  CLAUDE_BIN                Path to claude binary. Default: $(command -v claude).
+  CLAUDE_CHANNEL_PRODUCTION If "1", omit dev-only --dangerously-* flags.
+  CLAUDE_CHANNEL_PLUGIN_REF Override plugin ref for dev-channel loader.
+
+Examples:
+  # Foreground, auto-named session
+  claude-channel
+
+  # Foreground, named session
+  claude-channel --session-name auth-feature
+
+  # Background launch with named session, print JSON metadata to stdout
+  claude-channel --bg --session-name auth-feature --cwd ~/work/myrepo --print-info
+
+  # Production mode (no dev-only flags)
+  CLAUDE_CHANNEL_PRODUCTION=1 claude-channel --endpoint mimir
+EOF
+}
+
+die() {
+    printf 'claude-channel: error: %s\n' "$*" >&2
+    exit "${2:-2}"
+}
+
+warn() {
+    printf 'claude-channel: warning: %s\n' "$*" >&2
+}
+
+# Pre-flight: claude binary present?
+require_claude_bin() {
+    if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+        die "claude binary not found (set CLAUDE_BIN or put 'claude' in PATH)" 3
+    fi
+}
+
+# Source HERMES_REDIS_PASSWORD (or whatever the deployment uses) from keychain
+# on macOS — best-effort. The actual env var name is per-deployment; the
+# plugin's source-env.sh handles it. But to keep this wrapper useful even when
+# the user hasn't set up source-env.sh, we offer a macOS-keychain fallback for
+# the common case (hermes-redis-password keychain item exporting
+# HERMES_REDIS_PASSWORD).
+source_keychain_password() {
+    if [ "$(uname)" != "Darwin" ]; then
+        return 0
+    fi
+    if [ -n "${HERMES_REDIS_PASSWORD:-}" ]; then
+        return 0  # already set; respect caller
+    fi
+    if ! command -v security >/dev/null 2>&1; then
+        return 0
+    fi
+    local pwd
+    pwd=$(security find-generic-password -s "hermes-redis-password" -w 2>/dev/null || true)
+    if [ -n "$pwd" ]; then
+        export HERMES_REDIS_PASSWORD="$pwd"
+    fi
+}
+
+# ─── Argument parsing ───────────────────────────────────────────────────────
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --session-name)
+            [ $# -ge 2 ] || die "--session-name requires a value"
+            SESSION_NAME="$2"; shift 2 ;;
+        --session-name=*)
+            SESSION_NAME="${1#*=}"; shift ;;
+        --endpoint)
+            [ $# -ge 2 ] || die "--endpoint requires a value"
+            ENDPOINT="$2"; shift 2 ;;
+        --endpoint=*)
+            ENDPOINT="${1#*=}"; shift ;;
+        --bg|--background)
+            BACKGROUND=1; shift ;;
+        --cwd)
+            [ $# -ge 2 ] || die "--cwd requires a value"
+            CWD="$2"; shift 2 ;;
+        --cwd=*)
+            CWD="${1#*=}"; shift ;;
+        --print-info)
+            PRINT_INFO=1; shift ;;
+        --help|-h)
+            usage; exit 0 ;;
+        --)
+            shift
+            PASSTHRU_ARGS+=("$@")
+            break ;;
+        --*)
+            # Unknown long flag → pass through to claude
+            PASSTHRU_ARGS+=("$1"); shift ;;
+        *)
+            PASSTHRU_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# ─── Validation ─────────────────────────────────────────────────────────────
+
+if [ -n "$SESSION_NAME" ]; then
+    if ! [[ "$SESSION_NAME" =~ $SESSION_NAME_RE ]]; then
+        die "invalid session-name '$SESSION_NAME' (must match $SESSION_NAME_RE)"
+    fi
+    export CLAUDE_SESSION_NAME="$SESSION_NAME"
+fi
+
+if [ -n "$ENDPOINT" ]; then
+    export CLAUDE_CHANNEL_ENDPOINT="$ENDPOINT"
+fi
+
+if [ -n "$CWD" ]; then
+    cd "$CWD" || die "cannot cd to '$CWD'" 4
+fi
+
+require_claude_bin
+source_keychain_password
+export CLAUDE_CHANNEL_AUTO_CONNECT=1
+
+# Compose claude argv: dev flags (unless production) + plugin-ref + passthru.
+CLAUDE_ARGS=()
+if [ "$PRODUCTION" != "1" ]; then
+    CLAUDE_ARGS+=(--allow-dangerously-skip-permissions)
+    CLAUDE_ARGS+=(--dangerously-load-development-channels "$PLUGIN_REF")
+fi
+CLAUDE_ARGS+=("${PASSTHRU_ARGS[@]}")
+
+# ─── JSON emit helper ───────────────────────────────────────────────────────
+
+emit_info() {
+    # $1 = mode ("foreground"|"background"), $2 = pid, $3 = log_path (may be empty)
+    local mode="$1"
+    local pid="$2"
+    local log_path="$3"
+    # Escape JSON strings minimally — values we control don't contain quotes
+    # or backslashes given the regex on SESSION_NAME and the safe values we
+    # accept for ENDPOINT/CWD. printf with %s is fine here.
+    local json
+    json=$(printf '{"session_name":"%s","endpoint":"%s","log_path":"%s","pid":%s,"cwd":"%s","mode":"%s"}' \
+        "${SESSION_NAME}" "${ENDPOINT}" "${log_path}" "${pid}" "$(pwd)" "${mode}")
+    if [ "$mode" = "foreground" ]; then
+        # Foreground: don't pollute claude's stdout. Send to stderr.
+        printf '%s\n' "$json" >&2
+    else
+        printf '%s\n' "$json"
+    fi
+}
+
+# ─── Launch ─────────────────────────────────────────────────────────────────
+
+if [ "$BACKGROUND" -eq 1 ]; then
+    mkdir -p "$CACHE_DIR" || die "mkdir -p '$CACHE_DIR' failed" 4
+    NAME_FOR_LOG="${SESSION_NAME:-auto-$(date +%s)}"
+    LOG_PATH="${CACHE_DIR}/${NAME_FOR_LOG}-$(date +%s).log"
+
+    # POSIX-portable detach (no setsid on macOS): subshell + nohup + redirect
+    # + disown. Subshell isolates from parent process group.
+    (
+        nohup "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}" >"$LOG_PATH" 2>&1 </dev/null &
+        echo $! >"${LOG_PATH}.pid"
+        disown
+    )
+    # Read the PID we just wrote.
+    sleep 0.1
+    PID=$(cat "${LOG_PATH}.pid" 2>/dev/null || echo 0)
+    rm -f "${LOG_PATH}.pid"
+
+    if [ "$PRINT_INFO" -eq 1 ]; then
+        emit_info "background" "$PID" "$LOG_PATH"
+    else
+        printf 'claude-channel: spawned pid=%s log=%s\n' "$PID" "$LOG_PATH"
+    fi
+    exit 0
+else
+    # Foreground: replace wrapper with claude. PID stays the same.
+    if [ "$PRINT_INFO" -eq 1 ]; then
+        emit_info "foreground" "$$" ""
+    fi
+    exec "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"
+fi

--- a/plugins/redis-channel/scripts/install-claude-channel.sh
+++ b/plugins/redis-channel/scripts/install-claude-channel.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# install-claude-channel — symlink ~/bin/claude-channel → the cached plugin's wrapper.
+#
+# The plugin cache layout is versioned (per Claude Code's plugin loader), so
+# the symlink target moves between plugin updates. This installer resolves
+# the latest cached version of redis-channel and points ~/bin/claude-channel
+# at its claude-channel.sh.
+#
+# Re-run this script after each plugin update (or set up a hook).
+
+set -euo pipefail
+
+PLUGIN_CACHE_GLOB="$HOME/.claude/plugins/cache/infiquetra-plugins/redis-channel"
+BIN_DIR="$HOME/bin"
+SYMLINK="$BIN_DIR/claude-channel"
+
+# Find the latest version dir.
+if [ ! -d "$PLUGIN_CACHE_GLOB" ]; then
+    printf 'install-claude-channel: error: plugin cache not found at %s\n' \
+        "$PLUGIN_CACHE_GLOB" >&2
+    printf 'Install the redis-channel plugin via /plugin first.\n' >&2
+    exit 1
+fi
+
+# Sort versions naturally (0.4.12 > 0.4.2 etc).
+LATEST=$(find "$PLUGIN_CACHE_GLOB" -maxdepth 1 -mindepth 1 -type d \
+    | sort -V \
+    | tail -1)
+if [ -z "$LATEST" ]; then
+    printf 'install-claude-channel: error: no version dirs in %s\n' \
+        "$PLUGIN_CACHE_GLOB" >&2
+    exit 1
+fi
+
+TARGET="$LATEST/scripts/claude-channel.sh"
+if [ ! -x "$TARGET" ]; then
+    printf 'install-claude-channel: error: %s missing or not executable\n' \
+        "$TARGET" >&2
+    exit 1
+fi
+
+mkdir -p "$BIN_DIR"
+ln -sf "$TARGET" "$SYMLINK"
+
+printf '✓ %s -> %s\n' "$SYMLINK" "$TARGET"
+printf '\nVerify with:\n  claude-channel --help\n'

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.12"
+__version__ = "0.4.13"


### PR DESCRIPTION
## Summary

Third and final slice of Phase 2.5. Together with v0.4.11 (router-agnostic refactor) and v0.4.12 (env-var auto-connect), this closes the loop on "redis-channel sessions startable from outside the terminal."

**`~/bin/claude-channel` wrapper** at `plugins/redis-channel/scripts/claude-channel.sh`. Flags: `--session-name` (regex-validated pre-spawn), `--endpoint`, `--bg` (POSIX-portable detach via subshell + nohup + redirect — no `setsid` since macOS lacks it), `--cwd` (load-bearing: routers spawn in target dirs; auto-name uses cwd), `--print-info` (JSON to stderr in foreground / stdout in background), `--help`. Env knobs: `CLAUDE_BIN`, `CLAUDE_CHANNEL_PRODUCTION`, `CLAUDE_CHANNEL_PLUGIN_REF`.

Wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1` so the spawned CC session auto-registers presence without `/redis-channel-connect`. macOS-only best-effort keychain sourcing of `HERMES_REDIS_PASSWORD` for backward compat.

`install-claude-channel.sh` resolves the latest cached plugin version and symlinks `~/bin/claude-channel`. Re-run after each plugin update.

**PROTOCOL.md** gets a new "Programmatic session lifecycle" section documenting spawn/list/kill semantics for Phase 5's Mimir LLM tools and any future router. Includes PID-reuse mitigation (verify `ps -p <pid> -o comm=` before SIGTERM).

## Test plan
- [x] Manual smoke tests: `--help`, invalid session-name → exit 2, foreground prints JSON to stderr, background prints JSON to stdout + spawns detached
- [x] 165 redis-channel tests pass (no regression)
- [x] JSON valid; versions consistent (0.4.13)
- [ ] After merge: rerun `install-claude-channel.sh` to symlink the new version, then `claude-channel --help` should work from anywhere