### PR TITLE
fix(redis-channel): --bg injects env via --settings (v0.4.17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,24 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed — `claude-channel --bg` injects env via `--settings` so auto-connect fires in dispatched sessions (v0.4.17)
+
+Jeff tested v0.4.16's --bg path against a real backgrounded session, found that `/redis-channel-list` inside it reported "Not connected" — auto-connect didn't fire. Root cause: **background-dispatched claude sessions do not inherit env from the invoking shell**. claude --bg sends a spawn RPC to an agent dispatcher; the dispatched session starts with the dispatcher's env, not the wrapper's. So `CLAUDE_CHANNEL_AUTO_CONNECT=1` (set by the wrapper before exec) never reached the spawned MCP server.
+
+Verified by inspecting `~/bin/claude-codex`, which solves the same problem the same way: when --bg is detected, prepend `--settings '{"env":{...}}'` to claude's argv. claude reads the settings JSON and propagates the env entries into the dispatched session.
+
+**Fix in the wrapper:** when `--bg` / `--background` appears in pass-through args, the wrapper now builds a settings JSON containing the env vars the plugin needs and injects it as `--settings '{"env":{...}}'`. Vars injected:
+
+- `CLAUDE_CHANNEL_AUTO_CONNECT=1` (always — the gate that triggers auto-connect)
+- `CLAUDE_SESSION_NAME` (if `--session-name` was set)
+- `CLAUDE_CHANNEL_ENDPOINT` (if `--endpoint` was set)
+
+`HERMES_REDIS_PASSWORD` is NOT injected — it's per-deployment and handled by `~/.claude/channels/redis-channel/source-env.sh`, which the MCP launcher (`.mcp.json`) sources before starting each MCP server, including in dispatched bg sessions.
+
+If the user supplied their own `--settings` in passthru args (rare), the wrapper warns instead of double-injecting and reminds the user to put the env vars in their settings themselves. Matches the codex pattern (line 332-335 of `~/bin/claude-codex`).
+
+Manual smoke-tested: `--bg` alone → settings injected with the right env shape; no `--bg` → no injection (foreground inherits env normally); `--bg --settings <user>` → warn + leave their settings alone. 172 redis-channel tests pass; ruff clean.
+
 ### Changed — `claude-channel` is now a thin pass-through; `--bg` goes straight to claude (v0.4.16)
 
 Jeff caught that v0.4.15's tmux-based `--bg` was solving the wrong problem. **`claude --bg` is a real (if undocumented-in-help) claude flag** that spawns a native background agent, prints the agent ID + attach/logs/stop hints, and returns. Verified:

--- a/plugins/redis-channel/scripts/claude-channel.sh
+++ b/plugins/redis-channel/scripts/claude-channel.sh
@@ -176,12 +176,55 @@ require_claude_bin
 source_keychain_password
 export CLAUDE_CHANNEL_AUTO_CONNECT=1
 
-# Compose claude argv: dev flags (unless production) + plugin-ref + passthru.
+# Detect --bg / --background in the passthru args. Background-dispatched
+# claude sessions do NOT inherit env from this wrapper's invocation —
+# they're spawned by claude's agent-dispatch IPC, which gives them a
+# fresh env. To get our env vars (CLAUDE_CHANNEL_AUTO_CONNECT etc.) into
+# the dispatched session, we must inject them via --settings JSON.
+# Pattern verified against ~/bin/claude-codex which uses the same
+# mechanism for proxy env vars.
+bg_mode=0
+has_user_settings=0
+for arg in "${PASSTHRU_ARGS[@]}"; do
+    case "$arg" in
+        --bg|--background) bg_mode=1 ;;
+        --settings|--settings=*) has_user_settings=1 ;;
+    esac
+done
+
+# Compose claude argv: dev flags (unless production) + --settings env
+# injection (if --bg) + passthru.
 CLAUDE_ARGS=()
 if [ "$PRODUCTION" != "1" ]; then
     CLAUDE_ARGS+=(--allow-dangerously-skip-permissions)
     CLAUDE_ARGS+=(--dangerously-load-development-channels "$PLUGIN_REF")
 fi
+
+if [ "$bg_mode" -eq 1 ]; then
+    if [ "$has_user_settings" -eq 1 ]; then
+        printf 'claude-channel: warning: --bg + user-supplied --settings detected. ' >&2
+        printf 'Make sure your settings include env: {CLAUDE_CHANNEL_AUTO_CONNECT="1"' >&2
+        if [ -n "$SESSION_NAME" ]; then
+            printf ', CLAUDE_SESSION_NAME="%s"' "$SESSION_NAME" >&2
+        fi
+        if [ -n "$ENDPOINT" ]; then
+            printf ', CLAUDE_CHANNEL_ENDPOINT="%s"' "$ENDPOINT" >&2
+        fi
+        printf '} so redis-channel auto-connect fires in the dispatched session.\n' >&2
+    else
+        # Build {"env":{...}} JSON. Values are regex-validated (session_name)
+        # or simple strings (endpoint); no JSON-escape needed for these.
+        env_entries='"CLAUDE_CHANNEL_AUTO_CONNECT":"1"'
+        if [ -n "$SESSION_NAME" ]; then
+            env_entries="${env_entries},\"CLAUDE_SESSION_NAME\":\"${SESSION_NAME}\""
+        fi
+        if [ -n "$ENDPOINT" ]; then
+            env_entries="${env_entries},\"CLAUDE_CHANNEL_ENDPOINT\":\"${ENDPOINT}\""
+        fi
+        CLAUDE_ARGS+=(--settings "{\"env\":{${env_entries}}}")
+    fi
+fi
+
 CLAUDE_ARGS+=("${PASSTHRU_ARGS[@]}")
 
 exec "$CLAUDE_BIN" "${CLAUDE_ARGS[@]}"

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.16"
+__version__ = "0.4.17"


### PR DESCRIPTION
## Summary

Jeff tested v0.4.16's --bg path against a real backgrounded session and `/redis-channel-list` inside it reported "Not connected". Root cause: **claude --bg dispatches via IPC; the spawned session does NOT inherit env from the invoking shell**. Our `CLAUDE_CHANNEL_AUTO_CONNECT=1` never reached the bg agent's MCP server.

claude-codex solves this with `--settings '{"env":{...}}'` (lines 144-157 + 327-333). Our wrapper now does the same: when `--bg` is detected in passthru args, prepends `--settings` JSON with:

- `CLAUDE_CHANNEL_AUTO_CONNECT=1` (always — the gate)
- `CLAUDE_SESSION_NAME` (if `--session-name` was set)
- `CLAUDE_CHANNEL_ENDPOINT` (if `--endpoint` was set)

`HERMES_REDIS_PASSWORD` stays out of `--settings` — it's per-deployment; `~/.claude/channels/redis-channel/source-env.sh` (sourced by the `.mcp.json` launcher) handles it on each MCP-server spawn including dispatched ones.

If user supplied their own `--settings`, wrapper warns + skips injection (matches codex's defensive behavior).

## Test plan
- [x] 172 redis-channel tests pass; ruff clean
- [x] Manual smoke: `--bg` injects with right env shape; no `--bg` doesn't inject; `--bg --settings <user>` warns + leaves user settings alone
- [ ] After merge + symlink refresh: `claude-channel --session-name plugin-testing --bg` should spawn a bg session that auto-connects; `/redis-channel-list` inside it shows the session