### PR TITLE
feat(redis-channel): /redis-channel-setup + MCP startup nag (v0.4.14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,32 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — `/redis-channel-setup` self-service install + MCP startup nag (v0.4.14)
+
+Jeff flagged that v0.4.13's `install-claude-channel.sh` requires the user to remember to run a shell script after every plugin update — bad UX. Claude Code plugins don't expose a `postinstall` hook (verified by surveying the official plugins; Discord uses skills for setup, no install lifecycle hook exists), so the best fix is a self-service slash command + a passive startup check that nags when state drifts out of date.
+
+**New `redis_channel_setup` MCP tool + `/redis-channel-setup` slash command.** Idempotent — safe to re-run after every plugin update. Two actions:
+
+1. Symlink `~/bin/claude-channel` to `$CLAUDE_PLUGIN_ROOT/scripts/claude-channel.sh` (always overwrites — that's how plugin-update tracking works).
+2. Scaffold `~/.claude/channels/redis-channel/source-env.sh` and `registry.json` from the bundled examples in `docs/` IF those user files don't already exist. **Never overwrites existing user config** — re-running on a configured deployment is a no-op for config files.
+
+Returns a per-action status report (`linked` / `created_from_example` / `exists` / `skipped` / `error`) so the slash command markdown can render which actions did what.
+
+**MCP startup nag.** New `_log_setup_nag()` runs once when the MCP server boots (after `_enable_channel_capability`, before `app.run()`). Checks whether the symlink is current, source-env.sh exists, registry.json exists. If anything's missing or stale, logs a single WARNING to stderr listing the issues and suggesting `/redis-channel-setup`. Passive — never blocks startup, never modifies anything, never fails.
+
+This means: after every plugin update, the first time the user reconnects MCP, they see a stderr nag like:
+
+```
+WARNING redis-channel setup is incomplete — run /redis-channel-setup.
+Issues: ~/bin/claude-channel: stale (expected target: .../0.4.14/scripts/claude-channel.sh)
+```
+
+They run `/redis-channel-setup` once, the symlink refreshes, the nag goes away on next startup. No more remembering to run install scripts manually.
+
+Tests: 7 new for setup (fresh install, preserve user config, refresh stale symlink, broken plugin root, state reporting, nag fires when incomplete, nag silent when ready); 172 redis-channel tests total; ruff clean.
+
+`install-claude-channel.sh` stays in the repo as a manual fallback for cold-install scenarios (e.g., bootstrapping before Claude itself can talk to the plugin), but the slash command is now the canonical path.
+
 ### Added — `claude-channel` wrapper + PROTOCOL.md programmatic-launch contract (v0.4.13)
 
 Third and final slice of Phase 2.5. Together with v0.4.11 (router-agnostic refactor + registry resolver) and v0.4.12 (env-var auto-connect + status command), this closes the loop on "redis-channel sessions startable from outside the terminal."

--- a/plugins/redis-channel/commands/redis-channel-setup.md
+++ b/plugins/redis-channel/commands/redis-channel-setup.md
@@ -1,0 +1,24 @@
+---
+description: First-run setup. Symlinks ~/bin/claude-channel + scaffolds source-env.sh / registry.json from examples (won't overwrite existing config).
+argument-hint: ""
+---
+
+Run the idempotent first-run setup for `redis-channel`.
+
+**Action:** Call the `redis_channel_setup` MCP tool (no arguments).
+
+The tool returns `{ok: true, actions: [...], state: {...}}`. Render the result like this:
+
+- For each action in `actions`, show a one-line bullet:
+  - `linked` → `✓ ~/bin/claude-channel → <to>`
+  - `created_from_example` → `✓ <target> (from <example>) — <next_step>`
+  - `exists` → `· <target> (already exists; not overwritten)`
+  - `skipped` → `⚠ <target> skipped: <reason>`
+  - `error` → `✗ <target> failed: <detail>`
+- Then show a summary of `state`:
+  - If `all_ready: true`: "Setup complete. Try `claude-channel --help` in a new terminal."
+  - If `all_ready: false`: list the remaining issues from the state fields (`wrapper_symlink_status`, `source_env_exists`, `registry_exists`) and what the user should do.
+
+When the tool creates a fresh `registry.json` from the example, ALWAYS remind the user to edit it: the bundled example has placeholder Redis URL / password env name; they must fill in real values before the connect tool will work.
+
+Re-running this command after every plugin update is safe — the symlink gets refreshed to the latest cached version, and existing user config is never overwritten.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -23,11 +23,13 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import signal
 import socket
 import sys
 import threading
 import time
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -427,6 +429,195 @@ class ServerState:
 _STATE = ServerState()
 
 
+# ─── Setup / first-run scaffolding ──────────────────────────────────────────
+
+
+CHANNEL_CONFIG_DIR = Path("~/.claude/channels/redis-channel").expanduser()
+BIN_DIR = Path("~/bin").expanduser()
+WRAPPER_SYMLINK = BIN_DIR / "claude-channel"
+
+
+def _plugin_root() -> Path | None:
+    """Resolve the plugin's installed cache dir.
+
+    Claude Code sets `CLAUDE_PLUGIN_ROOT` when launching MCP servers from
+    plugin dirs. Fall back to deriving from this module's __file__ if the
+    env var isn't set (e.g., in tests).
+    """
+    env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env:
+        return Path(env)
+    # `server/channel.py` lives at <plugin_root>/server/channel.py
+    return Path(__file__).resolve().parent.parent
+
+
+def _expected_wrapper_path() -> Path | None:
+    """Where the symlink should point: <plugin_root>/scripts/claude-channel.sh."""
+    root = _plugin_root()
+    if root is None:
+        return None
+    return root / "scripts" / "claude-channel.sh"
+
+
+def _check_setup() -> dict[str, Any]:
+    """Return a structured report of which setup artifacts are present / current.
+
+    Used by both the setup tool (to decide what work to do) and the startup
+    nag (to decide whether to log a "run /redis-channel-setup" hint).
+    """
+    wrapper_target = _expected_wrapper_path()
+    symlink_status: str
+    if not WRAPPER_SYMLINK.exists() and not WRAPPER_SYMLINK.is_symlink():
+        symlink_status = "missing"
+    elif not WRAPPER_SYMLINK.is_symlink():
+        symlink_status = "exists_not_symlink"
+    else:
+        try:
+            actual = WRAPPER_SYMLINK.resolve()
+            if wrapper_target is not None and actual == wrapper_target.resolve():
+                symlink_status = "current"
+            else:
+                symlink_status = "stale"
+        except (OSError, RuntimeError):
+            symlink_status = "broken"
+
+    source_env = CHANNEL_CONFIG_DIR / "source-env.sh"
+    registry_json = CHANNEL_CONFIG_DIR / "registry.json"
+
+    return {
+        "plugin_root": str(_plugin_root()) if _plugin_root() else None,
+        "wrapper_symlink_path": str(WRAPPER_SYMLINK),
+        "wrapper_symlink_expected_target": (
+            str(wrapper_target) if wrapper_target else None
+        ),
+        "wrapper_symlink_status": symlink_status,
+        "source_env_path": str(source_env),
+        "source_env_exists": source_env.exists(),
+        "registry_path": str(registry_json),
+        "registry_exists": registry_json.exists(),
+        "all_ready": (
+            symlink_status == "current"
+            and source_env.exists()
+            and registry_json.exists()
+        ),
+    }
+
+
+def _do_setup(*, link_wrapper: bool, scaffold_configs: bool) -> dict[str, Any]:
+    """Do the install actions. Idempotent — safe to re-run.
+
+    `link_wrapper`: create/update the ~/bin/claude-channel symlink.
+    `scaffold_configs`: copy source-env.example.sh + registry.example.json
+      into the channel config dir if those files don't exist yet.
+
+    Never overwrites existing user config files. The wrapper symlink IS
+    overwritten on each call so plugin updates are picked up.
+    """
+    actions: list[dict[str, Any]] = []
+
+    if link_wrapper:
+        target = _expected_wrapper_path()
+        if target is None or not target.exists():
+            actions.append(
+                {
+                    "target": str(WRAPPER_SYMLINK),
+                    "status": "skipped",
+                    "reason": (
+                        f"plugin's claude-channel.sh not found at "
+                        f"{target} — is the plugin installed?"
+                    ),
+                }
+            )
+        else:
+            try:
+                BIN_DIR.mkdir(parents=True, exist_ok=True)
+                # Remove existing symlink/file first; ln -sf semantics in Python.
+                if WRAPPER_SYMLINK.is_symlink() or WRAPPER_SYMLINK.exists():
+                    WRAPPER_SYMLINK.unlink()
+                WRAPPER_SYMLINK.symlink_to(target)
+                actions.append(
+                    {
+                        "target": str(WRAPPER_SYMLINK),
+                        "status": "linked",
+                        "to": str(target),
+                    }
+                )
+            except OSError as e:
+                actions.append(
+                    {
+                        "target": str(WRAPPER_SYMLINK),
+                        "status": "error",
+                        "detail": str(e),
+                    }
+                )
+
+    if scaffold_configs:
+        root = _plugin_root()
+        docs = root / "docs" if root else None
+        CHANNEL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+        for filename, example_name in [
+            ("source-env.sh", "source-env.example.sh"),
+            ("registry.json", "registry.example.json"),
+        ]:
+            dest = CHANNEL_CONFIG_DIR / filename
+            example = docs / example_name if docs else None
+            if dest.exists():
+                actions.append(
+                    {
+                        "target": str(dest),
+                        "status": "exists",
+                        "note": "left as-is (will not overwrite user config)",
+                    }
+                )
+                continue
+            if example is None or not example.exists():
+                actions.append(
+                    {
+                        "target": str(dest),
+                        "status": "skipped",
+                        "reason": (
+                            f"example not found at {example} — is the plugin "
+                            f"installed?"
+                        ),
+                    }
+                )
+                continue
+            try:
+                shutil.copy2(example, dest)
+                # source-env.sh needs to be executable for safety
+                # (it's not exec'd via sh dot-source, but a future change
+                # might switch to exec; defense in depth).
+                if filename.endswith(".sh"):
+                    dest.chmod(0o755)
+                actions.append(
+                    {
+                        "target": str(dest),
+                        "status": "created_from_example",
+                        "example": str(example),
+                        "next_step": (
+                            "edit this file with your real values"
+                            if filename == "registry.json"
+                            else "edit if your env-var or keychain item name differs"
+                        ),
+                    }
+                )
+            except OSError as e:
+                actions.append(
+                    {
+                        "target": str(dest),
+                        "status": "error",
+                        "detail": str(e),
+                    }
+                )
+
+    return {
+        "ok": True,
+        "actions": actions,
+        "state": _check_setup(),
+    }
+
+
 def _format_registry_error(err: RegistryError) -> dict[str, Any]:
     if isinstance(err, RegistryNotFoundError):
         return {
@@ -586,6 +777,26 @@ def build_app() -> FastMCP:
     async def redis_channel_status(ctx: Context | None = None) -> dict[str, Any]:
         _STATE.ensure_consumer_attached(_build_async_notifier(ctx))
         return _STATE.status()
+
+    @app.tool(
+        name="redis_channel_setup",
+        description=(
+            "Idempotent first-run setup. Symlinks ~/bin/claude-channel to "
+            "this plugin's wrapper script (so the symlink follows plugin "
+            "updates) and scaffolds ~/.claude/channels/redis-channel/"
+            "source-env.sh + registry.json from the bundled examples if "
+            "they don't already exist. Never overwrites existing config — "
+            "safe to re-run after every plugin update. Returns a per-"
+            "action status report so the slash command can render which "
+            "files were linked/created/skipped and where to edit next."
+        ),
+    )
+    async def redis_channel_setup(
+        link_wrapper: bool = True, scaffold_configs: bool = True
+    ) -> dict[str, Any]:
+        return _do_setup(
+            link_wrapper=link_wrapper, scaffold_configs=scaffold_configs
+        )
 
     @app.tool(
         name="reply",
@@ -750,6 +961,35 @@ def _maybe_auto_connect() -> None:
         )
 
 
+def _log_setup_nag() -> None:
+    """One-shot startup check: if setup is incomplete, log a hint suggesting
+    the user run /redis-channel-setup. Passive — never blocks, never modifies
+    anything. Designed to surface in the user's terminal the next time they
+    reconnect MCP after a plugin update."""
+    try:
+        state = _check_setup()
+    except Exception:  # noqa: BLE001
+        return  # never let the nag break the server
+    if state.get("all_ready"):
+        return
+    issues = []
+    if state.get("wrapper_symlink_status") != "current":
+        issues.append(
+            f"~/bin/claude-channel: {state.get('wrapper_symlink_status')} "
+            f"(expected target: {state.get('wrapper_symlink_expected_target')})"
+        )
+    if not state.get("source_env_exists"):
+        issues.append(f"missing: {state.get('source_env_path')}")
+    if not state.get("registry_exists"):
+        issues.append(f"missing: {state.get('registry_path')}")
+    if issues:
+        log.warning(
+            "redis-channel setup is incomplete — run /redis-channel-setup. "
+            "Issues: %s",
+            "; ".join(issues),
+        )
+
+
 def run() -> int:
     logging.basicConfig(
         level=logging.INFO,
@@ -761,6 +1001,7 @@ def run() -> int:
     _install_signal_handlers()
     app = build_app()
     _enable_channel_capability(app)
+    _log_setup_nag()
     _maybe_auto_connect()
     app.run()  # blocks until stdio closes
     return 0

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -722,3 +722,192 @@ def test_status_after_startup_register_consumer_not_attached(
         assert s["session_name"] == out["session_name"]
     finally:
         patched_state.disconnect()
+
+
+# ─── Phase 2.5 follow-up: /redis-channel-setup ──────────────────────────────
+
+
+@pytest.fixture
+def fake_plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a fake plugin install layout in tmp_path with the scripts +
+    docs files the setup tool reads from."""
+    plugin = tmp_path / "plugin"
+    (plugin / "scripts").mkdir(parents=True)
+    (plugin / "docs").mkdir(parents=True)
+    wrapper = plugin / "scripts" / "claude-channel.sh"
+    wrapper.write_text("#!/bin/sh\necho fake\n")
+    wrapper.chmod(0o755)
+    (plugin / "docs" / "source-env.example.sh").write_text(
+        "#!/bin/sh\nexport FOO=bar\n"
+    )
+    (plugin / "docs" / "registry.example.json").write_text(
+        '{"endpoints":{}}\n'
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin))
+    return plugin
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect HOME-relative paths used by setup to a temp dir so tests
+    don't touch the user's real ~/bin or ~/.claude."""
+    home = tmp_path / "home"
+    home.mkdir()
+    bin_dir = home / "bin"
+    cfg_dir = home / ".claude" / "channels" / "redis-channel"
+    monkeypatch.setattr(channel, "BIN_DIR", bin_dir)
+    monkeypatch.setattr(channel, "WRAPPER_SYMLINK", bin_dir / "claude-channel")
+    monkeypatch.setattr(channel, "CHANNEL_CONFIG_DIR", cfg_dir)
+    return home
+
+
+def test_setup_fresh_creates_symlink_and_configs(
+    fake_plugin_root: Path, fake_home: Path
+) -> None:
+    """First-time setup: symlink absent, configs absent → both created."""
+    result = channel._do_setup(link_wrapper=True, scaffold_configs=True)
+    assert result["ok"] is True
+
+    symlink = fake_home / "bin" / "claude-channel"
+    assert symlink.is_symlink()
+    assert symlink.resolve() == (fake_plugin_root / "scripts" / "claude-channel.sh").resolve()
+
+    cfg = fake_home / ".claude" / "channels" / "redis-channel"
+    assert (cfg / "source-env.sh").exists()
+    assert (cfg / "registry.json").exists()
+
+    # State should now report all_ready
+    assert result["state"]["all_ready"] is True
+
+    statuses = [a["status"] for a in result["actions"]]
+    assert "linked" in statuses
+    assert statuses.count("created_from_example") == 2
+
+
+def test_setup_preserves_existing_user_config(
+    fake_plugin_root: Path, fake_home: Path
+) -> None:
+    """Re-running setup must NOT overwrite an existing source-env.sh / registry."""
+    cfg = fake_home / ".claude" / "channels" / "redis-channel"
+    cfg.mkdir(parents=True)
+    user_source = cfg / "source-env.sh"
+    user_source.write_text("#!/bin/sh\n# user-customized\nexport MY_PWD=secret\n")
+    user_registry = cfg / "registry.json"
+    user_registry.write_text('{"endpoints":{"my":{"redis_url":"redis://r"}}}\n')
+    user_source_content = user_source.read_text()
+    user_registry_content = user_registry.read_text()
+
+    result = channel._do_setup(link_wrapper=True, scaffold_configs=True)
+
+    # User content untouched
+    assert user_source.read_text() == user_source_content
+    assert user_registry.read_text() == user_registry_content
+
+    # Reported as exists (not overwritten)
+    config_actions = [
+        a for a in result["actions"] if "source-env" in a.get("target", "")
+        or "registry" in a.get("target", "")
+    ]
+    for a in config_actions:
+        assert a["status"] == "exists"
+
+
+def test_setup_refreshes_stale_symlink(
+    fake_plugin_root: Path, fake_home: Path, tmp_path: Path
+) -> None:
+    """If ~/bin/claude-channel points at an old cached version, setup
+    overwrites it to point at the current plugin root."""
+    symlink = fake_home / "bin" / "claude-channel"
+    symlink.parent.mkdir(parents=True)
+    stale_target = tmp_path / "old-cache" / "claude-channel.sh"
+    stale_target.parent.mkdir(parents=True)
+    stale_target.write_text("#!/bin/sh\necho stale\n")
+    stale_target.chmod(0o755)
+    symlink.symlink_to(stale_target)
+    assert symlink.resolve() == stale_target.resolve()
+
+    channel._do_setup(link_wrapper=True, scaffold_configs=False)
+
+    # Symlink now points at the current plugin's wrapper
+    assert symlink.is_symlink()
+    assert symlink.resolve() == (fake_plugin_root / "scripts" / "claude-channel.sh").resolve()
+
+
+def test_check_setup_reports_all_ready_only_when_complete(
+    fake_plugin_root: Path, fake_home: Path
+) -> None:
+    """Sanity-check the state report drives the startup nag correctly."""
+    # Nothing set up yet
+    state = channel._check_setup()
+    assert state["all_ready"] is False
+    assert state["wrapper_symlink_status"] == "missing"
+
+    # After full setup
+    channel._do_setup(link_wrapper=True, scaffold_configs=True)
+    state = channel._check_setup()
+    assert state["all_ready"] is True
+    assert state["wrapper_symlink_status"] == "current"
+    assert state["source_env_exists"] is True
+    assert state["registry_exists"] is True
+
+
+def test_setup_skips_link_when_wrapper_not_in_plugin_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defensive: if CLAUDE_PLUGIN_ROOT points somewhere with no
+    scripts/claude-channel.sh, the link action is skipped with a clear reason
+    (don't link to a broken target)."""
+    bogus_root = tmp_path / "bogus"
+    bogus_root.mkdir()
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(bogus_root))
+    bin_dir = tmp_path / "bin"
+    monkeypatch.setattr(channel, "BIN_DIR", bin_dir)
+    monkeypatch.setattr(channel, "WRAPPER_SYMLINK", bin_dir / "claude-channel")
+
+    result = channel._do_setup(link_wrapper=True, scaffold_configs=False)
+    link_actions = [
+        a for a in result["actions"] if "claude-channel" in a.get("target", "")
+    ]
+    assert len(link_actions) == 1
+    assert link_actions[0]["status"] == "skipped"
+    assert (bin_dir / "claude-channel").is_symlink() is False
+
+
+def test_setup_nag_logs_when_state_incomplete(
+    fake_home: Path,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_log_setup_nag emits a WARNING when setup is incomplete."""
+    # No plugin root, no symlink, no configs
+    monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    monkeypatch.setattr(
+        channel, "_check_setup", lambda: {
+            "all_ready": False,
+            "wrapper_symlink_status": "missing",
+            "wrapper_symlink_expected_target": "/x",
+            "source_env_path": "/y",
+            "source_env_exists": False,
+            "registry_path": "/z",
+            "registry_exists": False,
+        }
+    )
+    with caplog.at_level("WARNING", logger="redis_channel.channel"):
+        channel._log_setup_nag()
+    assert any(
+        "/redis-channel-setup" in r.message for r in caplog.records
+    )
+
+
+def test_setup_nag_silent_when_state_ready(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """_log_setup_nag stays quiet when everything is in order."""
+    monkeypatch.setattr(
+        channel, "_check_setup", lambda: {"all_ready": True}
+    )
+    with caplog.at_level("WARNING", logger="redis_channel.channel"):
+        channel._log_setup_nag()
+    assert not any(
+        "/redis-channel-setup" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary

Self-service first-run install. Replaces the "remember to run install-claude-channel.sh after every plugin update" UX with a slash command + passive startup nag.

**Why not a postinstall hook?** Surveyed the official plugins — none use one, and there's no documented `postinstall` field in plugin.json. Discord uses skills/slash commands for setup; we follow the same pattern.

**New `/redis-channel-setup` + `redis_channel_setup` MCP tool.** Idempotent. Two actions:

1. Symlink `~/bin/claude-channel` to `$CLAUDE_PLUGIN_ROOT/scripts/claude-channel.sh` (always overwrites — tracks plugin updates).
2. Scaffold `~/.claude/channels/redis-channel/source-env.sh` and `registry.json` from bundled examples — only if those user files don't already exist. **Never overwrites user config.**

Returns per-action status (`linked` / `created_from_example` / `exists` / `skipped` / `error`).

**MCP startup nag.** `_log_setup_nag()` runs once at server boot. If setup state is incomplete (stale symlink, missing source-env.sh, missing registry.json), logs a single WARNING to stderr suggesting `/redis-channel-setup`. Passive — never blocks, never modifies anything. User sees it on next MCP reconnect after a plugin update, runs the command once, nag stops.

## Test plan
- [x] 7 new tests for setup paths + nag behavior; 172 redis-channel tests total
- [x] ruff clean
- [x] JSON valid; versions consistent (0.4.14)
- [ ] After merge + reinstall: stderr nag fires (symlink will be stale → 0.4.13 → 0.4.14); user runs `/redis-channel-setup`; symlink refreshes; no more nag