### PR TITLE
fix(redis-channel): claude-channel --bg uses tmux for PTY (v0.4.15)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,25 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed — `claude-channel --bg` spawns via tmux to give claude a real PTY (v0.4.15)
+
+Jeff tested v0.4.14's wrapper, got an immediate crash with the log showing:
+```
+Error: Input must be provided either through stdin or as a prompt argument when using --print
+```
+
+Root cause: `claude --help` documents that "non-interactive mode (via -p, or **when stdout is not a TTY**, e.g. piped or redirected output)" auto-engages. The v0.4.13 `--bg` path used `nohup ... > log 2>&1 &`, which redirects stdout to a file → claude detects no-TTY → enters `--print` mode → no prompt arg present → exits immediately.
+
+Fix: spawn claude inside a detached **tmux** session, which provides a real PTY headlessly. Tested empirically: `tmux new-session -d` works from non-TTY contexts (verified from a stdio-only shell), the spawned process gets a working PTY, and the pane's output mirrors to the log file via `tmux pipe-pane -o`.
+
+Bonus: `tmux attach -t <session-name>` lets the user inspect a backgrounded session interactively. The tmux session name = the redis-channel session name (natural mapping).
+
+Trade-off: requires tmux installed. Wrapper now hard-fails with a clear error if tmux is missing: `background mode requires tmux (install via 'brew install tmux' on macOS or your package manager on Linux)`. macOS users with Homebrew, most Linux distros, and Jeff's setup all have tmux already; for environments that don't, foreground mode still works without it. Linux fallback to `script(1)` or Python `pty` was considered and rejected — `script` errors with `tcgetattr/ioctl: Operation not supported on socket` when called from a non-TTY context (e.g., Phase 5's Mimir-spawn from Hermes), and Python `pty` adds an interpreter dependency that tmux doesn't need.
+
+Output format unchanged. `--print-info` JSON still reports `pid` (now the tmux pane's claude PID) and `log_path` (now mirrored from tmux pipe-pane). New stderr line on spawn when not using `--print-info`: `attach with: tmux attach -t <session-name>`.
+
+Manual smoke-tested with `CLAUDE_BIN=/bin/sleep CLAUDE_CHANNEL_PRODUCTION=1` to confirm tmux session is created, pane_pid is captured correctly, log file mirroring is set up. Existing tests still pass; no unit tests added for the wrapper here (it's bash; subprocess.run tests deferred to a follow-up).
+
 ### Added — `/redis-channel-setup` self-service install + MCP startup nag (v0.4.14)
 
 Jeff flagged that v0.4.13's `install-claude-channel.sh` requires the user to remember to run a shell script after every plugin update — bad UX. Claude Code plugins don't expose a `postinstall` hook (verified by surveying the official plugins; Discord uses skills for setup, no install lifecycle hook exists), so the best fix is a self-service slash command + a passive startup check that nags when state drifts out of date.

--- a/plugins/redis-channel/scripts/claude-channel.sh
+++ b/plugins/redis-channel/scripts/claude-channel.sh
@@ -61,9 +61,11 @@ Options:
   --endpoint NAME        Router endpoint name. Exports CLAUDE_CHANNEL_ENDPOINT.
                          If omitted, plugin resolves to registry's
                          default_endpoint.
-  --bg, --background     Detached launch. stdout+stderr go to log file under
-                         ~/.cache/claude-channel/sessions/. Wrapper exits
-                         after spawn.
+  --bg, --background     Detached launch via tmux (claude needs a real PTY;
+                         plain nohup doesn't work). Log mirrors at
+                         ~/.cache/claude-channel/sessions/<name>-<epoch>.log.
+                         Attach later with: tmux attach -t <name>.
+                         Requires tmux installed.
   --cwd PATH             cd to PATH before exec/spawn. Load-bearing for
                          programmatic callers (auto-naming uses cwd).
   --print-info           Emit JSON {session_name, endpoint, log_path, pid,
@@ -225,22 +227,55 @@ if [ "$BACKGROUND" -eq 1 ]; then
     NAME_FOR_LOG="${SESSION_NAME:-auto-$(date +%s)}"
     LOG_PATH="${CACHE_DIR}/${NAME_FOR_LOG}-$(date +%s).log"
 
-    # POSIX-portable detach (no setsid on macOS): subshell + nohup + redirect
-    # + disown. Subshell isolates from parent process group.
-    (
-        nohup "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}" >"$LOG_PATH" 2>&1 </dev/null &
-        echo $! >"${LOG_PATH}.pid"
-        disown
-    )
-    # Read the PID we just wrote.
-    sleep 0.1
-    PID=$(cat "${LOG_PATH}.pid" 2>/dev/null || echo 0)
-    rm -f "${LOG_PATH}.pid"
+    # Claude requires a TTY on stdout — without one it auto-falls into --print
+    # mode and expects a prompt argument, then exits immediately. Plain
+    # `nohup ... > log 2>&1 &` reproduces this failure ("Input must be
+    # provided either through stdin or as a prompt argument when using
+    # --print"). Solution: spawn claude inside a detached tmux session
+    # which provides a real PTY. Bonuses: the user can `tmux attach -t
+    # <name>` later to inspect the live session, and the tmux session name
+    # naturally maps to the redis-channel session name. Trade-off: requires
+    # tmux installed.
+    if ! command -v tmux >/dev/null 2>&1; then
+        die "background mode requires tmux (install via 'brew install tmux' on macOS or your package manager on Linux)" 4
+    fi
+
+    # tmux session name must be unique among live tmux sessions; suffix with
+    # epoch to allow re-spawn after a previous session ends (or use a stable
+    # name if the caller supplied --session-name and there's no collision).
+    TMUX_SESSION="$NAME_FOR_LOG"
+    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+        TMUX_SESSION="${TMUX_SESSION}-$(date +%s)"
+    fi
+
+    # Build a single-string command for tmux to run. Quote each arg so spaces
+    # / special chars survive the shell that tmux invokes.
+    quoted=""
+    for arg in "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"; do
+        printf -v escaped '%q' "$arg"
+        quoted+="$escaped "
+    done
+
+    # Start the detached tmux session.
+    if ! tmux new-session -d -s "$TMUX_SESSION" "$quoted" 2>>"$LOG_PATH"; then
+        die "tmux new-session failed (see $LOG_PATH)" 4
+    fi
+
+    # Mirror the pane's output to the log file so the user can `tail -f` it
+    # without needing to attach. `-o` only opens; pane output is duplicated
+    # to the pipe target. `cat` keeps the log file open for appending.
+    tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_PATH'" 2>/dev/null || true
+
+    # Capture the pane's process PID (claude's PID, as a child of tmux's shell).
+    PID=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)
+    PID=${PID:-0}
 
     if [ "$PRINT_INFO" -eq 1 ]; then
         emit_info "background" "$PID" "$LOG_PATH"
     else
-        printf 'claude-channel: spawned pid=%s log=%s\n' "$PID" "$LOG_PATH"
+        printf 'claude-channel: spawned tmux session=%s pid=%s log=%s\n' \
+            "$TMUX_SESSION" "$PID" "$LOG_PATH"
+        printf '  attach with: tmux attach -t %s\n' "$TMUX_SESSION"
     fi
     exit 0
 else

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.14"
+__version__ = "0.4.15"


### PR DESCRIPTION
## Summary

Jeff tested v0.4.14's wrapper, hit an immediate crash. Log file showed:
```
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

`claude --help` confirms: *"non-interactive mode (via -p, or when stdout is not a TTY)"* auto-engages. Plain `nohup ... > log 2>&1 &` redirects stdout to a file → claude detects no-TTY → enters `--print` mode → no prompt arg → exits.

**Fix:** Spawn claude inside a detached `tmux` session, which provides a real PTY headlessly. Works:
- `tmux pipe-pane -o` mirrors the pane's output to the log file (so `tail -f` still works without attaching)
- `tmux list-panes -F '#{pane_pid}'` captures the claude PID for `--print-info` JSON
- **Bonus**: `tmux attach -t <session-name>` lets the user inspect the backgrounded session live
- tmux session name = redis-channel session name (natural mapping); collision suffixed with epoch

**Trade-off:** Requires `tmux` installed. Wrapper hard-fails with clear error + brew-install hint if missing.

**Alternatives considered + rejected:**
- `script(1)` — errors with `tcgetattr/ioctl: Operation not supported on socket` when called from non-TTY (Phase 5's Mimir-spawn from Hermes). Useless for the load-bearing programmatic-launch path.
- Python `pty` — works but adds Python interpreter cost where tmux is already battle-tested.

## Test plan
- [x] 172 redis-channel tests pass; ruff clean
- [x] Manual smoke: `CLAUDE_BIN=/bin/sleep CLAUDE_CHANNEL_PRODUCTION=1 claude-channel --bg --session-name x --print-info -- 60` → JSON with non-zero pid, tmux session alive, log file created, `tmux kill-session -t x` cleans up
- [ ] After merge + `/redis-channel-setup`: try `claude-channel --bg --session-name foo`; verify tmux session alive; `tmux attach -t foo` shows running claude; XADD inbound from another shell verifies round-trip