### PR TITLE
refactor(redis-channel): wrapper is now a thin pass-through; --bg goes to claude (v0.4.16)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,36 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed — `claude-channel` is now a thin pass-through; `--bg` goes straight to claude (v0.4.16)
+
+Jeff caught that v0.4.15's tmux-based `--bg` was solving the wrong problem. **`claude --bg` is a real (if undocumented-in-help) claude flag** that spawns a native background agent, prints the agent ID + attach/logs/stop hints, and returns. Verified:
+
+```
+$ claude --bg --help
+backgrounded · 1d80a5ac (idle — send a prompt to start)
+  claude agents             list sessions
+  claude attach 1d80a5ac    open in this terminal
+  claude logs 1d80a5ac      show recent output
+  claude stop 1d80a5ac      stop this session
+```
+
+Claude Code already handles background agents natively — process management, PTY allocation, logging, attach, stop — all built in. The wrapper trying to reimplement this with tmux was redundant + buggy (the v0.4.13 nohup version crashed because no PTY; the v0.4.15 tmux version worked but added a tmux dependency for no reason since claude handles it natively).
+
+**Fix.** Strip the wrapper down to a thin pure-pass-through:
+
+- `--bg` (and everything else claude understands: `--print`, `--resume`, `--model`, `--remote-control`, `--worktree`, etc.) is now an UNCLAIMED flag → falls through to claude's argv verbatim.
+- Wrapper's only owned flags: `--session-name`, `--endpoint`, `--cwd`, `--help`.
+- Removed: `--bg` / `--background` arg-parsing case, `BACKGROUND` variable, the entire if-bg-then-spawn-detached block, tmux logic, `--print-info` (claude's `agents --json` and the redis-channel presence registry are the canonical discovery mechanisms — wrapper doesn't need to invent a JSON emit).
+- The pass-through is greedy: any arg the wrapper doesn't claim goes to claude. Standard claude flags Just Work.
+
+**Tmux dependency dropped.** v0.4.15's hard requirement on tmux for `--bg` is gone — `claude --bg` doesn't need tmux. (The user's `~/bin/claude-codex` confirmed the pattern: passes `--bg` straight to claude in its argv array.)
+
+For Phase 5 (Mimir programmatic spawn): callers do `claude-channel --session-name foo --bg`. Claude returns the agent ID; caller polls `cc-sessions:hb:foo` for readiness (the canonical signal — works regardless of how claude was launched); kills via `claude stop <agent-id>` or by SIGTERM from `cc-sessions:registry`'s PID.
+
+`--print-info` removed since callers either pass `--session-name` (and already know it) or query `claude agents --json` / `cc-sessions:registry` to discover. Net: simpler wrapper, no wrapper-specific output format to learn.
+
+`install-claude-channel.sh` unchanged (still works as the manual install fallback). The `/redis-channel-setup` slash command shipped in v0.4.14 is still the canonical setup path.
+
 ### Fixed — `claude-channel --bg` spawns via tmux to give claude a real PTY (v0.4.15)
 
 Jeff tested v0.4.14's wrapper, got an immediate crash with the log showing:

--- a/plugins/redis-channel/PROTOCOL.md
+++ b/plugins/redis-channel/PROTOCOL.md
@@ -252,15 +252,16 @@ This section documents how an external router (or any tool, e.g. a CLI test harn
 ### Spawn a new session
 
 ```
-claude-channel --bg --session-name <NAME> --cwd <ABS_PATH> --print-info -- <claude args...>
+claude-channel --session-name <NAME> --cwd <ABS_PATH> --bg
 ```
 
-- `--session-name <NAME>` — required for programmatic use. Validated against `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- `--session-name <NAME>` — required for programmatic use. Validated against `^[a-z0-9][a-z0-9_-]{0,63}$`. Wrapper exports it as `CLAUDE_SESSION_NAME` for the plugin.
 - `--cwd <ABS_PATH>` — sets the spawned session's working dir. Load-bearing: the auto-name and registry-recorded `cwd` field both derive from this.
-- `--bg` — detached launch. Wrapper exits immediately after spawn.
-- `--print-info` — wrapper emits one JSON line on stdout (background mode) with `{session_name, endpoint, log_path, pid, cwd, mode}`.
+- `--bg` — claude's native background-agent flag. Passes through the wrapper to claude. Claude prints the agent ID + attach/logs/stop hints to stdout, then returns. The agent runs detached with a native PTY managed by claude.
 
-The wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1`, so the spawned CC session auto-registers presence + creates the consumer group at startup. After parsing the JSON, the caller MUST poll `EXISTS cc-sessions:hb:<NAME>` with backoff (100ms) up to a 15s timeout before XADD'ing inbound. Once `hb` exists, the session is live; XADD-ed inbound will not be lost (the consumer group was created BEFORE presence published — XREADGROUP `>` picks up anything in the gap once the consumer thread starts on first MCP tool dispatch).
+The wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1`, so the spawned CC session auto-registers presence + creates the inbound consumer group at startup. The caller MUST poll `EXISTS cc-sessions:hb:<NAME>` with backoff (100ms) up to a 15s timeout before XADD'ing inbound. Once `hb` exists, the session is live; XADD-ed inbound will not be lost (the consumer group was created BEFORE presence published — XREADGROUP `>` picks up anything in the gap once the consumer thread starts on first MCP tool dispatch).
+
+Discovering the spawned agent's claude-side ID (if needed): `claude agents --json` returns all live background sessions including the new one. For redis-channel purposes, `cc-sessions:registry`'s entry for `<NAME>` is the canonical source — it carries `pid`, `host`, `cwd`, `git_branch`, `started_at` — and is the only handle the protocol promises.
 
 ### Verify session readiness
 
@@ -275,6 +276,18 @@ HGETALL cc-sessions:registry
 For each `<NAME> -> <JSON>` pair, filter by `EXISTS cc-sessions:hb:<NAME>` to drop stale entries. See §Presence for full details.
 
 ### Tear down a session
+
+Two equivalent paths:
+
+**Via claude-native stop** (when claude knows the agent ID — i.e., the spawn captured it from claude's stdout):
+
+```
+claude stop <agent-id>
+```
+
+This is the cleanest path: claude's process manager handles the SIGTERM + cleanup, and the redis-channel plugin's signal handlers fire to disconnect cleanly.
+
+**Via redis-channel presence registry** (when only the redis-channel session name is known):
 
 ```
 HGET cc-sessions:registry <NAME>  →  parse JSON  →  read `pid` and `host`

--- a/plugins/redis-channel/scripts/claude-channel.sh
+++ b/plugins/redis-channel/scripts/claude-channel.sh
@@ -1,29 +1,34 @@
 #!/usr/bin/env bash
-# claude-channel — launch Claude Code with a redis-channel session configured.
+# claude-channel — launch claude with a redis-channel session pre-configured.
 #
-# Provides:
-#   - --session-name <name>  → exports CLAUDE_SESSION_NAME (validated)
-#   - --endpoint <name>      → exports CLAUDE_CHANNEL_ENDPOINT
-#   - --bg / --background    → detached launch with log file
-#   - --cwd <path>           → cd before exec (load-bearing for Phase 5)
-#   - --print-info           → emit JSON metadata for programmatic callers
-#   - --help                 → usage
+# Thin wrapper around `claude`. Sets env vars + dev flags the plugin needs,
+# then exec's claude. All standard claude flags (--bg, --print, --resume,
+# --model, --remote-control, --worktree, etc.) pass straight through.
+#
+# Wrapper-owned flags:
+#   --session-name NAME   exports CLAUDE_SESSION_NAME (regex-validated)
+#   --endpoint NAME       exports CLAUDE_CHANNEL_ENDPOINT
+#   --cwd PATH            cd before exec (load-bearing for auto-naming
+#                         and Phase 5 programmatic spawn)
+#   --help                show this help and exit
 #
 # Env knobs:
-#   CLAUDE_BIN                Override claude binary path. Default: `command -v claude`.
-#   CLAUDE_CHANNEL_PRODUCTION If "1", omit dev-only --dangerously-* flags.
-#   CLAUDE_CHANNEL_PLUGIN_REF Override plugin ref for --dangerously-load-development-channels.
-#                             Default: plugin:redis-channel@infiquetra-plugins.
+#   CLAUDE_BIN                  override claude binary path
+#   CLAUDE_CHANNEL_PRODUCTION   if "1", omit --dangerously-* dev flags
+#   CLAUDE_CHANNEL_PLUGIN_REF   override plugin ref for the dev-channel loader
 #
-# Designed for both human terminal use AND programmatic invocation by routers
-# (e.g., Phase 5's hermes-claude-code-router LLM tool that spawns CC sessions
-# on demand).
+# Backgrounding is claude's job: pass `--bg` to claude-channel and it goes
+# straight to claude, which spawns a background agent and prints the agent
+# ID + attach/logs/stop commands. Use `claude agents` to list and
+# `claude attach <id>` to attach. The redis-channel session presence
+# registry (cc-sessions:registry + hb keys) is the canonical discovery
+# mechanism for external consumers (Phase 5+).
 #
 # Exit codes:
-#   0  success (foreground: claude's exit code; background: spawned cleanly)
-#   2  invalid argument (e.g., bad session-name regex)
+#   0  success (claude's exit code in foreground; claude --bg returns 0)
+#   2  invalid wrapper argument (e.g., bad --session-name regex)
 #   3  claude binary not found
-#   4  internal error (mkdir failed, etc.)
+#   4  internal error (cd failed, etc.)
 
 set -uo pipefail
 
@@ -31,66 +36,59 @@ set -uo pipefail
 
 SESSION_NAME=""
 ENDPOINT=""
-BACKGROUND=0
 CWD=""
-PRINT_INFO=0
 CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude 2>/dev/null || true)}"
 PLUGIN_REF="${CLAUDE_CHANNEL_PLUGIN_REF:-plugin:redis-channel@infiquetra-plugins}"
 PRODUCTION="${CLAUDE_CHANNEL_PRODUCTION:-0}"
 
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-channel/sessions"
-
 # Session-name regex matches session_id.py:_NAME_RE.
 SESSION_NAME_RE='^[a-z0-9][a-z0-9_-]{0,63}$'
 
