### PR TITLE
fix(redis-channel): auto-connect falls back to single-endpoint convenience (v0.4.18)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,23 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed — auto-connect falls back to single-endpoint convenience (v0.4.18)
+
+Jeff tested v0.4.17, found `--bg` still landed in a session where `/redis-channel-list` reported "Not connected". Diagnostic via `ps eww -p <mcp-pid>` confirmed `CLAUDE_CHANNEL_AUTO_CONNECT=1` and `CLAUDE_SESSION_NAME=plugin-testing` DID make it into the bg session's env (so v0.4.17's `--settings` injection works). The actual bug: `_maybe_auto_connect` tried `CLAUDE_CHANNEL_ENDPOINT` env → `registry.defaults.auto_connect_endpoint` → bailed with "no endpoint resolvable" when both were unset.
+
+Existing solo-developer setups (like Jeff's) have ONE endpoint configured (`mimir`) but never set `auto_connect_endpoint` (the field was added in v0.4.11; older registries lack it). The fix is to fall through to `Registry.resolve_default_endpoint()`, which already has the single-endpoint convenience built in from v0.4.11.
+
+New resolution order in `_maybe_auto_connect`:
+1. `CLAUDE_CHANNEL_ENDPOINT` env var (explicit per-invocation override; set by the wrapper when user passes `--endpoint`)
+2. `registry.defaults.auto_connect_endpoint` (registry-wide pin; useful for multi-endpoint setups)
+3. `registry.resolve_default_endpoint()` — covers two cases: (a) `defaults.default_endpoint` names a configured endpoint, or (b) single-endpoint convenience fallback when only one endpoint is configured
+
+Multi-endpoint registries without a resolvable default still log a warning + skip (we can't guess which endpoint to pick). The warning message now includes the inner error from `resolve_default_endpoint` so the user knows whether the issue is multi-endpoint ambiguity vs missing config.
+
+For Jeff's specific setup (`mimir` is the only endpoint), `claude-channel --session-name plugin-testing --bg` will now auto-connect to `mimir` without any explicit endpoint flag or registry edit.
+
+New unit test: `test_maybe_auto_connect_falls_back_to_single_endpoint_convenience`. 173 redis-channel tests total; ruff clean.
+
 ### Fixed — `claude-channel --bg` injects env via `--settings` so auto-connect fires in dispatched sessions (v0.4.17)
 
 Jeff tested v0.4.16's --bg path against a real backgrounded session, found that `/redis-channel-list` inside it reported "Not connected" — auto-connect didn't fire. Root cause: **background-dispatched claude sessions do not inherit env from the invoking shell**. claude --bg sends a spawn RPC to an agent dispatcher; the dispatched session starts with the dispatcher's env, not the wrapper's. So `CLAUDE_CHANNEL_AUTO_CONNECT=1` (set by the wrapper before exec) never reached the spawned MCP server.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -922,12 +922,22 @@ def _maybe_auto_connect() -> None:
     gate = os.environ.get(_AUTO_CONNECT_ENV)
     if gate != "1":
         return
-    endpoint = os.environ.get(_AUTO_CONNECT_ENDPOINT_ENV)
-    # Fall back to registry.defaults.auto_connect_endpoint if env unset.
+    # Resolution order:
+    #   1. CLAUDE_CHANNEL_ENDPOINT env var (explicit, per-invocation)
+    #   2. registry.defaults.auto_connect_endpoint (explicit, registry-wide)
+    #   3. registry.defaults.default_endpoint via resolve_default_endpoint
+    #      (which also has single-endpoint convenience fallback)
+    # Steps 1 and 2 let the user PIN auto-connect to a specific endpoint
+    # even when multiple are configured. Step 3 is the "just works" case
+    # for users with one configured endpoint who haven't customized the
+    # auto-connect field. Each step that fails to resolve falls through;
+    # only fail loudly when ALL three come up empty AND we're a multi-
+    # endpoint registry (single-endpoint failures already have a clear
+    # error message inside resolve_default_endpoint).
+    endpoint: str | None = os.environ.get(_AUTO_CONNECT_ENDPOINT_ENV)
     if not endpoint:
         try:
             registry = load_registry()
-            endpoint = registry.defaults.auto_connect_endpoint
         except RegistryError as e:
             log.warning(
                 "auto-connect skipped: registry error (%s). Set "
@@ -936,15 +946,25 @@ def _maybe_auto_connect() -> None:
                 DEFAULT_CONFIG_PATH,
             )
             return
-    if not endpoint:
-        log.warning(
-            "auto-connect requested via %s=1 but no endpoint resolvable "
-            "(set %s or registry.defaults.auto_connect_endpoint). Server "
-            "continuing; use /redis-channel-connect manually.",
-            _AUTO_CONNECT_ENV,
-            _AUTO_CONNECT_ENDPOINT_ENV,
-        )
-        return
+        endpoint = registry.defaults.auto_connect_endpoint
+        if not endpoint:
+            # Step 3: try resolve_default_endpoint (single-endpoint
+            # convenience or registry.defaults.default_endpoint).
+            try:
+                ep_obj = registry.resolve_default_endpoint()
+                endpoint = ep_obj.name
+            except EndpointNotFoundError as e:
+                log.warning(
+                    "auto-connect requested via %s=1 but no endpoint "
+                    "resolvable: %s. Set %s, or "
+                    "registry.defaults.auto_connect_endpoint, or "
+                    "registry.defaults.default_endpoint. Server "
+                    "continuing; use /redis-channel-connect manually.",
+                    _AUTO_CONNECT_ENV,
+                    e,
+                    _AUTO_CONNECT_ENDPOINT_ENV,
+                )
+                return
     log.info("auto-connect: registering at endpoint=%s", endpoint)
     result = _STATE.startup_register(endpoint=endpoint)
     if result.get("ok"):

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -683,6 +683,42 @@ def test_maybe_auto_connect_registry_missing_continues(
     assert any("registry error" in r.message for r in caplog.records)
 
 
+def test_maybe_auto_connect_falls_back_to_single_endpoint_convenience(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When AUTO_CONNECT=1 but neither env nor auto_connect_endpoint is set,
+    and the registry has exactly ONE configured endpoint, fall through to
+    resolve_default_endpoint's single-endpoint convenience and auto-connect
+    to that endpoint. This is the common 'just works' path for solo setups
+    where the user hasn't set auto_connect_endpoint explicitly."""
+    from server import registry as registry_mod  # type: ignore[import-not-found]
+
+    fake_endpoint = registry_mod.Endpoint(
+        name="sole-endpoint",
+        redis_url="redis://h:6379/0",
+        redis_password_env=None,
+        display_name="Sole",
+    )
+    fake_registry = registry_mod.Registry(
+        endpoints={"sole-endpoint": fake_endpoint},
+        defaults=registry_mod.Defaults(),  # default_endpoint="default"; auto_connect_endpoint=None
+        source=Path("/dev/null"),
+    )
+    monkeypatch.setattr(channel, "load_registry", lambda: fake_registry)
+    monkeypatch.setenv("CLAUDE_CHANNEL_AUTO_CONNECT", "1")
+    monkeypatch.delenv("CLAUDE_CHANNEL_ENDPOINT", raising=False)
+
+    calls: list[str] = []
+
+    def fake_startup_register(*, endpoint: str) -> dict[str, Any]:
+        calls.append(endpoint)
+        return {"ok": True, "session_name": "x"}
+
+    monkeypatch.setattr(channel._STATE, "startup_register", fake_startup_register)
+    channel._maybe_auto_connect()
+    assert calls == ["sole-endpoint"]
+
+
 # ─── Phase 2.5: /redis-channel-status ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

v0.4.17's `--settings` injection works — verified `CLAUDE_CHANNEL_AUTO_CONNECT=1` and `CLAUDE_SESSION_NAME=plugin-testing` reached the bg session's MCP env via `ps eww -p <pid>`. But `/redis-channel-list` still reported "Not connected": `_maybe_auto_connect` was too strict, requiring either `CLAUDE_CHANNEL_ENDPOINT` env or `registry.defaults.auto_connect_endpoint`. Solo setups (one endpoint) have neither.

**Fix.** Fall through to `Registry.resolve_default_endpoint()` (which I added in v0.4.11 with single-endpoint convenience). New resolution order:

1. `CLAUDE_CHANNEL_ENDPOINT` env (explicit per-invocation; wrapper sets it when user passes `--endpoint`)
2. `registry.defaults.auto_connect_endpoint` (registry-wide pin)
3. `registry.resolve_default_endpoint()` — `default_endpoint` name, OR sole-endpoint convenience

Multi-endpoint registries without a resolvable default still log a warning and skip. Warning now wraps the inner error so the user can tell whether they hit multi-endpoint ambiguity or missing config.

## Test plan
- [x] 173 redis-channel tests pass (1 new); ruff clean
- [ ] After merge + symlink refresh: `claude-channel --session-name plugin-testing --bg` should land in a session where `/redis-channel-list` reports connected=true; `cc-sessions:hb:plugin-testing` appears in Redis