### PR TITLE
feat(redis-channel): Phase 6 polish — configure + auto-refresh + ARCHITECTURE.md (v0.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -343,7 +343,7 @@
     {
       "name": "redis-channel",
       "source": "./plugins/redis-channel",
-      "version": "0.4.18",
+      "version": "0.5.0",
       "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic; pair with any router implementation that speaks the protocol.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/.claude-plugin/plugin.json
+++ b/plugins/redis-channel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-channel",
-  "version": "0.4.18",
+  "version": "0.5.0",
   "description": "Claude Code channel that bridges sessions to external systems over Redis Streams. Router-agnostic: pair with any router implementation that speaks the protocol.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/redis-channel/ARCHITECTURE.md
+++ b/plugins/redis-channel/ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# Architecture — `redis-channel`
+
+## Why
+
+Claude Code's experimental **channels** capability lets a plugin emit `notifications/claude/channel` events into Claude's context and expose an MCP tool that ships replies back out. Channels are the protocol-level mechanism that makes external systems (Discord bots, web UIs, mobile apps) bidirectionally usable as Claude Code surfaces.
+
+`redis-channel` is a generic Redis-Streams channel plugin. It speaks a documented protocol (`PROTOCOL.md`) over Redis and bridges to any consumer that speaks the same protocol on the other side. Decoupling via Redis (rather than HTTP or direct IPC) buys: durability across CC-side restarts, multi-process safety (consumer groups), no port-binding, and the consumer can live on a different machine.
+
+The plugin is **router-agnostic**. One reference consumer is [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router) (Discord-via-Hermes); others are conceivable (Telegram bot, mobile app, CLI test harness). The plugin itself never references a specific consumer in code or descriptions — it's a generic Redis bridge.
+
+## System view
+
+```mermaid
+flowchart LR
+    User[Remote user<br/>Discord/Telegram/web]
+    Router[Router<br/>e.g. hermes-claude-code-router]
+    Redis[(Redis Streams<br/>cc-sessions:* keys)]
+    MCP[redis-channel MCP server<br/>python -m server]
+    Claude[Claude Code session]
+
+    User <-->|platform-native I/O| Router
+    Router <-->|XADD inbound<br/>XREADGROUP outbound| Redis
+    Redis <-->|XREADGROUP inbound<br/>XADD outbound| MCP
+    MCP <-->|notifications/claude/channel<br/>reply tool| Claude
+```
+
+**Flow of a single round-trip:**
+
+1. Remote user sends a message on the user-facing surface (e.g., Discord DM).
+2. Router translates → `XADD cc-sessions:<session>:inbound *` with a JSON payload conforming to `Inbound` schema.
+3. MCP server's consumer thread does `XREADGROUP GROUP cc:<session> consumer-1 BLOCK 1000 STREAMS ...:inbound >`, gets the message, validates against `Inbound`, emits `notifications/claude/channel` with `{content, meta}`.
+4. Claude Code injects the notification into the model's context as a `<channel ...>...</channel>` tag.
+5. Claude (the model) calls the `reply` MCP tool with `chat_id`, `text`, `voice`, `in_reply_to`.
+6. MCP server validates against `Outbound` and does `XADD cc-sessions:<session>:outbound * payload <JSON>`.
+7. Router's `XREADGROUP GROUP <router-name> consumer-1 BLOCK 1000 ...:outbound >` consumes and dispatches to the user-facing surface.
+
+## Components in this plugin
+
+```
+plugins/redis-channel/
+├── server/
+│   ├── __main__.py          # `python -m server` entry point → run()
+│   ├── channel.py           # FastMCP app: tools (connect, list, status, reply, setup, configure)
+│   ├── presence.py          # Registry HSET + heartbeat thread + lifecycle pubsub
+│   ├── redis_client.py      # Redis connection helper + URL-encoded password
+│   ├── redis_consumer.py    # XREADGROUP loop in a background thread
+│   ├── redis_producer.py    # XADD helper for outbound + permission_request
+│   ├── notifier.py          # AsyncNotifier (thread → asyncio bridge for MCP notifications)
+│   ├── registry.py          # Loads ~/.claude/channels/redis-channel/registry.json
+│   ├── session_id.py        # Auto-name from cwd + 8-hex hash; --session-name override
+│   └── protocol.py          # Pydantic models matching PROTOCOL.md
+├── commands/                # Claude Code slash commands
+├── .mcp.json                # Tells Claude Code how to launch the MCP server
+├── scripts/
+│   ├── claude-channel.sh    # ~/bin wrapper: env vars + dev flags + exec claude
+│   ├── install-claude-channel.sh  # Symlink installer (manual fallback)
+│   └── integ_test.py        # Headless full-pipeline integration test
+└── PROTOCOL.md              # Canonical Redis wire format
+```
+
+## State + lifecycle
+
+### Presence registry (per-session in Redis)
+
+```
+HSET cc-sessions:registry <session_name> <JSON {host, cwd, git_branch, started_at, pid, endpoint}>
+SET  cc-sessions:hb:<session_name> <last_heartbeat_ts> EX 60      # refreshed every 10s
+```
+
+Routers list live sessions by `HGETALL cc-sessions:registry` filtered by `EXISTS cc-sessions:hb:<name>`. Stale entries (process killed without graceful disconnect) get lazily GC'd by `list_live_sessions(gc_stale=True)`.
+
+### Connect/disconnect
+
+- **Connect** (`/redis-channel-connect` OR auto-connect via `CLAUDE_CHANNEL_AUTO_CONNECT=1` env): opens Redis, creates consumer group at `id="$"`, starts presence thread (heartbeat), then attaches consumer thread (XREADGROUP loop) + AsyncNotifier. Single-session-per-process — second connect replaces the first.
+
+- **Disconnect** (`/redis-channel-disconnect`, SIGTERM, atexit): stops consumer thread, stops heartbeat thread, `HDEL cc-sessions:registry <name>`, `DEL cc-sessions:hb:<name>`, `DEL` per-session streams, `PUBLISH cc-sessions:events:<name> {type: "unregistered"}`.
+
+### Auto-connect resolution order
+
+When `CLAUDE_CHANNEL_AUTO_CONNECT=1` (set by the `claude-channel` wrapper):
+1. `CLAUDE_CHANNEL_ENDPOINT` env var (explicit per-invocation override).
+2. `registry.defaults.auto_connect_endpoint` (registry-wide pin).
+3. `Registry.resolve_default_endpoint()` — `defaults.default_endpoint` name, OR single-endpoint convenience fallback when only one endpoint is configured.
+
+Failure modes (registry missing, endpoint unknown, Redis unreachable) → log warning, continue running; manual `/redis-channel-connect` still works.
+
+### Deferred consumer-thread start
+
+`startup_register()` (eager, at MCP boot) creates the consumer group + publishes presence — but does NOT start the consumer thread, because there's no MCP `Context` yet to build an `AsyncNotifier` from. The first MCP tool dispatch (any tool — `list`, `status`, `reply`) calls `ensure_consumer_attached()` which builds the notifier from the live `ctx` and starts the thread. Because the consumer group was created at `id="$"` BEFORE presence published, `XREADGROUP >` later picks up everything the router XADD'd in the gap — no silent drop.
+
+## Config files (per deployment)
+
+```
+~/.claude/channels/redis-channel/
+├── registry.json     # Endpoint definitions + defaults
+└── source-env.sh     # Sourced by .mcp.json launcher; exports env vars (passwords, etc.)
+```
+
+- **registry.json** is JSON, NOT a secret store. The Redis password lives in an env var whose name is referenced via `redis_password_env`.
+- **source-env.sh** is the per-deployment glue. The plugin doesn't bake env-var names; it reads them via the registry. The user's source-env.sh is responsible for populating those env vars (e.g., sourcing from macOS keychain).
+
+See `docs/registry.example.json` and `docs/source-env.example.sh` for templates. `/redis-channel-setup` scaffolds both from the examples; `/redis-channel-configure` adds/updates endpoints in `registry.json` without touching `source-env.sh`.
+
+## Claude Code integration knobs
+
+| Surface | Mechanism |
+|---|---|
+| MCP server startup | `.mcp.json` runs `uv run python3 -m server` |
+| Plugin-side coaching | `instructions=` field in `FastMCP(...)` — injected into Claude's system prompt at session start (not the `agents/` dir, which is subagent-invocable only) |
+| Channel notifications | `notifications/claude/channel` — requires the `claude/channel` experimental capability declared via a monkey-patch on `create_initialization_options`; Claude Code must be launched with `--dangerously-load-development-channels plugin:redis-channel@infiquetra-plugins` for channels to surface |
+| Slash commands | Markdown files in `commands/`, each documents a `redis_channel_*` MCP tool to call |
+| Wrapper | `~/bin/claude-channel` symlinked to `scripts/claude-channel.sh`; sets `CLAUDE_SESSION_NAME`, `CLAUDE_CHANNEL_ENDPOINT`, `CLAUDE_CHANNEL_AUTO_CONNECT=1`, dev flags, and execs claude |
+
+## Known limitations
+
+- **Channel notifications don't reach `--bg` / `/bg` dispatched sessions.** Claude Code's bg-dispatch carry-through flag set excludes `--dangerously-load-development-channels` (and `--channels`), so dispatched bg-spare processes don't recognize the channel capability and silently drop notifications. Foreground sessions (including tmux-wrapped foreground) work. See `docs/engineering-journal/LEARNINGS.md#cc-channels-bg-not-supported` for details.
+- **Local-terminal reply rendering is best-effort.** When Claude calls the `reply` tool, the tool's text content doesn't render as natural chat in the local terminal — Claude Code's UI shows "Called plugin:redis-channel:..." collapsed. The channel user sees the reply correctly; the local terminal user must expand the tool call to see what was sent. This is intended Claude Code Channels design; documented in `LEARNINGS.md#cc-channels-surface-split`.
+- **Cross-host kill not supported.** Routers can spawn + monitor sessions only on the same host as the router process. The registry's `host` field is informational; SIGTERM works only when host matches.
+
+## Cross-references
+
+- `PROTOCOL.md` — the canonical wire format (shared verbatim with any compliant router)
+- `docs/STATE_MACHINE.md` — router-side routing-target state machine (consumer concern, kept here for completeness)
+- `docs/engineering-journal/LEARNINGS.md` — empirical findings from the build
+- `docs/engineering-journal/DECISIONS.md` — ADRs that shaped the design

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -7,6 +7,22 @@ the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added — Phase 6 polish: configure command + auto-refresh symlink + ARCHITECTURE.md (v0.5.0)
+
+Phase 6 wraps up the CC-plugin side of the master plan. Three deliverables:
+
+**`/redis-channel-configure` slash command + `redis_channel_configure` MCP tool.** Was a stub since Phase 0; now fully implemented. Interactive endpoint setup that asks for redis_url, redis_password_env, display_name, set-as-default, then writes/updates `~/.claude/channels/redis-channel/registry.json` atomically. Idempotent — re-running for the same endpoint name overwrites the entry; other endpoints + defaults preserved. Validates: endpoint name matches `^[a-z0-9][a-z0-9_-]*$`, redis_url starts with `redis://` or `rediss://`. Does NOT create source-env.sh (that's `/redis-channel-setup`'s job).
+
+**Auto-refresh stale symlink in MCP startup nag.** Extends the v0.4.14 startup nag: when `~/bin/claude-channel` is a symlink pointing into our plugin cache hierarchy but at an OLDER version (the common "plugin updated, symlink lagged" case), the MCP server now refreshes it in-place + logs INFO. Scope: only self-managed symlinks; user-customized symlinks pointing elsewhere are left alone (nag still fires for those). Missing config files (source-env.sh, registry.json) stay nag-only — never auto-create user config. New helpers `_auto_refresh_stale_symlink()` and `_is_our_plugin_cache_target()`.
+
+**`plugins/redis-channel/ARCHITECTURE.md`** — system narrative with a Mermaid diagram covering roles, round-trip flow, components in this plugin, state + lifecycle semantics, config files, Claude Code integration knobs, known limitations (cross-ref'd to LEARNINGS). Plugin-side only; router-specific details stay in the router repo.
+
+**README polish** — Status section restructured to reflect what's actually shipped (P1, P2, P2.5, P6) and what's deferred to the router repo. Quickstart rewritten around `/redis-channel-setup` + `/redis-channel-configure` (was: "manually copy registry.example.json"). Known limitation about bg sessions called out at the top.
+
+Tests: 14 new (6 auto-refresh + 8 configure-endpoint); 187 redis-channel tests total; ruff clean.
+
+This release marks the CC-plugin side of the master plan as feature-complete. Router-side work (text routing, voice routing, permission relay, LLM tools) lives in [`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router).
+
 ### Fixed — auto-connect falls back to single-endpoint convenience (v0.4.18)
 
 Jeff tested v0.4.17, found `--bg` still landed in a session where `/redis-channel-list` reported "Not connected". Diagnostic via `ps eww -p <mcp-pid>` confirmed `CLAUDE_CHANNEL_AUTO_CONNECT=1` and `CLAUDE_SESSION_NAME=plugin-testing` DID make it into the bg session's env (so v0.4.17's `--settings` injection works). The actual bug: `_maybe_auto_connect` tried `CLAUDE_CHANNEL_ENDPOINT` env → `registry.defaults.auto_connect_endpoint` → bailed with "no endpoint resolvable" when both were unset.

--- a/plugins/redis-channel/README.md
+++ b/plugins/redis-channel/README.md
@@ -17,15 +17,30 @@ It is **not** a Discord bot. It does not touch Discord, voice-channel audio, STT
 
 ## Status
 
-**Phase 2 complete.** Presence + heartbeat (P1) plus inbound consumer + `reply` MCP tool (P2). Channel notifications surface as `notifications/claude/channel` events with the full Inbound payload; replies XADD onto the outbound stream with router-correlation IDs and an `in_reply_to` field for threading. Voice routing (P3), permission relay + AskUserQuestion interception (P4), and hybrid LLM-tool intelligence (P5) still to come — each requires matching router-side implementation. Roadmap: `/Users/jefcox/.claude/plans/i-would-like-to-distributed-hanrahan.md`.
+**CC-plugin side complete (foreground end-to-end verified).** Phases shipped:
+- **P1** — presence registry + heartbeat (`/redis-channel-list`, 60s hb TTL).
+- **P2** — inbound XREADGROUP → `notifications/claude/channel` → `reply` tool → outbound XADD round-trip.
+- **P2.5** — env-var-driven auto-connect (`CLAUDE_CHANNEL_AUTO_CONNECT=1`), `claude-channel` wrapper, `/redis-channel-setup` first-run helper, `/redis-channel-status` probe, self-refreshing wrapper symlink on plugin updates.
+- **P6** — `/redis-channel-configure` interactive endpoint setup, this README, [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+**Router-side phases** (voice routing, permission relay, hybrid LLM tools, etc.) live in the router repo ([`hermes-claude-code-router`](https://github.com/infiquetra/hermes-claude-code-router)) — they don't change this plugin. The CC-plugin side is feature-complete for what a router needs to drive it.
+
+**Known limitation** — `/redis-channel-connect` works in **foreground** claude sessions. Background-dispatched sessions (`claude --bg`, `/bg`) silently drop channel notifications because Claude Code's bg-carry-through flag set excludes `--dangerously-load-development-channels`. See [`docs/engineering-journal/LEARNINGS.md#cc-channels-bg-not-supported`](../../docs/engineering-journal/LEARNINGS.md#cc-channels-bg-not-supported) for the chase + the tmux-foreground workaround.
 
 ## Quickstart
 
-1. **Configure an endpoint.** Copy `docs/registry.example.json` to `~/.claude/channels/redis-channel/registry.json` and edit. At minimum set `redis_url` and `redis_password_env` (the name of the env var containing your Redis password — never embed the password in the file).
-2. **Make sure Python deps are available.** The plugin's MCP server (`python -m server`) needs `mcp` and `redis` on its Python path. `uv sync --extra dev` at the repo root covers it for development.
-3. **Connect from inside Claude Code.** Run `/redis-channel-connect` (uses the registry's `default_endpoint`, or `/redis-channel-connect <endpoint-name>` to pick a specific one). The session is registered with an auto-generated `<cwd-basename>-<8hex>` name, heartbeat starts.
-4. **Verify.** Run `/redis-channel-list` to see the registry. Start another CC session in a different repo and `/redis-channel-connect` it too; the list shows both.
-5. **Disconnect.** `/redis-channel-disconnect` gracefully unregisters. Killing the process is also safe — the heartbeat key expires within 60s and other sessions GC the entry the next time they `list`.
+1. **Install the plugin** via Claude Code's `/plugin` UI.
+2. **Run `/redis-channel-setup`** in a Claude Code session. This symlinks `~/bin/claude-channel` to the cached wrapper (refreshes on each plugin update) and scaffolds `~/.claude/channels/redis-channel/source-env.sh` + `registry.json` from the bundled examples (only if those user files don't already exist).
+3. **Edit `~/.claude/channels/redis-channel/source-env.sh`** to populate the env var named in your registry's `redis_password_env` field. Example for macOS keychain:
+   ```sh
+   export MY_REDIS_PASSWORD="$(security find-generic-password -s 'my-redis-keychain-item' -w)"
+   ```
+4. **Run `/redis-channel-configure`** to add your endpoint interactively (Redis URL, password env-var name, display name, set-as-default). Or edit `registry.json` directly.
+5. **Connect.** From inside Claude Code: `/redis-channel-connect` (uses the registry's `default_endpoint`, or `/redis-channel-connect <endpoint-name>` for a specific one). The session registers under an auto-generated `<cwd-basename>-<8hex>` name; heartbeat starts.
+
+   Or, for fresh sessions: launch via `claude-channel --session-name <name>` from a terminal. The wrapper sets `CLAUDE_CHANNEL_AUTO_CONNECT=1` so the plugin auto-connects at startup — no manual connect needed.
+6. **Verify.** `/redis-channel-list` shows the registry. `/redis-channel-status` reports the current session's state.
+7. **Disconnect.** `/redis-channel-disconnect` gracefully unregisters. Killing the process is also safe — the heartbeat key expires within 60s and other sessions GC the entry on the next `list`.
 
 ## Layout
 

--- a/plugins/redis-channel/commands/redis-channel-configure.md
+++ b/plugins/redis-channel/commands/redis-channel-configure.md
@@ -1,13 +1,43 @@
 ---
-description: Add or update a redis-channel endpoint configuration.
-argument-hint: "<endpoint-name>"
+description: Add or update an endpoint in the local redis-channel registry.
+argument-hint: "[endpoint-name]"
 ---
 
-Interactively configure the `redis-channel` endpoint named `$1` (or prompt for a name if `$1` is empty). Walks through:
+Help the user configure (add or update) a redis-channel endpoint. If `$1` is supplied, use it as the endpoint name; otherwise ask.
 
-- Redis URL (e.g., `redis://olympus-bus.infiquetra.com:6379/0`)
-- Password env-var name (no password value entered here — that lives in env)
-- Display name for `list` output
-- Persists to `~/.claude/channels/redis-channel/registry.json`
+**Pre-flight check.** If `~/.claude/channels/redis-channel/registry.json` does not exist AND `~/.claude/channels/redis-channel/source-env.sh` does not exist, suggest running `/redis-channel-setup` FIRST — that creates the per-deployment env file that populates the password env var. The user can still configure an endpoint without source-env.sh, but the connect won't work until they wire it up.
 
-**Not implemented in Phase 0.** Lands in Phase 6 polish.
+**Steps to gather:**
+
+1. **Endpoint name.** If `$1` is set and matches `^[a-z0-9][a-z0-9_-]*$`, use it. Else ask: *"What endpoint name? (e.g., `default`, `mimir`, `staging`)"*. Regex-validate before proceeding.
+
+2. **Redis URL.** Ask: *"Redis URL? (e.g., `redis://redis-host.example.com:6379/0` or `rediss://...` for TLS)"*. Must start with `redis://` or `rediss://`.
+
+3. **Password env var.** Ask: *"What env var name holds the Redis password? (e.g., `MY_REDIS_PASSWORD`; leave blank if Redis has no auth)"*. The actual password value lives in env — populated by `source-env.sh`, not entered here.
+
+4. **Display name** (optional). Ask: *"Human-readable display name? (shown in `/redis-channel-list`; default: same as endpoint name)"*. Blank = use endpoint name.
+
+5. **Set as default?** Ask: *"Make this the default endpoint for `/redis-channel-connect` (no args)? (yes/no)"*. If only one endpoint will be configured, default to yes; if multiple, default to no.
+
+6. **Confirm.** Summarize the values back to the user. Wait for explicit OK before writing.
+
+7. **Call the `redis_channel_configure` MCP tool** with:
+   - `endpoint_name=<from step 1>`
+   - `redis_url=<from step 2>`
+   - `redis_password_env=<from step 3, omit if blank>`
+   - `display_name=<from step 4, omit if blank>`
+   - `set_default=<from step 5>`
+
+**After the tool returns:**
+
+- On `{ok: true}` — report:
+  - `action` (created/updated)
+  - `endpoint_name` and `written` (path)
+  - `endpoint_count` (total endpoints now configured)
+  - `default_endpoint` (if non-null, mention which one is now default)
+  - **Reminder:** if `redis_password_env` is set, the user must have a line in `~/.claude/channels/redis-channel/source-env.sh` like:
+    ```
+    export <VAR>="$(security find-generic-password -s 'my-redis-keychain-item' -w)"
+    ```
+    Tell them to edit that file (or run `/redis-channel-setup` first if it doesn't exist) before trying `/redis-channel-connect`.
+- On `{ok: false}` — show `error` + `detail` and offer to retry with corrected values.

--- a/plugins/redis-channel/server/__init__.py
+++ b/plugins/redis-channel/server/__init__.py
@@ -11,4 +11,4 @@ This package is the CC-side implementation: an MCP server (stdio) that:
   - relays permission_request / permission_verdict
 """
 
-__version__ = "0.4.18"
+__version__ = "0.5.0"

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -23,6 +23,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import socket
@@ -503,6 +504,107 @@ def _check_setup() -> dict[str, Any]:
     }
 
 
+_ENDPOINT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+def _configure_endpoint(
+    *,
+    endpoint_name: str,
+    redis_url: str,
+    redis_password_env: str | None = None,
+    display_name: str | None = None,
+    set_default: bool = False,
+) -> dict[str, Any]:
+    """Add or update an endpoint in `~/.claude/channels/redis-channel/registry.json`.
+
+    Idempotent: if the endpoint already exists, its fields are overwritten
+    with the new values. Other endpoints + defaults are left intact. Writes
+    atomically via a .tmp + replace.
+
+    Does NOT create source-env.sh — that's `/redis-channel-setup`'s job.
+    """
+    if not _ENDPOINT_NAME_RE.match(endpoint_name):
+        return {
+            "ok": False,
+            "error": "invalid endpoint_name",
+            "detail": f"must match {_ENDPOINT_NAME_RE.pattern}; got {endpoint_name!r}",
+        }
+    if not (redis_url.startswith("redis://") or redis_url.startswith("rediss://")):
+        return {
+            "ok": False,
+            "error": "invalid redis_url",
+            "detail": "must start with redis:// or rediss://",
+        }
+    if redis_password_env is not None and not redis_password_env.strip():
+        # Empty string → treat as None (no password env)
+        redis_password_env = None
+
+    cfg_path = CHANNEL_CONFIG_DIR / "registry.json"
+    try:
+        CHANNEL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return {"ok": False, "error": "mkdir failed", "detail": str(e)}
+
+    if cfg_path.exists():
+        try:
+            existing = json.loads(cfg_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            return {
+                "ok": False,
+                "error": "registry parse error",
+                "detail": f"existing {cfg_path}: {e}",
+            }
+        if not isinstance(existing, dict):
+            return {
+                "ok": False,
+                "error": "registry shape error",
+                "detail": f"existing {cfg_path} top-level must be object",
+            }
+    else:
+        existing = {}
+
+    endpoints = existing.setdefault("endpoints", {})
+    if not isinstance(endpoints, dict):
+        return {
+            "ok": False,
+            "error": "registry shape error",
+            "detail": "endpoints must be object",
+        }
+    endpoint_entry: dict[str, Any] = {"redis_url": redis_url}
+    if redis_password_env is not None:
+        endpoint_entry["redis_password_env"] = redis_password_env
+    if display_name is not None and display_name.strip():
+        endpoint_entry["display_name"] = display_name.strip()
+    is_update = endpoint_name in endpoints
+    endpoints[endpoint_name] = endpoint_entry
+
+    if set_default:
+        defaults = existing.setdefault("defaults", {})
+        if not isinstance(defaults, dict):
+            return {
+                "ok": False,
+                "error": "registry shape error",
+                "detail": "defaults must be object",
+            }
+        defaults["default_endpoint"] = endpoint_name
+
+    tmp = cfg_path.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+        tmp.replace(cfg_path)
+    except OSError as e:
+        return {"ok": False, "error": "write failed", "detail": str(e)}
+
+    return {
+        "ok": True,
+        "written": str(cfg_path),
+        "endpoint_name": endpoint_name,
+        "action": "updated" if is_update else "created",
+        "endpoint_count": len(endpoints),
+        "default_endpoint": existing.get("defaults", {}).get("default_endpoint"),
+    }
+
+
 def _do_setup(*, link_wrapper: bool, scaffold_configs: bool) -> dict[str, Any]:
     """Do the install actions. Idempotent — safe to re-run.
 
@@ -799,6 +901,35 @@ def build_app() -> FastMCP:
         )
 
     @app.tool(
+        name="redis_channel_configure",
+        description=(
+            "Add or update an endpoint in the local registry file "
+            "(~/.claude/channels/redis-channel/registry.json). Idempotent + "
+            "atomic. Other endpoints + defaults are preserved. Pass "
+            "set_default=true to make this the connect-without-args "
+            "default. Does NOT create source-env.sh — use /redis-channel-"
+            "setup for that. Endpoint name must match "
+            "^[a-z0-9][a-z0-9_-]*$. redis_url must start with redis:// or "
+            "rediss://. redis_password_env names the env var that will "
+            "hold the password at runtime — populate it via source-env.sh."
+        ),
+    )
+    async def redis_channel_configure(
+        endpoint_name: str,
+        redis_url: str,
+        redis_password_env: str | None = None,
+        display_name: str | None = None,
+        set_default: bool = False,
+    ) -> dict[str, Any]:
+        return _configure_endpoint(
+            endpoint_name=endpoint_name,
+            redis_url=redis_url,
+            redis_password_env=redis_password_env,
+            display_name=display_name,
+            set_default=set_default,
+        )
+
+    @app.tool(
         name="reply",
         description=(
             "Send a reply to the originating chat surface. The router on the "
@@ -981,12 +1112,82 @@ def _maybe_auto_connect() -> None:
         )
 
 
+def _is_our_plugin_cache_target(symlink_target: Path) -> bool:
+    """True if `symlink_target` points into our plugin's cache dir hierarchy.
+
+    Used to bound the auto-refresh: only refresh symlinks whose target lives
+    under `~/.claude/plugins/cache/infiquetra-plugins/redis-channel/<version>/`.
+    Symlinks pointing elsewhere (user-customized, dev checkouts, etc.) are
+    left alone — we don't second-guess user intent."""
+    try:
+        resolved = symlink_target.resolve()
+    except (OSError, RuntimeError):
+        return False
+    cache_marker = Path.home() / ".claude/plugins/cache/infiquetra-plugins/redis-channel"
+    try:
+        resolved.relative_to(cache_marker)
+        return True
+    except ValueError:
+        return False
+
+
+def _auto_refresh_stale_symlink() -> str | None:
+    """If `~/bin/claude-channel` is a stale symlink into OUR plugin cache,
+    refresh it to point at the running version's wrapper. Self-heal after
+    plugin updates.
+
+    Scope: only refresh self-managed symlinks (target inside our cache dir
+    hierarchy). Don't touch:
+      - missing symlinks (user hasn't run /redis-channel-setup yet — nag
+        them via the existing path instead)
+      - non-symlink files at the path (user installed a real script there)
+      - symlinks pointing outside our cache (user customization, dev checkout)
+      - broken symlinks (target doesn't exist; can't safely guess intent)
+
+    Returns the new target string if a refresh happened, else None.
+    """
+    if not WRAPPER_SYMLINK.is_symlink():
+        return None
+    new_target = _expected_wrapper_path()
+    if new_target is None or not new_target.exists():
+        return None
+    try:
+        old_target = WRAPPER_SYMLINK.resolve()
+    except (OSError, RuntimeError):
+        return None
+    if old_target == new_target.resolve():
+        return None  # already current
+    if not _is_our_plugin_cache_target(WRAPPER_SYMLINK):
+        return None  # external target — don't touch
+    try:
+        WRAPPER_SYMLINK.unlink()
+        WRAPPER_SYMLINK.symlink_to(new_target)
+    except OSError as e:
+        log.warning("auto-refresh symlink failed: %s", e)
+        return None
+    return str(new_target)
+
+
 def _log_setup_nag() -> None:
     """One-shot startup check: if setup is incomplete, log a hint suggesting
-    the user run /redis-channel-setup. Passive — never blocks, never modifies
-    anything. Designed to surface in the user's terminal the next time they
-    reconnect MCP after a plugin update."""
+    the user run /redis-channel-setup. Passive — never blocks user-facing
+    work.
+
+    Self-healing for plugin updates: if the only issue is a stale symlink
+    AND that symlink already points into our plugin cache (i.e., user has
+    run /redis-channel-setup before but a plugin update made their symlink
+    point at the old version), auto-refresh it in-place + log INFO. The
+    user doesn't need to re-run /redis-channel-setup after every plugin
+    update for this common case.
+
+    For other issues (missing symlink, missing source-env.sh, missing
+    registry.json, external symlink target), keep the existing nag — those
+    need user intent (the user must decide whether to set up at all, OR
+    edit user config that we should never auto-create)."""
     try:
+        refreshed = _auto_refresh_stale_symlink()
+        if refreshed is not None:
+            log.info("auto-refreshed ~/bin/claude-channel → %s", refreshed)
         state = _check_setup()
     except Exception:  # noqa: BLE001
         return  # never let the nag break the server

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -947,3 +947,298 @@ def test_setup_nag_silent_when_state_ready(
     assert not any(
         "/redis-channel-setup" in r.message for r in caplog.records
     )
+
+
+# ─── Phase 6: auto-refresh stale symlink (extends v0.4.14 startup nag) ────
+
+
+def test_auto_refresh_skips_when_no_symlink(
+    fake_home: Path,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No symlink → don't auto-create; nag still fires via _log_setup_nag."""
+    monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    result = channel._auto_refresh_stale_symlink()
+    assert result is None
+
+
+def test_auto_refresh_skips_when_symlink_current(
+    fake_plugin_root: Path, fake_home: Path
+) -> None:
+    """If symlink already points at the running version's wrapper → no-op."""
+    channel._do_setup(link_wrapper=True, scaffold_configs=False)
+    symlink = fake_home / "bin" / "claude-channel"
+    assert symlink.is_symlink()
+    # Pre-condition: current.
+    pre_state = channel._check_setup()
+    assert pre_state["wrapper_symlink_status"] == "current"
+
+    result = channel._auto_refresh_stale_symlink()
+    assert result is None  # already current, nothing to do
+
+
+def test_auto_refresh_fixes_stale_symlink_into_our_cache(
+    fake_plugin_root: Path,
+    fake_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If symlink points at an OLDER version under our plugin cache,
+    refresh it to point at the running version's wrapper."""
+    # Create a fake "old cached version" inside our cache marker path so it
+    # passes the _is_our_plugin_cache_target check.
+    cache_marker = tmp_path / "home" / ".claude/plugins/cache/infiquetra-plugins/redis-channel"
+    old_version_dir = cache_marker / "0.4.5" / "scripts"
+    old_version_dir.mkdir(parents=True)
+    old_wrapper = old_version_dir / "claude-channel.sh"
+    old_wrapper.write_text("#!/bin/sh\necho old\n")
+    old_wrapper.chmod(0o755)
+    # Patch Path.home() so _is_our_plugin_cache_target compares against
+    # tmp_path/home, where our fake cache lives.
+    monkeypatch.setattr(channel.Path, "home", lambda: tmp_path / "home")
+
+    symlink = fake_home / "bin" / "claude-channel"
+    symlink.parent.mkdir(parents=True, exist_ok=True)
+    symlink.symlink_to(old_wrapper)
+    assert symlink.resolve() == old_wrapper.resolve()
+
+    refreshed = channel._auto_refresh_stale_symlink()
+    assert refreshed is not None
+    new_target = fake_plugin_root / "scripts" / "claude-channel.sh"
+    assert symlink.resolve() == new_target.resolve()
+
+
+def test_auto_refresh_leaves_external_symlink_alone(
+    fake_plugin_root: Path,
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If symlink points OUTSIDE our plugin cache (user customization,
+    dev checkout, alternate install), don't touch it. The nag still fires
+    via _log_setup_nag for the user to investigate."""
+    monkeypatch.setattr(channel.Path, "home", lambda: tmp_path / "home")
+    # External target outside our cache
+    external = tmp_path / "elsewhere" / "claude-channel-custom.sh"
+    external.parent.mkdir(parents=True)
+    external.write_text("#!/bin/sh\necho custom\n")
+    external.chmod(0o755)
+
+    symlink = fake_home / "bin" / "claude-channel"
+    symlink.parent.mkdir(parents=True, exist_ok=True)
+    symlink.symlink_to(external)
+
+    result = channel._auto_refresh_stale_symlink()
+    assert result is None
+    # Symlink unchanged
+    assert symlink.resolve() == external.resolve()
+
+
+def test_auto_refresh_leaves_non_symlink_alone(
+    fake_plugin_root: Path,  # noqa: ARG001
+    fake_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If something is at ~/bin/claude-channel but isn't a symlink (user
+    installed a real script there), leave it alone."""
+    monkeypatch.setattr(channel.Path, "home", lambda: fake_home)
+    bin_dir = fake_home / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    real_file = bin_dir / "claude-channel"
+    real_file.write_text("#!/bin/sh\necho real_script\n")
+    real_file.chmod(0o755)
+    assert not real_file.is_symlink()
+
+    result = channel._auto_refresh_stale_symlink()
+    assert result is None
+    # Still a real file, not a symlink
+    assert not real_file.is_symlink()
+    assert real_file.read_text() == "#!/bin/sh\necho real_script\n"
+
+
+def test_log_setup_nag_auto_refreshes_and_logs_info(
+    fake_plugin_root: Path,
+    fake_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end: stale symlink into our cache → nag auto-refreshes +
+    logs INFO; the WARNING about stale symlink does NOT fire afterward
+    (state becomes 'current')."""
+    cache_marker = tmp_path / "home" / ".claude/plugins/cache/infiquetra-plugins/redis-channel"
+    old_version_dir = cache_marker / "0.4.5" / "scripts"
+    old_version_dir.mkdir(parents=True)
+    old_wrapper = old_version_dir / "claude-channel.sh"
+    old_wrapper.write_text("#!/bin/sh\necho old\n")
+    old_wrapper.chmod(0o755)
+    monkeypatch.setattr(channel.Path, "home", lambda: tmp_path / "home")
+
+    symlink = fake_home / "bin" / "claude-channel"
+    symlink.parent.mkdir(parents=True, exist_ok=True)
+    symlink.symlink_to(old_wrapper)
+
+    # Also scaffold configs so source-env.sh + registry.json are present,
+    # leaving symlink staleness as the ONLY issue.
+    channel._do_setup(link_wrapper=False, scaffold_configs=True)
+
+    with caplog.at_level("INFO", logger="redis_channel.channel"):
+        channel._log_setup_nag()
+
+    # Auto-refresh fired
+    assert any("auto-refreshed" in r.message for r in caplog.records)
+    # No "setup is incomplete" warning (state was fixed in-place)
+    assert not any(
+        "setup is incomplete" in r.message for r in caplog.records
+    )
+
+
+# ─── Phase 6: /redis-channel-configure ─────────────────────────────────────
+
+
+def test_configure_creates_fresh_registry(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """Fresh: no existing registry.json → create it with the new endpoint."""
+    result = channel._configure_endpoint(
+        endpoint_name="default",
+        redis_url="redis://host.example.com:6379/0",
+        redis_password_env="MY_REDIS_PASSWORD",
+        display_name="Default endpoint",
+        set_default=True,
+    )
+    assert result["ok"] is True
+    assert result["action"] == "created"
+    assert result["endpoint_count"] == 1
+    assert result["default_endpoint"] == "default"
+    cfg_path = Path(result["written"])
+    assert cfg_path.exists()
+    data = json.loads(cfg_path.read_text())
+    assert "default" in data["endpoints"]
+    ep = data["endpoints"]["default"]
+    assert ep["redis_url"] == "redis://host.example.com:6379/0"
+    assert ep["redis_password_env"] == "MY_REDIS_PASSWORD"
+    assert ep["display_name"] == "Default endpoint"
+    assert data["defaults"]["default_endpoint"] == "default"
+
+
+def test_configure_adds_second_endpoint_preserves_first(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """Adding a second endpoint preserves the first + defaults."""
+    channel._configure_endpoint(
+        endpoint_name="prod",
+        redis_url="redis://prod:6379/0",
+        redis_password_env="PROD_PWD",
+        set_default=True,
+    )
+    result = channel._configure_endpoint(
+        endpoint_name="staging",
+        redis_url="redis://staging:6379/0",
+        redis_password_env="STAGING_PWD",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "created"
+    assert result["endpoint_count"] == 2
+    # Default still 'prod'
+    assert result["default_endpoint"] == "prod"
+
+    data = json.loads(Path(result["written"]).read_text())
+    assert set(data["endpoints"]) == {"prod", "staging"}
+    assert data["endpoints"]["prod"]["redis_url"] == "redis://prod:6379/0"
+    assert data["endpoints"]["staging"]["redis_url"] == "redis://staging:6379/0"
+
+
+def test_configure_updates_existing_endpoint(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """Re-running configure for the same name overwrites + reports 'updated'."""
+    channel._configure_endpoint(
+        endpoint_name="default",
+        redis_url="redis://old:6379/0",
+        redis_password_env="OLD_PWD",
+    )
+    result = channel._configure_endpoint(
+        endpoint_name="default",
+        redis_url="redis://new:6379/0",
+        redis_password_env="NEW_PWD",
+        display_name="Renamed",
+    )
+    assert result["ok"] is True
+    assert result["action"] == "updated"
+    assert result["endpoint_count"] == 1
+    data = json.loads(Path(result["written"]).read_text())
+    assert data["endpoints"]["default"]["redis_url"] == "redis://new:6379/0"
+    assert data["endpoints"]["default"]["redis_password_env"] == "NEW_PWD"
+    assert data["endpoints"]["default"]["display_name"] == "Renamed"
+
+
+def test_configure_rejects_invalid_endpoint_name(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    for bad in ["BadCaps", "-leading-dash", "spaces here", "", "_underscore_start"]:
+        result = channel._configure_endpoint(
+            endpoint_name=bad,
+            redis_url="redis://h:6379/0",
+        )
+        assert result["ok"] is False, bad
+        assert "invalid endpoint_name" in result["error"], bad
+
+
+def test_configure_rejects_invalid_redis_url(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    for bad in ["http://h:6379", "h:6379/0", "", "ftp://h"]:
+        result = channel._configure_endpoint(
+            endpoint_name="x",
+            redis_url=bad,
+        )
+        assert result["ok"] is False, bad
+        assert "invalid redis_url" in result["error"], bad
+
+
+def test_configure_normalizes_empty_password_env_to_none(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """Empty string redis_password_env → omitted from the written entry."""
+    result = channel._configure_endpoint(
+        endpoint_name="noauth",
+        redis_url="redis://h:6379/0",
+        redis_password_env="   ",  # whitespace
+    )
+    assert result["ok"] is True
+    data = json.loads(Path(result["written"]).read_text())
+    assert "redis_password_env" not in data["endpoints"]["noauth"]
+
+
+def test_configure_atomic_write_doesnt_leave_tmp(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """No .tmp file should remain after a successful write."""
+    result = channel._configure_endpoint(
+        endpoint_name="x",
+        redis_url="redis://h:6379/0",
+    )
+    cfg_path = Path(result["written"])
+    tmp = cfg_path.with_suffix(".json.tmp")
+    assert not tmp.exists()
+
+
+def test_configure_rejects_malformed_existing_registry(
+    fake_home: Path,  # noqa: ARG001
+) -> None:
+    """If existing registry.json is not valid JSON, surface a parse error +
+    don't clobber it."""
+    cfg_path = channel.CHANNEL_CONFIG_DIR / "registry.json"
+    channel.CHANNEL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text("{ this is not json")
+    before = cfg_path.read_text()
+
+    result = channel._configure_endpoint(
+        endpoint_name="x",
+        redis_url="redis://h:6379/0",
+    )
+    assert result["ok"] is False
+    assert "parse error" in result["error"]
+    # Original content untouched
+    assert cfg_path.read_text() == before


### PR DESCRIPTION
## Summary

Phase 6 wraps up the CC-plugin side of the master plan. Three deliverables in one PR:

**`/redis-channel-configure`** — was a Phase-0 stub; now implemented. New `redis_channel_configure` MCP tool atomically writes/updates `~/.claude/channels/redis-channel/registry.json`. Idempotent merge (other endpoints + defaults preserved). Validates endpoint name regex + redis_url scheme. Slash command walks user through fields and reminds them about `source-env.sh` after.

**Auto-refresh stale symlink** — extends v0.4.14 startup nag. When `~/bin/claude-channel` points into our plugin cache but at an older version (common case after plugin update), the MCP server self-heals on next boot + logs INFO. Scope-limited to symlinks targeting our cache hierarchy; user customizations elsewhere are left alone.

**`ARCHITECTURE.md`** — full plugin-side system narrative with Mermaid diagram. Roles, round-trip flow, components, state + lifecycle, config files, Claude Code integration knobs, known limitations. Router-specific details stay in router repo per scope discipline.

**README polish** — Status section reflects what's actually shipped (P1, P2, P2.5, P6); Quickstart rewritten around `/redis-channel-setup` + `/redis-channel-configure`; bg limitation called out at top.

## Test plan
- [x] 14 new tests (6 auto-refresh + 8 configure); 187 redis-channel tests total; ruff clean
- [x] JSON valid; versions consistent (0.5.0 across plugin.json, server/__init__.py, marketplace.json)
- [ ] After merge + plugin reinstall: `/redis-channel-configure default` writes a new endpoint; MCP startup auto-refreshes the symlink at v0.5.0