-# Collect pass-through args after --.
+# Everything we don't claim passes through to claude.
 PASSTHRU_ARGS=()
 
 # ─── Helpers ────────────────────────────────────────────────────────────────
 
 usage() {
     cat <<'EOF'
-Usage: claude-channel [OPTIONS] [-- <claude args>]
+Usage: claude-channel [WRAPPER OPTS] [CLAUDE OPTS] [-- <claude args>]
 
-Launch Claude Code with a redis-channel session pre-configured.
+Launch claude with a redis-channel session pre-configured. Sets the env
+vars and dev flags the plugin needs, then exec's claude. Standard claude
+flags (--bg, --print, --resume, --model, --remote-control, etc.) pass
+straight through.
 
-Options:
+Wrapper options:
   --session-name NAME    Session name (regex: ^[a-z0-9][a-z0-9_-]{0,63}$).
                          Exports CLAUDE_SESSION_NAME. If omitted, the
                          plugin auto-generates <cwd-basename>-<8hex>.
   --endpoint NAME        Router endpoint name. Exports CLAUDE_CHANNEL_ENDPOINT.
                          If omitted, plugin resolves to registry's
                          default_endpoint.
-  --bg, --background     Detached launch via tmux (claude needs a real PTY;
-                         plain nohup doesn't work). Log mirrors at
-                         ~/.cache/claude-channel/sessions/<name>-<epoch>.log.
-                         Attach later with: tmux attach -t <name>.
-                         Requires tmux installed.
-  --cwd PATH             cd to PATH before exec/spawn. Load-bearing for
-                         programmatic callers (auto-naming uses cwd).
-  --print-info           Emit JSON {session_name, endpoint, log_path, pid,
-                         cwd, mode} for programmatic callers. Foreground
-                         prints to stderr; background prints to stdout.
+  --cwd PATH             cd to PATH before exec. Load-bearing for
+                         auto-naming and programmatic callers spawning
+                         in a target dir.
   --help                 Show this help and exit.
-  --                     Everything after is passed verbatim to claude.
+  --                     Everything after passes verbatim to claude.
 
 Env knobs:
   CLAUDE_BIN                Path to claude binary. Default: $(command -v claude).
   CLAUDE_CHANNEL_PRODUCTION If "1", omit dev-only --dangerously-* flags.
   CLAUDE_CHANNEL_PLUGIN_REF Override plugin ref for dev-channel loader.
 
-Examples:
-  # Foreground, auto-named session
-  claude-channel
+Backgrounding: use claude's native --bg flag (just pass it as a claude
+option). claude prints the background agent ID + attach/logs/stop
+commands. `claude agents` lists running sessions.
 
+Examples:
   # Foreground, named session
   claude-channel --session-name auth-feature
 
-  # Background launch with named session, print JSON metadata to stdout
-  claude-channel --bg --session-name auth-feature --cwd ~/work/myrepo --print-info
+  # Background, named, in a specific dir
+  claude-channel --session-name auth-feature --cwd ~/work/myrepo --bg
 
-  # Production mode (no dev-only flags)
-  CLAUDE_CHANNEL_PRODUCTION=1 claude-channel --endpoint mimir
+  # Production mode (no dev-only flags), one-shot prompt
+  CLAUDE_CHANNEL_PRODUCTION=1 claude-channel --print "what's the status?"
 EOF
 }
 
@@ -99,29 +97,22 @@ die() {
     exit "${2:-2}"
 }
 
-warn() {
-    printf 'claude-channel: warning: %s\n' "$*" >&2
-}
-
-# Pre-flight: claude binary present?
 require_claude_bin() {
     if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
         die "claude binary not found (set CLAUDE_BIN or put 'claude' in PATH)" 3
     fi
 }
 
-# Source HERMES_REDIS_PASSWORD (or whatever the deployment uses) from keychain
-# on macOS — best-effort. The actual env var name is per-deployment; the
-# plugin's source-env.sh handles it. But to keep this wrapper useful even when
-# the user hasn't set up source-env.sh, we offer a macOS-keychain fallback for
-# the common case (hermes-redis-password keychain item exporting
-# HERMES_REDIS_PASSWORD).
+# Source HERMES_REDIS_PASSWORD from macOS keychain if not already set.
+# Best-effort; the plugin's source-env.sh (sourced by .mcp.json) is the
+# primary mechanism, but this fallback covers wrapper-initiated launches
+# where the MCP server hasn't started yet.
 source_keychain_password() {
     if [ "$(uname)" != "Darwin" ]; then
         return 0
     fi
     if [ -n "${HERMES_REDIS_PASSWORD:-}" ]; then
-        return 0  # already set; respect caller
+        return 0
     fi
     if ! command -v security >/dev/null 2>&1; then
         return 0
@@ -147,30 +138,24 @@ while [ $# -gt 0 ]; do
             ENDPOINT="$2"; shift 2 ;;
         --endpoint=*)
             ENDPOINT="${1#*=}"; shift ;;
-        --bg|--background)
-            BACKGROUND=1; shift ;;
         --cwd)
             [ $# -ge 2 ] || die "--cwd requires a value"
             CWD="$2"; shift 2 ;;
         --cwd=*)
             CWD="${1#*=}"; shift ;;
-        --print-info)
-            PRINT_INFO=1; shift ;;
         --help|-h)
             usage; exit 0 ;;
         --)
             shift
             PASSTHRU_ARGS+=("$@")
             break ;;
-        --*)
-            # Unknown long flag → pass through to claude
-            PASSTHRU_ARGS+=("$1"); shift ;;
         *)
+            # Pass through everything we don't claim (flags AND positional).
             PASSTHRU_ARGS+=("$1"); shift ;;
     esac
 done
 
-# ─── Validation ─────────────────────────────────────────────────────────────
+# ─── Validation + env setup ─────────────────────────────────────────────────
 
 if [ -n "$SESSION_NAME" ]; then
     if ! [[ "$SESSION_NAME" =~ $SESSION_NAME_RE ]]; then
@@ -199,89 +184,4 @@ if [ "$PRODUCTION" != "1" ]; then
 fi
 CLAUDE_ARGS+=("${PASSTHRU_ARGS[@]}")
 
-# ─── JSON emit helper ───────────────────────────────────────────────────────
-
-emit_info() {
-    # $1 = mode ("foreground"|"background"), $2 = pid, $3 = log_path (may be empty)
-    local mode="$1"
-    local pid="$2"
-    local log_path="$3"
-    # Escape JSON strings minimally — values we control don't contain quotes
-    # or backslashes given the regex on SESSION_NAME and the safe values we
-    # accept for ENDPOINT/CWD. printf with %s is fine here.
-    local json
-    json=$(printf '{"session_name":"%s","endpoint":"%s","log_path":"%s","pid":%s,"cwd":"%s","mode":"%s"}' \
-        "${SESSION_NAME}" "${ENDPOINT}" "${log_path}" "${pid}" "$(pwd)" "${mode}")
-    if [ "$mode" = "foreground" ]; then
-        # Foreground: don't pollute claude's stdout. Send to stderr.
-        printf '%s\n' "$json" >&2
-    else
-        printf '%s\n' "$json"
-    fi
-}
-
-# ─── Launch ─────────────────────────────────────────────────────────────────
-
-if [ "$BACKGROUND" -eq 1 ]; then
-    mkdir -p "$CACHE_DIR" || die "mkdir -p '$CACHE_DIR' failed" 4
-    NAME_FOR_LOG="${SESSION_NAME:-auto-$(date +%s)}"
-    LOG_PATH="${CACHE_DIR}/${NAME_FOR_LOG}-$(date +%s).log"
-
-    # Claude requires a TTY on stdout — without one it auto-falls into --print
-    # mode and expects a prompt argument, then exits immediately. Plain
-    # `nohup ... > log 2>&1 &` reproduces this failure ("Input must be
-    # provided either through stdin or as a prompt argument when using
-    # --print"). Solution: spawn claude inside a detached tmux session
-    # which provides a real PTY. Bonuses: the user can `tmux attach -t
-    # <name>` later to inspect the live session, and the tmux session name
-    # naturally maps to the redis-channel session name. Trade-off: requires
-    # tmux installed.
-    if ! command -v tmux >/dev/null 2>&1; then
-        die "background mode requires tmux (install via 'brew install tmux' on macOS or your package manager on Linux)" 4
-    fi
-
-    # tmux session name must be unique among live tmux sessions; suffix with
-    # epoch to allow re-spawn after a previous session ends (or use a stable
-    # name if the caller supplied --session-name and there's no collision).
-    TMUX_SESSION="$NAME_FOR_LOG"
-    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-        TMUX_SESSION="${TMUX_SESSION}-$(date +%s)"
-    fi
-
-    # Build a single-string command for tmux to run. Quote each arg so spaces
-    # / special chars survive the shell that tmux invokes.
-    quoted=""
-    for arg in "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"; do
-        printf -v escaped '%q' "$arg"
-        quoted+="$escaped "
-    done
-
-    # Start the detached tmux session.
-    if ! tmux new-session -d -s "$TMUX_SESSION" "$quoted" 2>>"$LOG_PATH"; then
-        die "tmux new-session failed (see $LOG_PATH)" 4
-    fi
-
-    # Mirror the pane's output to the log file so the user can `tail -f` it
-    # without needing to attach. `-o` only opens; pane output is duplicated
-    # to the pipe target. `cat` keeps the log file open for appending.
-    tmux pipe-pane -t "$TMUX_SESSION" -o "cat >> '$LOG_PATH'" 2>/dev/null || true
-
-    # Capture the pane's process PID (claude's PID, as a child of tmux's shell).
-    PID=$(tmux list-panes -t "$TMUX_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)
-    PID=${PID:-0}
-
-    if [ "$PRINT_INFO" -eq 1 ]; then
-        emit_info "background" "$PID" "$LOG_PATH"
-    else
-        printf 'claude-channel: spawned tmux session=%s pid=%s log=%s\n' \
-            "$TMUX_SESSION" "$PID" "$LOG_PATH"
-        printf '  attach with: tmux attach -t %s\n' "$TMUX_SESSION"
-    fi
-    exit 0
-else
-    # Foreground: replace wrapper with claude. PID stays the same.
-    if [ "$PRINT_INFO" -eq 1 ]; then
-        emit_info "foreground" "$$" ""
-    fi
-    exec "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"
-fi
+exec "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.15"
+__version__ = "0.4.16"


### PR DESCRIPTION
## Summary

v0.4.15 was wrong. `claude --bg` is a real (if undocumented-in-help) claude flag — confirmed by inspecting `~/bin/claude-codex` which Jeff runs daily with `--bg`, and by running `claude --bg --help` which produces:

```
backgrounded · 1d80a5ac (idle — send a prompt to start)
  claude agents             list sessions
  claude attach 1d80a5ac    open in this terminal
  claude logs 1d80a5ac      show recent output
  claude stop 1d80a5ac      stop this session
```

Claude Code handles background agents natively — PTY allocation, process management, attach/logs/stop machinery, all built in. The v0.4.15 tmux wrapper was redundant + added an unnecessary dependency.

**Fix.** Strip claude-channel down to a thin pass-through:

- Wrapper-owned flags: `--session-name`, `--endpoint`, `--cwd`, `--help`.
- Everything else passes through to claude verbatim: `--bg`, `--print`, `--resume`, `--model`, `--remote-control`, `--worktree`, etc.
- Removed: `--bg`/`--background` parsing, BACKGROUND variable, detach block, tmux logic, `--print-info` (claude `agents --json` + cc-sessions:registry are the canonical discovery mechanisms).
- **tmux dependency dropped.**

PROTOCOL.md launch contract updated: spawn pattern is now `claude-channel --session-name <N> --cwd <D> --bg`; kill path includes `claude stop <agent-id>` as the cleanest option alongside the existing SIGTERM-via-registry path.

## Test plan
- [x] 172 redis-channel tests pass; ruff clean
- [x] Manual smoke: --help works, invalid session-name → exit 2, --bg flows to claude argv, dev flags prepended in non-production mode
- [ ] After merge + `/redis-channel-setup`: `claude-channel --session-name foo --bg` → claude prints agent ID + attach hints; XADD inbound from another shell works against the running agent