### PR TITLE
feat(team-execution): add validator orchestration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -275,8 +275,8 @@
     {
       "name": "team-execution",
       "source": "./plugins/team-execution",
-      "version": "1.5.0",
-      "description": "Two-phase plan execution with multi-reviewer consensus. Auto-suggests on non-trivial plans, plus /team-setup wizard for tmux + Claude settings.",
+      "version": "2.0.0",
+      "description": "Two-phase plan execution with reviewer consensus, validator gates, and guarded nonprod automation for Infiquetra repositories.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"
@@ -289,6 +289,9 @@
         "code-review",
         "consensus",
         "reviewers",
+        "validators",
+        "automation",
+        "nonprod",
         "workflow"
       ],
       "category": "development"

--- a/.codex/plans/2026-05-27-team-execution-v2-validator-port.md
+++ b/.codex/plans/2026-05-27-team-execution-v2-validator-port.md
@@ -1,0 +1,42 @@
+# team-execution v2.0.0 Validator Port
+
+## Goal
+
+Port `team-execution` from reviewer-only orchestration to reviewer, validator, and
+nonprod automation guidance for Infiquetra repositories.
+
+## Scope
+
+- Bump plugin and marketplace metadata to `2.0.0`.
+- Add validator roster, references, agent prompts, and execution rules.
+- Add appsec audit skill for URL and input trust-boundary review.
+- Reconcile `/team-setup` references with real bundled assets.
+- Preserve current base reviewers, including `architecture-reviewer`.
+- Remove source-provenance wording and source-domain identifiers from plugin files.
+
+## Phases
+
+1. Baseline inspect current plugin, tests, manifests, setup assets, and journal.
+2. Add targeted failing tests for the v2 contract.
+3. Update plugin docs, commands, references, agents, skills, assets, and metadata.
+4. Run targeted plugin tests, metadata/link/forbidden-term checks, and supported repo checks.
+5. Update engineering journal and commit scoped changes.
+
+## Current State
+
+- Branch: `feat/team-execution-v2-validator-port`
+- Metadata, docs, references, validator agents, appsec skill, and setup assets updated.
+- Engineering journal entries added for setup asset drift and validator orchestration decision.
+- Tracked source-domain residue removed from scaffold templates, examples, changelogs, and tests.
+
+## Checks Run
+
+- `git status --short`
+- Team-execution file inventory and content inspection
+- `uv run pytest tests/test_team_execution_plugin.py -q` (red, then green)
+- `uv run ruff check .`
+- `uv run pytest` (553 passed)
+- `uv run bandit -r plugins/team-execution`
+- `uv run bandit -r plugins/` (fails on pre-existing low-severity findings outside this change)
+- `git diff --check`
+- transient tracked-file forbidden-term scan

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,38 @@
 
 ---
 
+## 2026-05-27
+
+### `team-execution` v2 uses context-selected validators and guarded nonprod automation (commit pending)  {#team-execution-v2-validators}
+
+**Decision.** Evolve `team-execution` from reviewer-only orchestration into a reviewer plus
+validator workflow. Validators are a maximum available roster, selected by repository context,
+changed files, workflows, contracts, docs, tests, and optional `.team-execution.json`. Automation
+is allowed only for `github.com/infiquetra/*`, only after gates pass, and only for nonprod or
+publish-nonprod workflows.
+
+**Rejected alternatives.**
+- *Spawn every validator on every plan.* Rejected: creates noise, cost, and false blockers for
+  validators unrelated to the change.
+- *Let validators run before reviewer consensus.* Rejected: reviewer non-consensus means the
+  implementation is still unstable; validator findings would be stale or duplicated.
+- *Allow generic deployment automation once checks pass.* Rejected: production, staging, branch
+  deletion, force-push, and credential changes carry a higher operational risk than this plugin
+  should automate.
+
+**Rationale.** Context selection keeps validator evidence proportional to risk while still making
+the approved roster available. Gating validators after reviewer consensus creates a stable artifact
+to scan and test. Nonprod-only automation gives useful end-to-end validation without turning a
+planning plugin into a production deployment system.
+
+**Revisit when.** We have repeated evidence that a validator category is always selected together
+with another category and should be merged, or when production deployment safety is owned by a
+separate audited release plugin.
+
+**Refs.** LEARNINGS [team setup asset drift](LEARNINGS.md#team-setup-asset-drift).
+
+---
+
 ## 2026-05-25
 
 ### `redis-channel` plugin: Hermes-agnostic Claude Code channel over Redis Streams (commit pending)  {#redis-bridge-decoupled}

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,35 @@
 
 ---
 
+## 2026-05-27
+
+### Setup commands must prove every bundled asset path exists  {#team-setup-asset-drift}
+
+**Context.** The `team-execution` v2 validator port reworked `/team-setup` and exposed that the
+existing command referenced `docs/example_tmux.conf` and `docs/agent-overflow.sh`, but the plugin
+did not actually ship those files.
+
+**Evidence.** `tests/test_team_execution_plugin.py::test_team_setup_references_existing_assets`
+failed before the port because `plugins/team-execution/docs/example_tmux.conf` was absent. The
+fix adds both files under `plugins/team-execution/docs/` and keeps `/team-setup` pointing at those
+packaged paths.
+
+**Mechanism.** The setup command evolved as operational documentation, but no repository check tied
+its copy commands to real plugin assets. The command could therefore promise an install path that
+worked only in a developer's local config, not from a fresh plugin package.
+
+**Fix.** Add packaged setup assets and a contract test that every `/team-setup` asset reference
+resolves in the plugin tree (commit pending).
+
+**Validation.** `uv run pytest tests/test_team_execution_plugin.py -q` now passes.
+
+**Generalizable rule.** Any plugin command that copies, installs, or references bundled files needs
+a manifest-style test proving those paths exist in the package, not just in a developer's machine.
+
+**Refs.** DECISIONS [team-execution validators](DECISIONS.md#team-execution-v2-validators).
+
+---
+
 ## 2026-05-26
 
 ### Channel-plugin notifications don't reach `--bg` / `/bg` sessions: Claude Code's carry-through set excludes channels  {#cc-channels-bg-not-supported}

--- a/plugins/docs-generator/README.md
+++ b/plugins/docs-generator/README.md
@@ -183,7 +183,7 @@ $ python3 scripts/docs_generator.py generate --type api-spec --service wallet
 ## Overview
 Digital wallet service for vehicle custody platform.
 
-**Base URL**: `https://wallet.vecu.example.com`
+**Base URL**: `https://wallet.infiquetra.example.com`
 **Authentication**: JWT Bearer token
 
 ## Endpoints
@@ -332,7 +332,7 @@ fi
 service:
   name: wallet-service
   description: Digital wallet service for vehicle custody
-  base_url: https://wallet.vecu.example.com
+  base_url: https://wallet.infiquetra.example.com
 
 documentation:
   output_dir: docs
@@ -422,7 +422,7 @@ python3 scripts/docs_generator.py generate --template custom-readme.md.j2
 ### Diagram Customization
 ```bash
 # Generate diagrams with custom styling
-python3 scripts/docs_generator.py diagrams --style vecu --output docs/images/
+python3 scripts/docs_generator.py diagrams --style infiquetra --output docs/images/
 ```
 
 ## Notes

--- a/plugins/docs-generator/skills/generate-docs/scripts/docs_generator.py
+++ b/plugins/docs-generator/skills/generate-docs/scripts/docs_generator.py
@@ -140,7 +140,7 @@ Copyright © 2024 your organization Inc.
 ## Overview
 REST API for {self.service_name.replace("-", " ").title()} service.
 
-**Base URL**: `https://{self.service_name}.vecu.example.com`
+**Base URL**: `https://{self.service_name}.infiquetra.example.com`
 **Authentication**: JWT Bearer token
 
 ## Authentication
@@ -262,7 +262,7 @@ headers = {{"Authorization": f"Bearer {{token}}"}}
 
 # List resources
 response = requests.get(
-    "https://{self.service_name}.vecu.example.com/resources",
+    "https://{self.service_name}.infiquetra.example.com/resources",
     headers=headers
 )
 resources = response.json()

--- a/plugins/identity-toolkit/skills/digital-identity-design/references/identity-architecture-patterns.md
+++ b/plugins/identity-toolkit/skills/digital-identity-design/references/identity-architecture-patterns.md
@@ -665,7 +665,7 @@ class DIDAuthentication:
     "kid": "key-1"
   },
   "payload": {
-    "iss": "https://auth.vecu.com",
+    "iss": "https://auth.infiquetra.com",
     "sub": "user-123",
     "aud": "wallet-service",
     "exp": 1735689600,

--- a/plugins/pagerduty/skills/pagerduty-teams/SKILL.md
+++ b/plugins/pagerduty/skills/pagerduty-teams/SKILL.md
@@ -35,7 +35,7 @@ echo $PAGERDUTY_API_KEY
 python plugins/pagerduty/skills/pagerduty-incidents/scripts/pagerduty_client.py teams list
 
 # Search teams by name
-python plugins/pagerduty/skills/pagerduty-incidents/scripts/pagerduty_client.py teams list --query "vecu"
+python plugins/pagerduty/skills/pagerduty-incidents/scripts/pagerduty_client.py teams list --query "infiquetra"
 ```
 
 #### Get Team Details
@@ -213,7 +213,7 @@ Returns:
 **User**: "Show me all Infiquetra teams"
 
 **Response**:
-1. List teams with `--query "vecu"`
+1. List teams with `--query "infiquetra"`
 2. Display team names, IDs, member counts
 3. Show associated services per team
 4. Highlight primary contact/manager

--- a/plugins/python-toolkit/references/lambda-patterns.md
+++ b/plugins/python-toolkit/references/lambda-patterns.md
@@ -27,7 +27,7 @@ from aws_lambda_powertools.metrics import MetricUnit
 
 logger = Logger()
 tracer = Tracer()
-metrics = Metrics(namespace="VECUWalletService")
+metrics = Metrics(namespace="InfiquetraWalletService")
 
 
 @logger.inject_lambda_context(log_event=True)
@@ -224,7 +224,7 @@ def handler(event, context):
 from aws_lambda_powertools import Metrics
 from aws_lambda_powertools.metrics import MetricUnit
 
-metrics = Metrics(namespace="VECUWalletService", service="wallet-api")
+metrics = Metrics(namespace="InfiquetraWalletService", service="wallet-api")
 
 
 @metrics.log_metrics(capture_cold_start_metric=True)
@@ -514,16 +514,16 @@ def batch_write_transactions(transactions: list[dict]) -> None:
 from aws_lambda_powertools.utilities import parameters
 
 # Get SSM parameter
-api_key = parameters.get_parameter("/vecu/wallet/api-key")
+api_key = parameters.get_parameter("/infiquetra/wallet/api-key")
 
 # Get secret from Secrets Manager
-db_credentials = parameters.get_secret("vecu/wallet/db-creds")
+db_credentials = parameters.get_secret("infiquetra/wallet/db-creds")
 
 # Get multiple parameters with caching
 @parameters.clear_cache  # Clear cache after function execution
 def handler(event, context):
     # Cached for 5 minutes by default
-    config = parameters.get_parameters("/vecu/wallet/config")
+    config = parameters.get_parameters("/infiquetra/wallet/config")
 
     return {"statusCode": 200}
 ```
@@ -597,7 +597,7 @@ from aws_lambda_powertools.metrics import MetricUnit
 # Initialize Powertools
 logger = Logger(service="wallet-service")
 tracer = Tracer(service="wallet-service")
-metrics = Metrics(namespace="VECUWalletService", service="wallet-api")
+metrics = Metrics(namespace="InfiquetraWalletService", service="wallet-api")
 app = APIGatewayRestResolver()
 
 # DynamoDB setup

--- a/plugins/sdk-lifecycle/README.md
+++ b/plugins/sdk-lifecycle/README.md
@@ -40,7 +40,7 @@ python plugins/sdk-lifecycle/skills/sdk-scaffolding/scripts/scaffold_sdk.py \
   --name "my-sdk" \
   --language "python" \
   --description "Python SDK for Infiquetra Wallet Service" \
-  --api-url "https://wallet.vecu.example.com"
+  --api-url "https://wallet.infiquetra.example.com"
 ```
 
 **Output:**
@@ -367,7 +367,7 @@ git push --tags
 - [Infiquetra Test Suite](../test-suite) - Parallel quality checks
 - [Infiquetra Docs Generator](../docs-generator) - Service documentation
 - [your organization package registry (PyPI/npm)](https://registry.example.com)
-- [Infiquetra documentation portal](https://documentation portal.vecu.example.com)
+- [Infiquetra documentation portal](https://documentation portal.infiquetra.example.com)
 
 ## Contributing
 

--- a/plugins/sdk-lifecycle/skills/sdk-documentation/SKILL.md
+++ b/plugins/sdk-lifecycle/skills/sdk-documentation/SKILL.md
@@ -249,12 +249,12 @@ Use JSDoc comments:
  *
  * @example
  * ```typescript
- * const client = new VECUServiceClient({ apiKey: 'your-key' });
+ * const client = new InfiquetraServiceClient({ apiKey: 'your-key' });
  * const resource = await client.getResource('res-123');
  * console.log(resource.name);
  * ```
  */
-export class VECUServiceClient {
+export class InfiquetraServiceClient {
   /**
    * Gets a resource by ID.
    *
@@ -296,7 +296,7 @@ This example demonstrates:
 """
 
 import asyncio
-from vecu_service_sdk import Client, SDKError
+from infiquetra_service_sdk import Client, SDKError
 
 
 async def main():

--- a/plugins/sdk-lifecycle/skills/sdk-scaffolding/SKILL.md
+++ b/plugins/sdk-lifecycle/skills/sdk-scaffolding/SKILL.md
@@ -42,7 +42,7 @@ Before scaffolding, verify:
 ### Step 1: Gather Project Information
 
 Ask the user for:
-- **SDK name** (e.g., "my-sdk", "infiquetra.SDK", "@vecu/identity-sdk")
+- **SDK name** (e.g., "my-sdk", "infiquetra.SDK", "@infiquetra/identity-sdk")
 - **Language** (.NET, Python, or TypeScript)
 - **Description** (brief description of SDK purpose)
 - **Target API** (base URL of the service this SDK will wrap)
@@ -67,7 +67,7 @@ The script will create:
 ```
 my-sdk/
 ├── src/
-│   └── vecu_my_sdk/
+│   └── infiquetra_my_sdk/
 │       ├── __init__.py
 │       ├── client.py
 │       ├── models.py
@@ -189,7 +189,7 @@ target-version = "py312"
 #### TypeScript (package.json)
 ```json
 {
-  "name": "@vecu/my-sdk",
+  "name": "@infiquetra/my-sdk",
   "version": "0.1.0",
   "description": "TypeScript SDK for Infiquetra Wallet Service",
   "main": "dist/index.js",

--- a/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/dotnet-template.md
+++ b/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/dotnet-template.md
@@ -59,7 +59,7 @@ infiquetra.Service.SDK/
     <Company>your organization</Company>
     <Product>Infiquetra Service SDK</Product>
     <Description>C# SDK for Infiquetra Service API</Description>
-    <PackageTags>vecu;sdk;vehicle-custody</PackageTags>
+    <PackageTags>infiquetra;sdk;vehicle-custody</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/infiquetra/service-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/infiquetra/service-sdk</RepositoryUrl>
@@ -117,7 +117,7 @@ public class ServiceClient : IDisposable
     {
         _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
         _httpClient = httpClient ?? new HttpClient();
-        _httpClient.BaseAddress = new Uri(baseUrl ?? "https://api.service.vecu.example.com");
+        _httpClient.BaseAddress = new Uri(baseUrl ?? "https://api.service.infiquetra.example.com");
         _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", _apiKey);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "service-sdk/0.1.0");

--- a/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/python-template.md
+++ b/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/python-template.md
@@ -7,7 +7,7 @@ Complete structure and patterns for Python SDK projects.
 ```
 service-sdk/
 ├── src/
-│   └── vecu_service_sdk/
+│   └── infiquetra_service_sdk/
 │       ├── __init__.py          # Package exports
 │       ├── client.py            # Main SDK client
 │       ├── models.py            # Pydantic data models
@@ -54,7 +54,7 @@ authors = [
 requires-python = ">=3.12"
 readme = "README.md"
 license = {text = "MIT"}
-keywords = ["vecu", "sdk", "vehicle-custody"]
+keywords = ["infiquetra", "sdk", "vehicle-custody"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -86,7 +86,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/infiquetra/service-sdk"
-Documentation = "https://documentation portal.vecu.example.com/service-sdk"
+Documentation = "https://documentation portal.infiquetra.example.com/service-sdk"
 Repository = "https://github.com/infiquetra/service-sdk"
 
 [build-system]
@@ -190,13 +190,13 @@ from .exceptions import (
 )
 
 
-class VECUServiceClient:
+class InfiquetraServiceClient:
     """
     Client for interacting with Infiquetra Service API.
 
     Example:
         ```python
-        async with VECUServiceClient(api_key="your-key") as client:
+        async with InfiquetraServiceClient(api_key="your-key") as client:
             resource = await client.get_resource("resource-id")
             print(resource.name)
         ```
@@ -204,7 +204,7 @@ class VECUServiceClient:
 
     def __init__(
         self,
-        base_url: str = "https://api.service.vecu.example.com",
+        base_url: str = "https://api.service.infiquetra.example.com",
         api_key: Optional[str] = None,
         timeout: float = 30.0,
         max_retries: int = 3,
@@ -401,14 +401,14 @@ class RateLimitError(SDKError):
 
 import pytest
 from unittest.mock import AsyncMock, patch
-from vecu_service_sdk import VECUServiceClient
-from vecu_service_sdk.models import Resource
+from infiquetra_service_sdk import InfiquetraServiceClient
+from infiquetra_service_sdk.models import Resource
 
 
 @pytest.fixture
 async def client():
     """Create test client."""
-    async with VECUServiceClient(api_key="test-key") as client:
+    async with InfiquetraServiceClient(api_key="test-key") as client:
         yield client
 
 

--- a/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/typescript-template.md
+++ b/plugins/sdk-lifecycle/skills/sdk-scaffolding/references/typescript-template.md
@@ -41,7 +41,7 @@ service-sdk/
 
 ```json
 {
-  "name": "@vecu/service-sdk",
+  "name": "@infiquetra/service-sdk",
   "version": "0.1.0",
   "description": "TypeScript SDK for Infiquetra Service API",
   "main": "dist/index.js",
@@ -62,7 +62,7 @@ service-sdk/
     "prepublishOnly": "npm run build && npm test"
   },
   "keywords": [
-    "vecu",
+    "infiquetra",
     "sdk",
     "vehicle-custody",
     "typescript"
@@ -73,7 +73,7 @@ service-sdk/
     "type": "git",
     "url": "https://github.com/infiquetra/service-sdk"
   },
-  "homepage": "https://documentation portal.vecu.example.com/service-sdk",
+  "homepage": "https://documentation portal.infiquetra.example.com/service-sdk",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -160,17 +160,17 @@ export interface ClientConfig {
  *
  * @example
  * ```typescript
- * const client = new VECUServiceClient({ apiKey: 'your-api-key' });
+ * const client = new InfiquetraServiceClient({ apiKey: 'your-api-key' });
  * const resource = await client.getResource('resource-id');
  * console.log(resource.name);
  * ```
  */
-export class VECUServiceClient {
+export class InfiquetraServiceClient {
   private readonly axios: AxiosInstance;
 
   constructor(config: ClientConfig) {
     const {
-      baseUrl = 'https://api.service.vecu.example.com',
+      baseUrl = 'https://api.service.infiquetra.example.com',
       apiKey,
       timeout = 30000,
       maxRetries = 3,
@@ -423,18 +423,18 @@ export class ValidationError extends SDKError {
 ## Testing Pattern (Jest)
 
 ```typescript
-import { VECUServiceClient } from '../client';
+import { InfiquetraServiceClient } from '../client';
 import { Resource } from '../models';
 import axios from 'axios';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe('VECUServiceClient', () => {
-  let client: VECUServiceClient;
+describe('InfiquetraServiceClient', () => {
+  let client: InfiquetraServiceClient;
 
   beforeEach(() => {
-    client = new VECUServiceClient({ apiKey: 'test-key' });
+    client = new InfiquetraServiceClient({ apiKey: 'test-key' });
     jest.clearAllMocks();
   });
 

--- a/plugins/sdk-lifecycle/skills/sdk-security-review/references/vulnerability-management.md
+++ b/plugins/sdk-lifecycle/skills/sdk-security-review/references/vulnerability-management.md
@@ -157,7 +157,7 @@ pip install --upgrade service-sdk>=1.2.6
 dotnet add package infiquetra.Service.SDK --version 1.2.6
 
 # TypeScript
-npm install @vecu/service-sdk@^1.2.6
+npm install @infiquetra/service-sdk@^1.2.6
 ```
 
 ## Workaround

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -152,7 +152,7 @@ The 10-step flow:
 
 ### Added
 - Initial release of sdlc-manager plugin for the Mount Olympus agent team
-- Adapted from vecu-sdlc-manager, made organization-agnostic for Infiquetra
+- Updated wording to use Infiquetra conventions consistently
 - 6 skills: sdlc-board, sdlc-issues, sdlc-labels, sdlc-metrics, sdlc-milestones, sdlc-rollout
 - 4 commands: /sdlc-board, /sdlc-create, /sdlc-metrics, /sdlc-triage
 - 1 agent: sdlc-operator

--- a/plugins/team-execution/.claude-plugin/plugin.json
+++ b/plugins/team-execution/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "team-execution",
-  "version": "1.5.0",
-  "description": "Two-phase plan execution with multi-reviewer consensus. Auto-suggests on non-trivial plans, plus /team-setup wizard for tmux + Claude settings.",
+  "version": "2.0.0",
+  "description": "Two-phase plan execution with reviewer consensus, validator gates, and guarded nonprod automation for Infiquetra repositories.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
@@ -12,6 +12,9 @@
     "plan-execution",
     "code-review",
     "consensus",
-    "reviewers"
+    "reviewers",
+    "validators",
+    "automation",
+    "nonprod"
   ]
 }

--- a/plugins/team-execution/CHANGELOG.md
+++ b/plugins/team-execution/CHANGELOG.md
@@ -1,93 +1,116 @@
-# Changelog — team-execution
+# Changelog - team-execution
 
 All notable changes to this plugin are documented here.
 
 ---
 
-## [1.5.0] — 2026-03-29
+## [2.0.0] - 2026-05-27
 
-### Fixed
-- **Workers now pack into 2x2 grids, reviewers get solo windows**: `agent-overflow.sh` completely rewritten with two-phase routing. Phase 1 (synchronous): break new pane from orchestrator window immediately. Phase 2 (background, 1s delay): read pane title and route — `worker-*` agents join into an existing `workers` window (up to 4 panes tiled), reviewers/advocates stay solo with their agent name as the window name.
-- **Shift+Down no longer intercepted by tmux**: Removed `-n` (no-prefix) flag from `S-Up`/`S-Down` bindings. Now require prefix key so terminal apps (vim, less, text selection) receive Shift+arrows normally. New binding: `prefix + Shift+Down/Up`.
-- **Window creation beeps silenced**: Added `bell-action none` and `visual-bell off` to tmux.conf.
-- **Windows named after agents**: After pane title propagates (~1s), the new window is renamed to the agent name (e.g., `security-reviewer`, `devils-advocate`) or `workers` for worker windows.
-- **Window management with many agents**: Added `prefix+w` (fullscreen window tree) and `prefix+f` (find window by name). Window name truncated to 15 chars in status bar to prevent overflow with 10+ windows.
+### Added
+- Validators are now a first-class umbrella alongside workers and reviewers.
+- Added scanner, tester, monitor, and operational validator roster:
+  `deploy-watcher`, `security-scanner`, `iac-cost-scanner`, `api-compat-scanner`,
+  `dependency-scanner`, `smoke-tester`, `scenario-tester`, `api-contract-tester`,
+  `sdk-regression-tester`, `event-flow-tester`, `ui-regression-tester`,
+  `performance-tester`, `concurrency-tester`, `github-actions-monitor`, and
+  `runtime-monitor`.
+- Added validator reference docs for registry, criteria, execution order, evidence/state
+  format, spawn quirks, and pane behavior.
+- Added optional `.team-execution.json` guidance for `required_validators`,
+  `disabled_validators`, `nonprod_workflows`, `scenario_hints`, and `smoke_targets`.
+- Added guarded nonprod automation rules for Infiquetra repositories.
+- Added `appsec-audit` skill for URL/input trust-boundary review, SSRF-style risk,
+  redirects, metadata endpoints, allowlists, and evidence-backed findings.
+- Added packaged `/team-setup` tmux assets:
+  `docs/example_tmux.conf` and `docs/agent-overflow.sh`.
 
 ### Changed
-- `agent-overflow.sh`: Full rewrite — uses `break-pane -d -P -F '#{window_id}'` to capture stable window ID at break time, routing via background subprocess
-- `tmux.conf`: Bell suppression, Shift fix, window name format, two new keybindings
-- Quick reference comments updated to describe new window layout model
+- Phase A now derives a team plan from repo type, changed files, workflows, contracts,
+  docs, tests, and optional `.team-execution.json`.
+- Phase B order is now workers, reviewer consensus, scanners, PR/CI/nonprod coordination,
+  testers, monitors, then completion.
+- Reviewer non-consensus blocks validators unless the user explicitly overrides.
+- Hard-fail scanner/tester findings block auto-merge, nonprod deploy, and completion.
+- Remediation is capped at 3 loops before escalation.
+- Plugin and marketplace metadata bumped to `2.0.0`.
+
+### Removed
+- Removed stale migration notes from the initial release entry.
 
 ---
 
-## [1.4.0] — 2026-03-29
+## [1.5.0] - 2026-03-29
 
 ### Fixed
-- **Workers no longer prompt user for permissions**: Changed worker spawn mode from `plan` to `bypassPermissions`. Claude Code's `plan` mode routes file access prompts and plan approval requests to the user — not the orchestrator. `bypassPermissions` workers run unrestricted with no user interruptions; quality control is handled entirely by the review cycle.
-- **tmux agent overflow**: `agent-overflow.sh` MAX_PANES was static at 4, allowing all 4 workers to crowd into the main window before overflow triggered. Changed to dynamic logic: main window (index 1) gets MAX_PANES=1 (agents always overflow to their own window); agent overflow windows get MAX_PANES=4.
+- Workers pack into 2x2 grids, while reviewers get solo windows.
+- Shift+Down and Shift+Up require the tmux prefix, preserving terminal-app behavior.
+- Window creation bells are silenced.
+- Windows are named after agents.
+- Window management with many agents adds prefix+w and prefix+f helpers.
 
 ### Changed
-- Step A4 team structure template: worker rows now show `bypassPermissions` mode instead of `plan (requires approval)`
-- Review Protocol note updated: "Workers run in `bypassPermissions` mode — no permission prompts, quality enforced by review cycle"
-- Step B1 rewritten from "Plan Approval Gate" to "Worker Kickoff" — workers read their tasks and begin implementing immediately; no ExitPlanMode/plan_approval_request flow for workers
-- `docs/agent-overflow.sh` (plugin copy) kept in sync with installed `~/.config/tmux/agent-overflow.sh`
+- Overflow routing uses a stable tmux window ID and delayed pane-title routing.
+- tmux configuration documents the window layout model.
 
 ---
 
-## [1.3.0] — 2026-03-29
+## [1.4.0] - 2026-03-29
+
+### Fixed
+- Workers no longer prompt the user for permissions; review cycles enforce quality.
+- Agent overflow treats the main window differently from agent overflow windows.
 
 ### Changed
-- Skill now auto-suggests during plan mode for any non-trivial plan (3+ steps, 3+ files)
-- Expanded natural language triggers: "use agents", "agent team", "agentic team", "team of agents", "agentic approach", "run with agents", etc.
-- When auto-suggesting, offers A/B choice so user can always decline
-- Skill no longer re-suggests if user declines in the same session
+- Worker rows use `bypassPermissions` mode.
+- Step B1 is the worker kickoff step.
 
-## [1.2.0] — 2026-03-29
+---
 
-### Added
-- **Step A0: Environment Pre-flight** in SKILL.md — checks CLAUDE.md handoff rule, tmux environment, and Claude settings before Phase A begins
-- **`/team-setup` command** — standalone setup wizard that validates environment, offers to install tmux config + overflow script, configures Claude settings, and manages CLAUDE.md handoff rule
-- tmux checks are opt-out: users can dismiss permanently, re-enable with `/team-setup reset`
-- Checks Claude `settings.json` for `teammateMode` and `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`
-
-## [1.1.0] — 2026-03-29
+## [1.3.0] - 2026-03-29
 
 ### Changed
-- Phase A now calls `ExitPlanMode` itself (new Step A5) — plan is a single atomic artifact
-- Added Critical Constraints block at Phase B entry: TeamCreate is the ONLY permitted first action
-- Strengthened CLAUDE.md auto-handoff rule with explicit prohibitions against Agent tool usage
+- Skill auto-suggests during plan mode for non-trivial plans.
+- Natural-language triggers include agent-team phrasing.
+- The user can decline team planning for the current session.
 
-## [1.0.0] — 2026-03-25
+---
+
+## [1.2.0] - 2026-03-29
 
 ### Added
-- Initial release of the `team-execution` plugin (ported from vecu-team-execution v2.0.0, made organization-agnostic)
-- Two-phase execution model: Phase A during plan mode, Phase B orchestrated directly by Claude
-- `team-execution` skill: Phase A team planning + Phase B orchestration protocol
-- `/team-execute` slash command
+- Environment pre-flight checks for the handoff rule, tmux environment, and settings.
+- `/team-setup` wizard for setup validation and guided fixes.
+- Dismissible tmux checks.
+
+---
+
+## [1.1.0] - 2026-03-29
+
+### Changed
+- Phase A submits the plan as one atomic artifact.
+- Phase B entry constraints require the team handoff as the first action.
+
+---
+
+## [1.0.0] - 2026-03-25
+
+### Added
+- Initial release of the `team-execution` plugin.
+- Two-phase execution model: Phase A during planning, Phase B direct orchestration.
+- `team-execution` skill.
+- `/team-execute` slash command.
 - 3 base reviewers always present:
-  - `devils-advocate-reviewer` (red): challenges assumptions, edge cases, failure modes
-  - `security-reviewer` (orange): OWASP/secrets/auth/PII coverage
-  - `architecture-reviewer` (purple): design patterns, separation of concerns, convention adherence
-- 7 optional reviewers triggered by keyword detection:
-  - `infra-reviewer` (blue): CDK/AWS/Lambda/DynamoDB
-  - `api-reviewer` (green): API design/versioning/deprecation
-  - `testing-reviewer` (yellow): test coverage/patterns
-  - `code-quality-reviewer` (cyan): DRY/SOLID/complexity/naming
-  - `privacy-reviewer` (pink): privacy by design/PII/GDPR
-  - `clarity-reviewer` (teal): docs readability/structure/understandability
-  - `ai-usefulness-reviewer` (gold): AI-consumability of specs/issues
-- Reference files:
-  - `reviewer-registry.md`: keyword trigger map for optional reviewers
-  - `review-criteria.md`: scoring rubrics for all reviewer types
-  - `consensus-protocol.md`: 3-iteration process, scoring thresholds, escalation
-- Plan triage escape hatch for trivial config-only changes
-- Plan type classification: code vs docs/specs vs mixed
-- Claude acts as orchestrator directly — no separate execution-lead agent needed
-
-### Changed from vecu-team-execution v2.0.0
-- Removed `execution-lead` agent — Claude orchestrates directly
-- Replaced `adr-reviewer` with `architecture-reviewer` (project-agnostic pattern/convention review)
-- Removed all organization-specific ADR path dependencies
-- Removed hardcoded ADR references (ADR-005, ADR-006, ADR-013, ADR-027)
-- Updated all file paths to `team-execution/` prefix
-- Updated author and repository metadata to Infiquetra
+  - `devils-advocate-reviewer`: assumptions, edge cases, failure modes.
+  - `security-reviewer`: OWASP, secrets, auth/authZ, and PII coverage.
+  - `architecture-reviewer`: design patterns, separation of concerns, and conventions.
+- 7 optional reviewers triggered by context:
+  - `infra-reviewer`: cloud infrastructure.
+  - `api-reviewer`: API design, versioning, and deprecation.
+  - `testing-reviewer`: test coverage and patterns.
+  - `code-quality-reviewer`: DRY, complexity, naming, and patterns.
+  - `privacy-reviewer`: privacy by design and PII handling.
+  - `clarity-reviewer`: documentation clarity.
+  - `ai-usefulness-reviewer`: AI-consumability of specs and issues.
+- Reference files for reviewer registry, review criteria, and consensus protocol.
+- Plan triage escape hatch for trivial config-only changes.
+- Plan type classification for code, docs/specs, and mixed plans.

--- a/plugins/team-execution/README.md
+++ b/plugins/team-execution/README.md
@@ -1,13 +1,18 @@
 # team-execution
 
-Two-phase plan execution with automatic multi-reviewer consensus workflow.
+Two-phase plan execution with reviewer consensus, validator gates, and guarded nonprod
+automation for Infiquetra repositories.
 
-**Phase A** runs during plan mode: reads the plan, derives workers from phases, detects optional
-reviewers by keyword, and embeds a `## Team Structure` section into the plan.
+**Phase A** runs during planning. It reads the requested work, inspects repository signals,
+classifies the repo and risk profile, derives workers, reviewers, and selected validators, and
+embeds a `## Team Structure` plus validator plan into the approved plan.
 
-**Phase B** runs after plan exit: a global CLAUDE.md rule sees `## Team Structure` and fires
-TeamCreate automatically. Claude orchestrates workers through plan approval gates, parallel
-execution, and a max-3-iteration review cycle with >= 9.0 consensus threshold.
+**Phase B** runs after plan approval. Workers complete the change, reviewers reach consensus,
+scanners validate the local result, CI and optional nonprod automation are coordinated, and
+testers/monitors validate the deployed nonprod result.
+
+Validators are available as a roster. They are selected by task context; they are not spawned
+all at once.
 
 ---
 
@@ -17,184 +22,147 @@ execution, and a max-3-iteration review cycle with >= 9.0 consensus threshold.
 /team-execute
 ```
 
-Or describe what you want to build — Claude enters plan mode, the skill embeds the Team
-Structure, and execution begins automatically when you exit plan mode.
+Or provide an existing plan:
 
-If you already have a written plan:
 ```
 /team-execute [paste plan here or provide file path]
 ```
 
----
-
-## Setup: CLAUDE.md Handoff Rule
-
-This plugin requires one rule in your global `~/.claude/CLAUDE.md` to enable the automatic
-Phase A → Phase B handoff:
-
-```markdown
-## Team Execution Auto-Handoff
-
-When a plan exits plan mode and contains an explicit **## Team Structure** section with named
-agents, skip all skill invocations and go directly to TeamCreate. Parse the Team Structure
-table for workers and reviewers, then follow the Phase B orchestration protocol from
-`team-execution/skills/team-execution/SKILL.md`.
-```
-
-Without this rule, Phase A will embed the Team Structure but execution won't start automatically
-on plan exit.
-
----
-
-## How It Works
+Run setup checks:
 
 ```
-Phase A: During Plan Mode
-  → /team-execute enters plan mode
-  → Skill reads plan, classifies type (code/docs/mixed)
-  → Triage check: trivial config? offer to skip
-  → Detect optional reviewers from plan keywords
-  → Derive workers from plan phases
-  → User confirms team lineup
-  → Skill embeds ## Team Structure into the plan
-  → User exits plan mode
-
-                    ↓ CLAUDE.md handoff ↓
-
-Phase B: After Plan Exit (automatic)
-  → CLAUDE.md rule sees ## Team Structure → fires TeamCreate
-  → Claude parses Team Structure, starts 4-step protocol:
-
-  Step 1: Worker Kickoff
-    → Workers execute (bypassPermissions — no user prompts)
-    → Claude monitors progress via messaging
-    → Redirects if a worker goes off-track
-
-  Step 2: Execution
-    → Workers implement in parallel where tasks allow
-    → Claude monitors + unblocks dependencies
-
-  Step 3: Review Cycle (max 3 iterations)
-    → All reviewers score in parallel (5 dimensions each, 0-10)
-    → If all >= 9.0 → consensus → done
-    → Else: fixes routed to workers → only failed reviewers re-run
-
-  Step 4: Completion
-    → Final score report
-    → Commit if needed
-    → Team shutdown
+/team-setup
 ```
-
----
-
-## The CLAUDE.md Handoff Mechanism
-
-The transition from Phase A to Phase B works through the rule in your global `~/.claude/CLAUDE.md`.
-
-When the plan exits plan mode with a `## Team Structure` section embedded, this rule fires
-automatically — no explicit `/team-execute` needed post-planning. This is why the skill
-must embed the section BEFORE ExitPlanMode, not after.
 
 ---
 
 ## What You Get
 
-### Always Included
+### Base Reviewers
 
-| Reviewer | Color | Focus |
-|----------|-------|-------|
-| Devil's Advocate | 🔴 Red | Assumptions, edge cases, failure modes, scope creep |
-| Security Reviewer | 🟠 Orange | OWASP Top 10, secrets, auth/authZ, PII |
-| Architecture Reviewer | 🟣 Purple | Design patterns, separation of concerns, convention adherence |
+Always included:
 
-### Automatically Suggested (by keyword detection)
+| Reviewer | Focus |
+|----------|-------|
+| `devils-advocate-reviewer` | Assumptions, edge cases, failure modes, scope creep |
+| `security-reviewer` | OWASP Top 10, secrets, auth/authZ, PII, supply chain |
+| `architecture-reviewer` | Design patterns, separation of concerns, convention adherence |
 
-| Trigger Keywords | Reviewer |
-|-----------------|----------|
-| CDK, Lambda, DynamoDB, S3, IAM, KMS, AWS | 🔵 Infra Reviewer |
-| API, endpoint, REST, OpenAPI, versioning | 🟢 API Reviewer |
-| pytest, test, coverage, mock, fixture | 🟡 Testing Reviewer |
-| refactor, DRY, SOLID, complexity, patterns | 🩵 Code Quality Reviewer |
-| PII, GDPR, consent, retention, privacy | 🩷 Privacy Reviewer |
-| docs, README, specification, guide, runbook | 🩵 Clarity Reviewer |
-| SKILL.md, GitHub issue, acceptance criteria | 🟡 AI Usefulness Reviewer |
+Optional reviewers are still available for infrastructure, API, testing, code quality,
+privacy, clarity, and AI-usefulness review.
+
+### Validators
+
+Validators run after worker completion and reviewer consensus. They are grouped by the signal
+they provide:
+
+| Group | Agents |
+|-------|--------|
+| Scanners | `security-scanner`, `iac-cost-scanner`, `api-compat-scanner`, `dependency-scanner` |
+| Testers | `smoke-tester`, `scenario-tester`, `api-contract-tester`, `sdk-regression-tester`, `event-flow-tester`, `ui-regression-tester`, `performance-tester`, `concurrency-tester` |
+| Monitors | `github-actions-monitor`, `runtime-monitor` |
+| Operational | `deploy-watcher` |
+
+Selected validators use OSS/free tools when applicable: Semgrep, Bandit, pip-audit, Trivy,
+Gitleaks, detect-secrets, Checkov, oasdiff, Schemathesis, Playwright, and k6. Missing selected
+tools fail loud with setup guidance.
 
 ---
 
-## Team Structure Format
+## Optional Configuration
 
-The canonical format embedded into plans:
+Target repositories may define `.team-execution.json`. Absence is valid; the skill infers from
+changed files, workflows, contracts, docs, tests, and repository layout.
 
-```markdown
-## Team Structure
+```json
+{
+  "required_validators": ["security-scanner", "smoke-tester"],
+  "disabled_validators": ["performance-tester"],
+  "nonprod_workflows": ["publish-nonprod.yml"],
+  "scenario_hints": ["checkout flow", "webhook replay"],
+  "smoke_targets": ["https://example-nonprod.internal/health"]
+}
+```
 
-| Agent | Role | Mode | Responsibilities |
-|-------|------|------|------------------|
-| `worker-1` | [Phase 1 name] | bypassPermissions | [Tasks from plan] |
-| `worker-2` | [Phase 2 name] | bypassPermissions | [Tasks from plan] |
-| `security-reviewer` | Security Reviewer | general-purpose | OWASP, secrets, auth/authZ, PII |
-| `devils-advocate` | Devil's Advocate | general-purpose | Assumptions, edge cases, failure modes |
-| `architecture-reviewer` | Architecture Reviewer | general-purpose | Design patterns, separation of concerns, conventions |
+The config may require or disable validators, name nonprod workflows, and provide scenario or
+smoke-test hints. Required validators that cannot run block automation and completion until the
+missing setup is resolved or the user explicitly changes the plan.
 
-### Review Protocol
-- Consensus threshold: **>= 9.0/10** from every reviewer
-- Maximum **3 review iterations**
-- Security/auth < 5.0 is a **blocking stop**
-- Workers run in `bypassPermissions` mode — no permission prompts, quality enforced by review cycle
+---
 
-### Reference Files
+## Phase B Order
+
+1. Workers complete approved implementation tasks.
+2. Reviewers run the consensus protocol.
+3. Reviewer non-consensus blocks validators unless the user explicitly overrides.
+4. Scanners run against the local result.
+5. PR, CI, merge, and nonprod deployment are coordinated only after gates pass.
+6. Testers validate the deployed nonprod result.
+7. Monitors verify GitHub Actions and runtime signals.
+8. Completion reports evidence, state paths, residual risks, and blocked automation.
+
+Hard-fail scanner or tester findings block auto-merge, nonprod deployment, and completion.
+The orchestrator may run a maximum of 3 remediation loops before escalating to the user.
+
+---
+
+## Automation Guardrails
+
+Automation is allowed only when all of these are true:
+
+- Repository remote matches `github.com/infiquetra/*`.
+- The work follows the repo default branch model.
+- Reviewer, scanner, CI, and required tester gates passed.
+- The workflow is explicitly nonprod or publish-nonprod.
+- No production, staging, force-push, branch deletion, or credential-changing action is involved.
+
+Any ambiguous signal blocks automation.
+
+---
+
+## Validator State
+
+Validator run state is JSON under ignored repo-local:
+
+```
+.claude/team-execution/validators/
+```
+
+If `.claude/` is not ignored in the target repository, the skill instructs the user to add an
+ignore rule or use a user-local fallback:
+
+```
+~/.claude/team-execution/state/<repo>/
+```
+
+State files record selected validators, commands, tool availability, evidence paths, findings,
+remediation loops, and final gate status.
+
+---
+
+## Setup Assets
+
+`/team-setup` validates the handoff rule, tmux display configuration, and bundled assets:
+
+- `docs/example_tmux.conf`
+- `docs/agent-overflow.sh`
+
+The setup command copies these assets only after user confirmation and reports manual setup
+instructions if it cannot find them.
+
+---
+
+## Reference Files
+
 - `team-execution/skills/team-execution/references/reviewer-registry.md`
 - `team-execution/skills/team-execution/references/review-criteria.md`
 - `team-execution/skills/team-execution/references/consensus-protocol.md`
-```
-
-Note: No `lead` row — Claude orchestrates directly.
-
----
-
-## Consensus Protocol
-
-All reviewers must score **>= 9.0/10** to reach consensus.
-
-If consensus is not reached, fix requests are consolidated and routed to workers. Only reviewers
-that scored < 9.0 re-run in the next iteration. Maximum 3 iterations.
-
-After 3 cycles, execution proceeds with the best available version and documents any
-unresolved issues.
-
-**Hard stop**: Any security or auth dimension scoring < 5.0 is treated as a blocking issue
-and flagged immediately.
-
----
-
-## Triage Escape Hatch
-
-For trivial changes (single config file, no security surface, < 3 files, no docs content),
-Phase A offers:
-
-- **A)** Skip team planning entirely (recommended for trivial changes)
-- **B)** Full review team anyway
-- **C)** Devil's Advocate only (lightweight check)
-
-Docs-only plans **do not qualify** for the escape hatch — documentation is specifications
-for code and deserves full review.
-
----
-
-## Architecture Reviewer Context Loading
-
-The Architecture Reviewer searches for project-local architecture docs:
-
-```
-1. ./docs/adrs/
-2. ./docs/architecture/
-3. ./architecture-decisions/
-4. ./architecture/
-5. ./docs/decisions/
-```
-
-It keyword-matches the plan against any docs found, then loads only relevant ones. If no
-architecture docs exist, it scores based on observable codebase patterns.
+- `team-execution/skills/team-execution/references/validator-registry.md`
+- `team-execution/skills/team-execution/references/validator-criteria.md`
+- `team-execution/skills/team-execution/references/validator-execution-order.md`
+- `team-execution/skills/team-execution/references/validator-evidence-state.md`
+- `team-execution/skills/team-execution/references/validator-spawn-quirks.md`
+- `team-execution/skills/team-execution/references/validator-pane-behavior.md`
 
 ---
 
@@ -203,24 +171,35 @@ architecture docs exist, it scores based on observable codebase patterns.
 ```
 team-execution/
 ├── .claude-plugin/plugin.json
-├── skills/team-execution/
-│   ├── SKILL.md                    # Phase A (plan mode) + Phase B (orchestration protocol)
-│   └── references/
-│       ├── reviewer-registry.md    # Keyword triggers + reviewer list
-│       ├── review-criteria.md      # Scoring rubrics for all reviewers
-│       └── consensus-protocol.md  # 3-iteration loop, re-review scoping
+├── docs/
+│   ├── agent-overflow.sh
+│   └── example_tmux.conf
+├── skills/
+│   ├── appsec-audit/
+│   │   └── SKILL.md
+│   └── team-execution/
+│       ├── SKILL.md
+│       └── references/
+│           ├── consensus-protocol.md
+│           ├── review-criteria.md
+│           ├── reviewer-registry.md
+│           ├── validator-criteria.md
+│           ├── validator-evidence-state.md
+│           ├── validator-execution-order.md
+│           ├── validator-pane-behavior.md
+│           ├── validator-registry.md
+│           └── validator-spawn-quirks.md
 ├── agents/
-│   ├── devils-advocate-reviewer.md # Base (red)
-│   ├── security-reviewer.md        # Base (orange)
-│   ├── architecture-reviewer.md    # Base (purple)
-│   ├── infra-reviewer.md           # Optional (blue)
-│   ├── api-reviewer.md             # Optional (green)
-│   ├── testing-reviewer.md         # Optional (yellow)
-│   ├── code-quality-reviewer.md    # Optional (cyan)
-│   ├── privacy-reviewer.md         # Optional (pink)
-│   ├── clarity-reviewer.md         # Optional (teal)
-│   └── ai-usefulness-reviewer.md   # Optional (gold)
-├── commands/team-execute.md        # /team-execute slash command
+│   ├── devils-advocate-reviewer.md
+│   ├── security-reviewer.md
+│   ├── architecture-reviewer.md
+│   ├── security-scanner.md
+│   ├── smoke-tester.md
+│   ├── github-actions-monitor.md
+│   └── ... validator and optional reviewer agents
+├── commands/
+│   ├── team-execute.md
+│   └── team-setup.md
 ├── README.md
 └── CHANGELOG.md
 ```

--- a/plugins/team-execution/agents/api-compat-scanner.md
+++ b/plugins/team-execution/agents/api-compat-scanner.md
@@ -1,0 +1,23 @@
+---
+name: api-compat-scanner
+description: |
+  Scanner validator for team-execution. Checks API compatibility for contract and endpoint
+  changes.
+
+  Candidate tools: oasdiff, Schemathesis.
+model: inherit
+color: green
+---
+
+# API Compatibility Scanner
+
+You validate API contract compatibility.
+
+## Checks
+
+- Breaking OpenAPI, AsyncAPI, protobuf, or GraphQL schema changes.
+- Endpoint request/response drift.
+- Missing versioning or migration notes for breaking changes.
+- Contract-test target availability.
+
+Hard-fail unversioned breaking changes that affect existing consumers.

--- a/plugins/team-execution/agents/api-contract-tester.md
+++ b/plugins/team-execution/agents/api-contract-tester.md
@@ -1,0 +1,23 @@
+---
+name: api-contract-tester
+description: |
+  Tester validator for team-execution. Runs contract tests for API schemas, endpoint
+  behavior, and generated client expectations.
+
+  Candidate tools: Schemathesis, oasdiff.
+model: inherit
+color: green
+---
+
+# API Contract Tester
+
+You validate API implementation against contracts.
+
+## Checks
+
+- OpenAPI or other schema conformance.
+- Error response shape and required fields.
+- Backward compatibility for existing examples.
+- Contract fixture updates.
+
+Hard-fail required contract violations.

--- a/plugins/team-execution/agents/concurrency-tester.md
+++ b/plugins/team-execution/agents/concurrency-tester.md
@@ -1,0 +1,21 @@
+---
+name: concurrency-tester
+description: |
+  Tester validator for team-execution. Tests concurrent execution, locks, retries,
+  idempotency, races, and worker coordination.
+model: inherit
+color: purple
+---
+
+# Concurrency Tester
+
+You validate concurrency-sensitive behavior.
+
+## Checks
+
+- Parallel workers, queues, locks, and idempotency keys.
+- Retry behavior and duplicate submissions.
+- Shared state mutation under concurrent use.
+- Existing stress or race-focused tests.
+
+Hard-fail data loss, duplicate side effects, deadlocks, or race-prone required paths.

--- a/plugins/team-execution/agents/dependency-scanner.md
+++ b/plugins/team-execution/agents/dependency-scanner.md
@@ -1,0 +1,23 @@
+---
+name: dependency-scanner
+description: |
+  Scanner validator for team-execution. Checks dependency manifests, lockfiles, and container
+  inputs for vulnerable or risky supply-chain changes.
+
+  Candidate tools: pip-audit, Trivy.
+model: inherit
+color: orange
+---
+
+# Dependency Scanner
+
+You validate dependency and supply-chain changes.
+
+## Checks
+
+- New dependencies and whether they are necessary.
+- Lockfile updates and vulnerable packages.
+- Container base images and filesystem package vulnerabilities.
+- Package publishing metadata when SDK or library release files change.
+
+Hard-fail critical reachable vulnerabilities or unreviewed high-risk dependency additions.

--- a/plugins/team-execution/agents/deploy-watcher.md
+++ b/plugins/team-execution/agents/deploy-watcher.md
@@ -1,0 +1,28 @@
+---
+name: deploy-watcher
+description: |
+  Operational validator for team-execution. Watches allowed nonprod or publish-nonprod
+  workflows after reviewer, scanner, CI, and required tester gates pass.
+
+  NOT for: production, staging, force-push, branch deletion, or credential changes.
+model: inherit
+color: blue
+---
+
+# Deploy Watcher
+
+You coordinate only explicitly allowed nonprod automation.
+
+## Required Checks
+
+- Remote is `github.com/infiquetra/*`.
+- Workflow name or environment is nonprod or publish-nonprod.
+- Reviewer consensus and scanner gates passed.
+- No production, staging, force-push, branch deletion, or credential-changing action.
+
+Ambiguity means blocked.
+
+## Evidence
+
+Report workflow name, run URL or ID, commit SHA, target environment, artifact or endpoint, and
+rollback notes if available.

--- a/plugins/team-execution/agents/event-flow-tester.md
+++ b/plugins/team-execution/agents/event-flow-tester.md
@@ -1,0 +1,21 @@
+---
+name: event-flow-tester
+description: |
+  Tester validator for team-execution. Validates queues, streams, webhooks, pub/sub,
+  retries, idempotency, and async event paths.
+model: inherit
+color: purple
+---
+
+# Event Flow Tester
+
+You validate event-driven behavior.
+
+## Checks
+
+- Event publish and consume paths.
+- Retry, idempotency, duplicate, and out-of-order behavior.
+- Webhook signature and replay behavior where applicable.
+- Existing integration scripts or tests.
+
+Hard-fail lost, duplicated, or unvalidated required events.

--- a/plugins/team-execution/agents/github-actions-monitor.md
+++ b/plugins/team-execution/agents/github-actions-monitor.md
@@ -1,0 +1,22 @@
+---
+name: github-actions-monitor
+description: |
+  Monitor validator for team-execution. Checks GitHub Actions status and relevant logs for
+  PR, CI, merge, and nonprod workflow gates.
+model: inherit
+color: blue
+---
+
+# GitHub Actions Monitor
+
+You monitor GitHub Actions evidence.
+
+## Checks
+
+- Required CI checks.
+- Nonprod or publish-nonprod workflow status.
+- Failed jobs and relevant log excerpts.
+- Run URL, workflow name, branch, and commit SHA.
+
+Blocked required workflows block completion. Optional failed workflows are warnings unless the
+plan marks them required.

--- a/plugins/team-execution/agents/iac-cost-scanner.md
+++ b/plugins/team-execution/agents/iac-cost-scanner.md
@@ -1,0 +1,24 @@
+---
+name: iac-cost-scanner
+description: |
+  Scanner validator for team-execution. Reviews infrastructure-as-code security, policy,
+  and cost-risk signals.
+
+  Candidate tools: Checkov, Trivy.
+model: inherit
+color: blue
+---
+
+# IaC Cost Scanner
+
+You validate infrastructure changes for policy and cost risk.
+
+## Checks
+
+- Broad IAM actions or resources without justification.
+- Public exposure, weak encryption, missing logging, or missing retention controls.
+- Cost-risk resources such as NAT gateways, large instances, provisioned capacity, or
+  retained resources.
+- CloudFormation, CDK, Terraform, Kubernetes, and container image risks where present.
+
+Hard-fail concrete high-risk findings. Warn on missing optional cost data.

--- a/plugins/team-execution/agents/performance-tester.md
+++ b/plugins/team-execution/agents/performance-tester.md
@@ -1,0 +1,23 @@
+---
+name: performance-tester
+description: |
+  Tester validator for team-execution. Validates latency, throughput, benchmark, and load
+  claims when performance risk is in scope.
+
+  Candidate tool: k6.
+model: inherit
+color: magenta
+---
+
+# Performance Tester
+
+You validate performance-sensitive changes.
+
+## Checks
+
+- Existing benchmark or load-test scripts.
+- k6 tests when configured.
+- Query/runtime changes with user-perceived latency risk.
+- Resource cost claims tied to performance changes.
+
+Warn when no baseline exists. Hard-fail explicit threshold regressions.

--- a/plugins/team-execution/agents/runtime-monitor.md
+++ b/plugins/team-execution/agents/runtime-monitor.md
@@ -1,0 +1,21 @@
+---
+name: runtime-monitor
+description: |
+  Monitor validator for team-execution. Checks runtime health using repository-appropriate
+  observability after nonprod deploy or publish.
+model: inherit
+color: blue
+---
+
+# Runtime Monitor
+
+You validate runtime signals after nonprod deployment or publish.
+
+## Checks
+
+- CloudWatch signals for AWS repositories.
+- Prometheus/Grafana-style signals for home-lab or local-infra repositories.
+- Health endpoints and error logs where configured.
+- Time window and target environment.
+
+Report healthy, degraded, missing signal, blocked, or not applicable.

--- a/plugins/team-execution/agents/scenario-tester.md
+++ b/plugins/team-execution/agents/scenario-tester.md
@@ -1,0 +1,21 @@
+---
+name: scenario-tester
+description: |
+  Tester validator for team-execution. Executes scenario flows from plan context or
+  `.team-execution.json` scenario_hints.
+model: inherit
+color: yellow
+---
+
+# Scenario Tester
+
+You validate representative user or operator scenarios.
+
+## Checks
+
+- Scenario hints from `.team-execution.json`.
+- Acceptance criteria from the plan.
+- Existing repo scripts that exercise full workflows.
+- Meaningful edge cases surfaced by reviewers.
+
+Report each scenario as pass, warn, hard-fail, or blocked with evidence.

--- a/plugins/team-execution/agents/sdk-regression-tester.md
+++ b/plugins/team-execution/agents/sdk-regression-tester.md
@@ -1,0 +1,21 @@
+---
+name: sdk-regression-tester
+description: |
+  Tester validator for team-execution. Checks SDK compatibility, generated client behavior,
+  packaging smoke tests, and regression fixtures.
+model: inherit
+color: green
+---
+
+# SDK Regression Tester
+
+You validate SDK-facing changes.
+
+## Checks
+
+- Existing SDK regression tests.
+- Generated client snapshots or fixtures.
+- Package build/import smoke checks.
+- Breaking change indicators and migration evidence.
+
+Hard-fail regressions in documented SDK behavior.

--- a/plugins/team-execution/agents/security-scanner.md
+++ b/plugins/team-execution/agents/security-scanner.md
@@ -1,0 +1,29 @@
+---
+name: security-scanner
+description: |
+  Scanner validator for team-execution. Runs code, secret, and appsec scans using OSS/free
+  tools where available.
+
+  Candidate tools: Semgrep, Bandit, Gitleaks, detect-secrets.
+model: inherit
+color: orange
+---
+
+# Security Scanner
+
+You collect security scan evidence after reviewer consensus.
+
+## Checks
+
+- Secret-like values in tracked files.
+- High-confidence injection, SSRF-style, redirect, and input validation risks.
+- Python security issues when Python code is present.
+- Policy or config changes that increase exposure.
+
+## Missing Tools
+
+If a selected required tool is missing, mark the gate blocked and provide setup guidance.
+
+## Evidence
+
+Record commands, exit codes, findings, severity, file/path, and remediation guidance.

--- a/plugins/team-execution/agents/smoke-tester.md
+++ b/plugins/team-execution/agents/smoke-tester.md
@@ -1,0 +1,20 @@
+---
+name: smoke-tester
+description: |
+  Tester validator for team-execution. Runs the narrowest meaningful smoke tests for services,
+  CLIs, health endpoints, or configured smoke targets.
+model: inherit
+color: yellow
+---
+
+# Smoke Tester
+
+You verify the deployed or runnable result at the shallowest useful level.
+
+## Checks
+
+- Health endpoints, CLI entrypoints, app startup, or configured `smoke_targets`.
+- Expected status codes, output shape, and obvious failure logs.
+- Required target availability.
+
+Hard-fail required smoke target failures. Warn when optional targets are absent.

--- a/plugins/team-execution/agents/ui-regression-tester.md
+++ b/plugins/team-execution/agents/ui-regression-tester.md
@@ -1,0 +1,23 @@
+---
+name: ui-regression-tester
+description: |
+  Tester validator for team-execution. Runs browser/UI regression checks for frontend
+  workflows and visible behavior.
+
+  Candidate tool: Playwright.
+model: inherit
+color: cyan
+---
+
+# UI Regression Tester
+
+You validate browser-visible behavior.
+
+## Checks
+
+- Existing Playwright or frontend test commands.
+- Key route/screen smoke checks.
+- Console errors, failed network requests, and obvious layout breakage.
+- Screenshots when useful for evidence.
+
+Hard-fail user-visible regressions in required flows.

--- a/plugins/team-execution/commands/team-execute.md
+++ b/plugins/team-execution/commands/team-execute.md
@@ -1,62 +1,49 @@
 ---
 name: team-execute
-description: Execute a plan with automatic multi-reviewer consensus workflow
+description: Execute a plan with reviewer consensus, validator gates, and guarded nonprod automation
 argument-hint: "[plan text or file path]"
 ---
 
-Handle this command as follows based on what's available:
+Handle this command based on available input.
 
 ## Case 1: No plan provided
 
-If `$ARGUMENTS` is empty and there is no plan in the current conversation context:
+If `$ARGUMENTS` is empty and there is no plan in the current conversation context, ask the
+user to describe the work or provide a plan.
 
-Ask the user:
-```
-Please describe what you want to build or provide a plan to execute.
+Then enter plan mode and invoke:
 
-Once you share the details, I'll enter plan mode to structure the work, then the
-team-execution skill will embed a Team Structure into the plan. When you exit plan mode,
-TeamCreate will fire automatically.
-```
+`team-execution/skills/team-execution/SKILL.md`
 
-## Case 2: Plan exists but has no `## Team Structure` section
+## Case 2: Plan exists but has no `## Team Structure`
 
-If a plan is present (from `$ARGUMENTS`, a file path, or the current conversation) but it
-does NOT contain a `## Team Structure` section:
+If a plan is present from `$ARGUMENTS`, a file path, or the current conversation, and it does
+not contain `## Team Structure`, enter plan mode and invoke Phase A of:
 
-Enter plan mode and invoke Phase A of the `team-execution` skill:
 `team-execution/skills/team-execution/SKILL.md`
 
 Phase A will:
-1. Classify the plan (code/docs/mixed)
-2. Run the triage escape hatch check
-3. Detect optional reviewers from plan keywords
-4. Derive workers from plan phases
-5. Get user confirmation
-6. Embed `## Team Structure` into the plan
 
-After Phase A completes, the plan is ready. When the user exits plan mode, the global
-CLAUDE.md rule will detect `## Team Structure` and fire TeamCreate automatically.
+1. Inspect plan and repository signals.
+2. Read optional `.team-execution.json`.
+3. Derive workers from plan phases.
+4. Select reviewers.
+5. Select context-appropriate validators.
+6. Decide whether nonprod automation is eligible.
+7. Embed `## Team Structure`, validator gates, and reference files into the plan.
 
 ## Case 3: Plan already has `## Team Structure`
 
-If the plan already contains a `## Team Structure` section (e.g., the user ran Phase A in
-a prior session and saved the plan):
+If the plan already contains `## Team Structure`, announce that it is ready for execution and
+then follow Phase B of:
 
-Announce:
-```
-✅ This plan already has a Team Structure defined. Ready to begin execution.
+`team-execution/skills/team-execution/SKILL.md`
 
-Exiting plan mode now — TeamCreate will fire and you'll orchestrate workers and reviewers
-directly following Phase B of the team-execution skill.
-```
-
-Then exit plan mode so the CLAUDE.md rule triggers TeamCreate.
-
----
+Phase B order is worker completion, reviewer consensus, scanners, CI/nonprod coordination,
+testers, monitors, and final evidence report.
 
 ## Quick Reference
 
-The plan to execute (if provided):
+The plan to execute, if provided:
 
 $ARGUMENTS

--- a/plugins/team-execution/commands/team-setup.md
+++ b/plugins/team-execution/commands/team-setup.md
@@ -1,14 +1,16 @@
 ---
 name: team-setup
-description: Validate and configure tmux + Claude settings for team-execution agent teams
+description: Validate and configure team-execution handoff, tmux panes, and local validator state
 argument-hint: "[reset]"
 ---
 
 # Team Execution Setup Wizard
 
 Run a full environment check for team-execution and guide the user through fixing any issues.
+Ask before writing user-level files.
 
-If `$ARGUMENTS` contains "reset", first clear the tmux dismissal:
+If `$ARGUMENTS` contains `reset`, first clear the tmux dismissal:
+
 ```bash
 python3 -c "
 import json, os
@@ -19,16 +21,14 @@ if os.path.exists(path):
     with open(path, 'w') as f: json.dump(d, f, indent=2)
     print('tmux setup checks re-enabled.')
 else:
-    print('No dismissal found — checks are already active.')
+    print('No dismissal found; checks are already active.')
 "
 ```
 
-## Step 1: Run All Checks
-
-Run every check and collect results:
+## Step 1: Run Checks
 
 ```bash
-echo "=== CLAUDE.md Handoff Rule ==="
+echo "=== Handoff Rule ==="
 grep -q "Team Execution Auto-Handoff" ~/.claude/CLAUDE.md 2>/dev/null && echo "handoff:OK" || echo "handoff:MISSING"
 
 echo "=== tmux Environment ==="
@@ -37,9 +37,12 @@ command -v tmux >/dev/null 2>&1 && echo "tmux:OK:$(tmux -V)" || echo "tmux:MISSI
 [ -f ~/.tmux.conf ] && echo "config:OK" || echo "config:MISSING"
 [ -x ~/.config/tmux/agent-overflow.sh ] && echo "overflow:OK" || echo "overflow:MISSING"
 
-echo "=== Claude Settings ==="
-cat ~/.claude.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); m=d.get('teammateMode','unset'); print(f'teammateMode:{m}')" 2>/dev/null || echo "teammateMode:unset"
-cat ~/.claude/settings.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('env',{}).get('CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS','unset'); print(f'agentTeams:{v}')" 2>/dev/null || echo "agentTeams:unset"
+echo "=== Bundled Assets ==="
+[ -f ./plugins/team-execution/docs/example_tmux.conf ] && echo "example_tmux:OK" || echo "example_tmux:MISSING"
+[ -f ./plugins/team-execution/docs/agent-overflow.sh ] && echo "agent_overflow_asset:OK" || echo "agent_overflow_asset:MISSING"
+
+echo "=== Validator State ==="
+git check-ignore -q .claude && echo "claude_ignore:OK" || echo "claude_ignore:MISSING"
 
 echo "=== tmux Dismissal ==="
 cat ~/.claude/team-execution.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('DISMISSED' if d.get('tmux_setup_dismissed') else 'ACTIVE')" 2>/dev/null || echo "ACTIVE"
@@ -47,97 +50,48 @@ cat ~/.claude/team-execution.json 2>/dev/null | python3 -c "import sys,json; d=j
 
 ## Step 2: Display Results
 
-Show a clear summary:
+Show a concise summary:
 
-```
+```text
 Team Execution Environment Check
-═══════════════════════════════════════════════════
 
-Critical (required for skill to work):
-  [✅ or ⚠️] CLAUDE.md auto-handoff rule
+Critical:
+  [OK/WARN] CLAUDE.md auto-handoff rule
 
-tmux Agent Teams (recommended):
-  [✅ or ⚠️] tmux installed [version]
-  [✅ or ⚠️] Running inside tmux session
-  [✅ or ⚠️] ~/.tmux.conf configured
-  [✅ or ⚠️] Overflow script (agent-overflow.sh)
-  [✅ or ⚠️] teammateMode in ~/.claude.json
-  [✅ or ⚠️] Agent teams feature flag
+tmux panes:
+  [OK/WARN] tmux installed
+  [OK/WARN] Running inside tmux
+  [OK/WARN] ~/.tmux.conf configured
+  [OK/WARN] ~/.config/tmux/agent-overflow.sh installed
+  [OK/WARN] Bundled docs/example_tmux.conf exists
+  [OK/WARN] Bundled docs/agent-overflow.sh exists
 
-tmux checks: [active / dismissed]
-═══════════════════════════════════════════════════
+Validator state:
+  [OK/WARN] .claude/ ignored for .claude/team-execution/validators/
 ```
 
-## Step 3: Offer Fixes for Each Issue
+## Step 3: Fix Handoff Rule
 
-Walk through each failing check and offer to fix it. Ask the user for confirmation before each change.
+If the handoff rule is missing, offer to append this to `~/.claude/CLAUDE.md`:
 
-### Fix: CLAUDE.md handoff rule missing
-
-Offer to append the auto-handoff rule to `~/.claude/CLAUDE.md`:
-
-```
-The team-execution skill requires this rule in ~/.claude/CLAUDE.md to automatically
-trigger TeamCreate when a plan with ## Team Structure exits plan mode.
-
-Shall I add it to your ~/.claude/CLAUDE.md?
-```
-
-If yes, append:
 ```markdown
 
 ## Team Execution Auto-Handoff
 
-When a plan exits plan mode and contains an explicit **## Team Structure** section with named agents:
+When a plan exits plan mode and contains an explicit **## Team Structure** section:
 
-1. **Your ONLY next action is TeamCreate** — no exceptions, no other actions first.
-2. **Do NOT use the Agent tool** for any implementation work in this plan.
-3. Parse the `## Team Structure` table for workers and reviewers.
-4. Call TeamCreate immediately with those agents.
-5. Then follow the Phase B orchestration protocol from `team-execution/skills/team-execution/SKILL.md`.
-
-This rule takes **priority over any other agent-spawning or task-delegation behavior**. If you find yourself about to spawn a sub-agent for implementation work, stop — route it to a TeamCreate worker instead.
+1. Parse workers, reviewers, validators, reference files, and execution gates.
+2. Follow Phase B from `team-execution/skills/team-execution/SKILL.md`.
+3. Workers complete changes before reviewers run.
+4. Reviewer consensus gates validators unless the user explicitly overrides.
+5. Scanner/tester hard-fail findings block automation and completion.
 ```
 
-### Fix: tmux not installed
+## Step 4: Fix tmux Asset Setup
 
-Show:
-```
-tmux is required for split-pane agent teams. Install it:
+If `~/.tmux.conf` is missing, offer to install the bundled config.
 
-  macOS:  brew install tmux
-  Ubuntu: sudo apt install tmux
-  Fedora: sudo dnf install tmux
-```
-
-### Fix: Not running inside tmux
-
-Show:
-```
-You're not currently inside a tmux session. Agent teams need tmux for split panes.
-
-Start a session and relaunch claude:
-  tmux new -s agents
-  claude
-```
-
-### Fix: ~/.tmux.conf missing
-
-The team-execution plugin ships an optimized tmux config. Offer to install it:
-
-```
-The team-execution plugin includes an optimized tmux config for agent teams:
-  - Auto-overflow: max 4 panes per window, auto-breaks to new window
-  - Prefix+hjkl pane navigation (Ctrl+h/l stays free for iTerm2)
-  - Green-on-black theme with agent names in pane borders
-  - Hybrid tile+zoom layout
-
-Shall I install it?
-```
-
-If yes:
 ```bash
-# Find the plugin's docs directory
 PLUGIN_DIR=$(find ~/.claude/plugins -path "*/team-execution/docs/example_tmux.conf" 2>/dev/null | head -1 | xargs dirname)
 if [ -z "$PLUGIN_DIR" ]; then
   PLUGIN_DIR=$(find . -path "*/team-execution/docs/example_tmux.conf" 2>/dev/null | head -1 | xargs dirname)
@@ -145,14 +99,14 @@ fi
 
 if [ -n "$PLUGIN_DIR" ]; then
   cp "$PLUGIN_DIR/example_tmux.conf" ~/.tmux.conf
-  echo "Installed ~/.tmux.conf"
+  echo "Installed ~/.tmux.conf from docs/example_tmux.conf"
 else
-  echo "Could not find example_tmux.conf in plugin directory."
+  echo "Could not find docs/example_tmux.conf in plugin directory."
   echo "Manual install: cp docs/example_tmux.conf ~/.tmux.conf"
 fi
 ```
 
-### Fix: agent-overflow.sh missing
+If `~/.config/tmux/agent-overflow.sh` is missing, offer to install the bundled script.
 
 ```bash
 PLUGIN_DIR=$(find ~/.claude/plugins -path "*/team-execution/docs/agent-overflow.sh" 2>/dev/null | head -1 | xargs dirname)
@@ -164,78 +118,37 @@ if [ -n "$PLUGIN_DIR" ]; then
   mkdir -p ~/.config/tmux
   cp "$PLUGIN_DIR/agent-overflow.sh" ~/.config/tmux/agent-overflow.sh
   chmod +x ~/.config/tmux/agent-overflow.sh
-  echo "Installed ~/.config/tmux/agent-overflow.sh"
+  echo "Installed ~/.config/tmux/agent-overflow.sh from docs/agent-overflow.sh"
 else
-  echo "Could not find agent-overflow.sh in plugin directory."
+  echo "Could not find docs/agent-overflow.sh in plugin directory."
   echo "Manual install: cp docs/agent-overflow.sh ~/.config/tmux/ && chmod +x ~/.config/tmux/agent-overflow.sh"
 fi
 ```
 
-### Fix: teammateMode not set
+If tmux config changed and a tmux session is active:
 
-Show:
-```
-Claude Code's teammateMode controls how agent teammates are displayed.
-For split-pane agent teams, it should be set to "tmux".
-
-Shall I set it? This writes to ~/.claude.json.
-```
-
-If yes:
-```bash
-python3 -c "
-import json, os
-path = os.path.expanduser('~/.claude.json')
-d = {}
-if os.path.exists(path):
-    with open(path) as f: d = json.load(f)
-d['teammateMode'] = 'tmux'
-with open(path, 'w') as f: json.dump(d, f, indent=2)
-print('Set teammateMode to tmux in ~/.claude.json')
-"
-```
-
-### Fix: Agent teams feature flag not set
-
-Show:
-```
-The experimental agent teams feature needs to be enabled in Claude settings.
-
-Shall I enable it? This writes to ~/.claude/settings.json.
-```
-
-If yes:
-```bash
-python3 -c "
-import json, os
-path = os.path.expanduser('~/.claude/settings.json')
-d = {}
-if os.path.exists(path):
-    with open(path) as f: d = json.load(f)
-if 'env' not in d: d['env'] = {}
-d['env']['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = '1'
-with open(path, 'w') as f: json.dump(d, f, indent=2)
-print('Enabled CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS in settings.json')
-"
-```
-
-## Step 4: Reload (if changes were made)
-
-If any tmux config was installed or modified:
 ```bash
 [ -n "$TMUX" ] && tmux source ~/.tmux.conf && echo "tmux config reloaded"
 ```
 
-## Step 5: Offer tmux Dismissal
+## Step 5: Fix Validator State Safety
 
-If all tmux checks pass or the user doesn't want tmux:
-```
-All checks complete. Would you like to:
-  A) Keep tmux checks active (will check on next /team-execute)
-  B) Dismiss tmux checks (won't ask again — run /team-setup reset to re-enable)
+If `.claude/` is not ignored in the target repository, show:
+
+```text
+Validator state defaults to .claude/team-execution/validators/.
+Add .claude/ to .gitignore before using repo-local validator state, or use:
+
+  ~/.claude/team-execution/state/<repo>/
 ```
 
-If B:
+Do not create repo-local validator state until the user confirms `.claude/` is ignored or
+chooses the user-local fallback.
+
+## Step 6: Dismiss tmux Checks
+
+If the user does not want tmux setup checks:
+
 ```bash
 mkdir -p ~/.claude && echo '{"tmux_setup_dismissed": true}' > ~/.claude/team-execution.json
 ```

--- a/plugins/team-execution/docs/agent-overflow.sh
+++ b/plugins/team-execution/docs/agent-overflow.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pane_id="${1:-}"
+
+if [ -z "$pane_id" ]; then
+  echo "agent-overflow: missing pane id" >&2
+  exit 2
+fi
+
+title="$(tmux display-message -p -t "$pane_id" '#{pane_title}' 2>/dev/null || true)"
+
+case "$title" in
+  worker-*) target_window="workers" ;;
+  *-scanner) target_window="scanners" ;;
+  *-tester) target_window="testers" ;;
+  *-monitor) target_window="monitors" ;;
+  deploy-watcher) target_window="deploy-watcher" ;;
+  *-reviewer|devils-advocate) target_window="$title" ;;
+  *)
+    echo "agent-overflow: leaving pane in place; unknown agent title '$title'" >&2
+    exit 0
+    ;;
+esac
+
+if [ "$target_window" = "$title" ]; then
+  tmux break-pane -d -t "$pane_id" -n "$target_window"
+  exit 0
+fi
+
+if ! tmux list-windows -F '#W' | grep -Fxq "$target_window"; then
+  tmux new-window -d -n "$target_window"
+fi
+
+tmux join-pane -d -s "$pane_id" -t "$target_window"
+tmux select-layout -t "$target_window" tiled >/dev/null

--- a/plugins/team-execution/docs/example_tmux.conf
+++ b/plugins/team-execution/docs/example_tmux.conf
@@ -1,0 +1,29 @@
+# team-execution example tmux configuration
+
+set -g mouse on
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+set -g status on
+set -g status-left '#S '
+set -g status-right '%Y-%m-%d %H:%M'
+set -g window-status-current-format ' #[bold]#I:#W '
+set -g window-status-format ' #I:#W '
+
+set -g pane-border-status top
+set -g pane-border-format ' #T '
+set -g bell-action none
+set -g visual-bell off
+
+bind-key h select-pane -L
+bind-key j select-pane -D
+bind-key k select-pane -U
+bind-key l select-pane -R
+bind-key w choose-tree -Zw
+bind-key f command-prompt -p "find-window:" "find-window '%%'"
+
+bind-key S-Down select-layout tiled
+bind-key S-Up resize-pane -Z
+
+set-hook -g after-split-window 'run-shell "~/.config/tmux/agent-overflow.sh #{pane_id}"'

--- a/plugins/team-execution/skills/appsec-audit/SKILL.md
+++ b/plugins/team-execution/skills/appsec-audit/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: appsec-audit
+description: |
+  Application security audit focused on URL and input trust boundaries, SSRF-style risks,
+  redirects, metadata endpoints, allowlists, and evidence-backed findings.
+when_to_use: |
+  Use when reviewing code that accepts URLs, fetches remote resources, follows redirects,
+  proxies requests, imports external data, parses user-controlled input, or touches
+  network egress controls.
+---
+
+# AppSec Audit
+
+Use this skill to audit application code for URL and input trust boundary risks. Focus on
+evidence-backed findings, not speculative concerns.
+
+---
+
+## Scope
+
+Review:
+
+- User-controlled URLs, hosts, paths, query strings, headers, and webhook destinations.
+- HTTP clients, redirect handling, proxy code, file importers, and fetch/download helpers.
+- SSRF-style paths to cloud metadata endpoint addresses and internal networks.
+- DNS rebinding, scheme confusion, localhost/private-network access, and open redirects.
+- Allowlist and blocklist enforcement.
+- Input parsing at trust boundaries.
+
+---
+
+## Process
+
+1. Map external inputs and trust boundaries.
+2. Trace each input to network, file, shell, database, template, or redirect sinks.
+3. Check validation order: parse, canonicalize, validate, then use.
+4. Confirm allowlists are positive and exact enough for the risk.
+5. Check redirects do not escape the approved destination set.
+6. Check cloud metadata endpoint protections and private network restrictions.
+7. Produce findings only when code evidence supports the risk.
+
+---
+
+## SSRF Checklist
+
+- Reject non-HTTP schemes unless explicitly required.
+- Reject localhost, loopback, link-local, private, multicast, and unspecified addresses.
+- Protect metadata endpoints, including `169.254.169.254` and provider-specific hostnames.
+- Re-resolve DNS or pin validated IPs when redirects or retries occur.
+- Validate every redirect hop.
+- Enforce outbound allowlists at the URL/host layer and, where possible, network egress layer.
+- Set conservative timeouts and response size limits.
+
+---
+
+## Finding Format
+
+```markdown
+## AppSec Audit Finding
+
+**Severity**: [Critical/High/Medium/Low]
+**Category**: [SSRF / redirect / input validation / allowlist / metadata endpoint / other]
+**File**: [path:line]
+**Evidence**: [Specific code behavior and data flow]
+**Impact**: [What an attacker can do]
+**Fix**: [Concrete remediation]
+**Validation**: [How to prove the fix]
+```
+
+If no findings are found, state the files reviewed and any residual test gaps.

--- a/plugins/team-execution/skills/team-execution/SKILL.md
+++ b/plugins/team-execution/skills/team-execution/SKILL.md
@@ -1,555 +1,406 @@
 ---
 name: team-execution
 description: |
-  Two-phase structured plan execution with automatic multi-reviewer consensus workflow.
+  Two-phase structured plan execution with reviewer consensus, validator gates,
+  and guarded nonprod automation for Infiquetra repositories.
 
-  Phase A runs DURING plan mode: reads the plan, derives workers from plan phases, detects
-  optional reviewers from keywords, embeds a ## Team Structure section, and calls
-  ExitPlanMode itself. The plan is a single atomic artifact — implementation steps, team
-  roster, and review protocol approved together in one unit.
+  Phase A runs during planning: inspect the requested work, derive workers,
+  reviewers, and selected validators, then embed the team plan into the user-approved
+  plan artifact.
 
-  Phase B is the orchestration protocol that Claude follows directly after plan approval:
-  TeamCreate fires immediately (ONLY permitted first action), then plan approval gates,
-  parallel execution, max-3-iteration review cycle with 9/10 consensus threshold, and
-  completion reporting.
-
-  Pattern source: adapted from a structured team review cycle for code/plan execution.
+  Phase B runs after approval: workers complete changes, reviewers reach consensus,
+  scanners run, PR/CI/nonprod coordination happens only after gates pass, and
+  testers plus monitors validate the deployed nonprod result.
 when_to_use: |
-  Use this skill PROACTIVELY when in plan mode and ANY of these are true:
-  - The plan has 3+ steps, touches 3+ files, or involves docs/specs
-  - The plan involves multiple parallel work streams
-  - The user says: "agent team", "agentic team", "team of agents", "use agents",
-    "set up a team", "use team-execution", "who should review this?", "what team
-    do I need?", "agentic approach", "run this with agents"
-  - The user asks for code review as part of a plan
+  Use this skill proactively when in plan mode and any of these are true:
+  - The plan has 3+ steps, touches 3+ files, or involves docs/specs.
+  - The plan involves multiple work streams, repositories, contracts, workflows, or deployments.
+  - The user asks for agent teams, team-execution, validator gates, nonprod automation,
+    review consensus, or automated checks.
+  - The user asks for code review as part of a plan.
 
-  When auto-suggesting on a non-trivial plan, ask:
-    "This plan has [N] steps across [M] files. Would you like to set up an agent
-     team with workers and reviewers?
-       A) Yes, run team planning
-       B) No, I'll handle this myself"
-
-  Do NOT use when:
-  - The plan already has a ## Team Structure section (TeamCreate will fire automatically)
-  - The change is trivially simple (single file, no security surface, < 3 steps)
-  - The user has already declined team planning for this plan in this session
+  Do not use when:
+  - The plan already has a ## Team Structure section.
+  - The change is trivially simple and the user declines team planning.
+  - The user has already declined team planning for this plan in this session.
 ---
 
 # Team Execution Skill
 
 This skill has two phases:
 
-- **Phase A** runs DURING plan mode. You read the current plan, classify it, derive workers
-  from plan phases, detect optional reviewers, get user confirmation, embed the
-  `## Team Structure` section, and then call `ExitPlanMode` yourself. The plan is a single
-  atomic artifact — the user approves the implementation plan, team roster, and review
-  protocol in one unit. You do NOT spawn agents or call TeamCreate during Phase A.
+- **Phase A** runs during planning. You inspect the plan and repository signals, derive
+  workers, reviewers, selected validators, and automation eligibility, then embed the
+  `## Team Structure` section into the plan before plan approval.
+- **Phase B** is the orchestration protocol. It is followed directly by the main agent after
+  the user approves the plan.
 
-- **Phase B** is the orchestration protocol for Claude to follow directly. It is NOT
-  invoked as a separate agent. When Phase A calls ExitPlanMode and the plan contains
-  `## Team Structure`, your ONLY permitted next action is TeamCreate. Read Phase B as your
-  operating instructions and orchestrate workers and reviewers directly.
+Validators are selected by task context. Do not spawn the full validator roster by default.
 
 ---
 
-# Phase A: Team Planning (runs DURING plan mode)
+# Phase A: Team Planning
 
 ## Step A0: Environment Pre-flight
 
-Before doing anything else, validate that the user's environment is ready for team execution.
-Run these checks silently using bash commands. Only show output if something needs attention.
+Run pre-flight checks silently. Show only actionable gaps.
 
-### A0a. CLAUDE.md Auto-Handoff Rule (always checked)
+### A0a. Handoff Rule
 
-Run:
+Check for the handoff rule:
+
 ```bash
 grep -q "Team Execution Auto-Handoff" ~/.claude/CLAUDE.md 2>/dev/null && echo "FOUND" || echo "MISSING"
 ```
 
-If **MISSING**: this is critical — the skill will not work properly without it. Show:
-```
-⚠️  CLAUDE.md auto-handoff rule not found.
+If missing, tell the user to run `/team-setup` or add the rule manually. Do not block plan
+creation.
 
-The team-execution skill requires a rule in ~/.claude/CLAUDE.md to trigger TeamCreate
-automatically after plan approval. Without it, the handoff from planning to execution
-will not fire.
+### A0b. Setup Assets
 
-Run /team-setup to install it, or add this to ~/.claude/CLAUDE.md manually:
+If setup is requested, `/team-setup` must reference packaged assets that exist in this plugin:
 
-  ## Team Execution Auto-Handoff
+- `team-execution/docs/example_tmux.conf`
+- `team-execution/docs/agent-overflow.sh`
 
-  When a plan exits plan mode and contains an explicit ## Team Structure section:
-  1. Your ONLY next action is TeamCreate — no exceptions
-  2. Do NOT use the Agent tool for implementation work
-  3. Parse the Team Structure table for workers and reviewers
-  4. Call TeamCreate immediately
-  5. Then follow Phase B orchestration from team-execution SKILL.md
-
-  This rule takes priority over any other agent-spawning behavior.
-```
-
-Proceed to A1 after showing the warning — do not block.
-
-### A0b. tmux Environment (skipped if opted out)
-
-First check if the user has dismissed tmux setup:
-```bash
-cat ~/.claude/team-execution.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('DISMISSED' if d.get('tmux_setup_dismissed') else 'CHECK')" 2>/dev/null || echo "CHECK"
-```
-
-If **DISMISSED**: skip all tmux checks silently. Proceed to A1.
-
-If **CHECK**: run these checks and collect results:
-```bash
-# 1. tmux installed?
-command -v tmux >/dev/null 2>&1 && echo "tmux:OK" || echo "tmux:MISSING"
-
-# 2. Running inside tmux?
-[ -n "$TMUX" ] && echo "session:OK" || echo "session:MISSING"
-
-# 3. tmux.conf exists?
-[ -f ~/.tmux.conf ] && echo "config:OK" || echo "config:MISSING"
-
-# 4. Overflow script installed?
-[ -x ~/.config/tmux/agent-overflow.sh ] && echo "overflow:OK" || echo "overflow:MISSING"
-
-# 5. Claude settings: teammateMode set?
-cat ~/.claude.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); m=d.get('teammateMode','unset'); print(f'teammateMode:{m}')" 2>/dev/null || echo "teammateMode:unset"
-
-# 6. Claude settings: agent teams feature enabled?
-cat ~/.claude/settings.json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('env',{}).get('CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS','unset'); print(f'agentTeams:{v}')" 2>/dev/null || echo "agentTeams:unset"
-```
-
-If **all OK** (tmux installed, in session, config present, overflow installed, teammateMode is "tmux" or "auto", agentTeams is "1"): proceed silently to A1.
-
-If **any MISSING or misconfigured**: show the results table and offer options:
-```
-tmux environment check:
-  ✅ tmux installed          (or ⚠️  tmux not installed)
-  ✅ Running in tmux session (or ⚠️  Not in tmux session)
-  ✅ ~/.tmux.conf present    (or ⚠️  ~/.tmux.conf not found)
-  ✅ Overflow script ready   (or ⚠️  agent-overflow.sh not installed)
-  ✅ teammateMode: tmux      (or ⚠️  teammateMode not set — agents won't use split panes)
-  ✅ Agent teams enabled     (or ⚠️  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set)
-
-Options:
-  A) Run /team-setup to configure tmux for agent teams
-  B) Skip tmux setup — I have my own terminal config
-  C) Don't ask again — dismiss tmux checks permanently
-```
-
-If user picks **B**: proceed to A1.
-If user picks **C**: write the dismissal file and proceed:
-```bash
-mkdir -p ~/.claude && echo '{"tmux_setup_dismissed": true}' > ~/.claude/team-execution.json
-```
-If user picks **A**: tell them to run `/team-setup` after this session, then proceed to A1.
+If either asset is unavailable in the installed plugin, fail loud with manual setup guidance.
 
 ---
 
-## Step A1: Plan Intake & Triage
+## Step A1: Plan and Repository Intake
 
-### A1a. Locate the Plan
+Derive the plan from all available signals:
 
-The plan is already in the current plan-mode session. If multiple plans are in context,
-ask the user to confirm which one to annotate with a team structure.
+- User plan text and acceptance criteria.
+- Repo type and language/tooling.
+- Changed files, staged files, and branch state.
+- GitHub workflows under `.github/workflows/`.
+- API contracts such as OpenAPI, AsyncAPI, protobuf, GraphQL schemas, or SDK fixtures.
+- Documentation, runbooks, architecture docs, and issue specs.
+- Test suites and existing quality commands.
+- Optional `.team-execution.json`.
 
-### A1b. Classify Plan Type
+The `.team-execution.json` file is optional. Absence means infer from the repo. Supported keys:
 
-Read the plan and classify it:
+```json
+{
+  "required_validators": ["security-scanner", "smoke-tester"],
+  "disabled_validators": ["performance-tester"],
+  "nonprod_workflows": ["publish-nonprod.yml"],
+  "scenario_hints": ["checkout flow", "webhook replay"],
+  "smoke_targets": ["https://example-nonprod.internal/health"]
+}
+```
+
+If present:
+
+- `required_validators` must be selected unless explicitly impossible.
+- `disabled_validators` must not run unless the user overrides.
+- `nonprod_workflows` limits deployment/publish workflow candidates.
+- `scenario_hints` inform scenario and event-flow testers.
+- `smoke_targets` inform smoke tests.
+
+---
+
+## Step A2: Classify Work
+
+Classify the plan:
 
 | Type | Definition |
 |------|------------|
-| **code** | Primarily code changes: implementations, refactors, bug fixes, infrastructure |
-| **docs/specs** | Primarily documentation: README, specs, issue templates, SKILL.md, ADRs |
-| **mixed** | Both code AND documentation/spec content |
+| code | Primarily code changes, refactors, bug fixes, or infrastructure |
+| docs/specs | Primarily documentation, issue specs, skill docs, or runbooks |
+| mixed | Both code and documentation/spec content |
 
-This classification determines which optional reviewers are suggested in Step A2.
+Also classify repository signals:
 
-### A1c. Run Triage Check
-
-A plan qualifies for the **triage escape hatch** ONLY if ALL four criteria are true:
-
-1. Single config file change (version bump, env var, flag toggle)
-2. No security surface affected (no auth, secrets, permissions, PII)
-3. Fewer than 3 files modified
-4. No specification or documentation content
-
-**Docs-only plans do NOT qualify** — documentation is specs for code and deserves full review.
-
-If all criteria are met, offer:
-```
-This looks like a trivial config change. How would you like to proceed?
-
-A) Skip team planning (recommended for this change)
-B) Full review team anyway
-C) Devil's Advocate only (lightweight check)
-```
-
-If the user picks A, stop here — do not embed a Team Structure section.
-If any criterion is not met, proceed directly to Step A2.
+| Repo Signal | Examples |
+|-------------|----------|
+| Python service | `pyproject.toml`, `requirements.txt`, `pytest`, FastAPI, Lambda handlers |
+| AWS/CDK service | `cdk.json`, `template.yaml`, CloudFormation, SAM, Lambda, IAM |
+| API contract repo | OpenAPI, AsyncAPI, protobuf, GraphQL schema |
+| SDK repo | `sdk`, generated clients, package publishing workflows |
+| Frontend repo | React, Next.js, Vite, Playwright, browser smoke targets |
+| Home-lab/observability | Ansible, Prometheus, Grafana, Docker Compose, local infra |
 
 ---
 
-## Step A2: Reviewer Detection & Team Proposal
+## Step A3: Reviewer Selection
 
-### A2a. Detect Optional Reviewers
+Read:
 
-Read `team-execution/skills/team-execution/references/reviewer-registry.md`.
+- `team-execution/skills/team-execution/references/reviewer-registry.md`
+- `team-execution/skills/team-execution/references/review-criteria.md`
+- `team-execution/skills/team-execution/references/consensus-protocol.md`
 
-Scan the plan content for keywords in the optional reviewer trigger table. Based on plan type:
-- **code** plans: check code-focused keyword triggers
-- **docs/specs** plans: check doc-focused keyword triggers
-- **mixed** plans: check both trigger sets
+Base reviewers always included:
 
-### A2b. Present Reviewer Proposal
+- `devils-advocate-reviewer`
+- `security-reviewer`
+- `architecture-reviewer`
 
-Show the user:
-```
-Base reviewers (always included):
-  🔴 Devil's Advocate — assumptions, edge cases, failure modes
-  🟠 Security Reviewer — OWASP, secrets, auth/authZ, PII
-  🟣 Architecture Reviewer — design patterns, separation of concerns, convention adherence
+Optional reviewers are suggested from plan and repo signals.
 
-Suggested optional reviewers (detected from plan content):
-  [e.g., 🔵 Infra Reviewer — CDK/Lambda/cloud infrastructure detected]
-  [e.g., 🟢 API Reviewer — new endpoint patterns detected]
-
-Confirm, skip optional reviewers, or add custom reviewers?
-```
-
-**Hard gate**: Wait for user confirmation before proceeding to Step A3.
+Reviewer non-consensus blocks validators unless the user explicitly overrides.
 
 ---
 
-## Step A3: Worker Derivation
+## Step A4: Validator Selection
 
-For each major phase or parallel work stream in the plan, propose a named worker:
+Read:
 
-- Worker names should reflect the phase: `worker-docs`, `worker-api`, `worker-infra`, etc.
-- Each worker maps to one parallel group (`[P1]`, `[P2]`) or one major sequential phase
-- If the plan has only one phase, propose a single `worker-1`
+- `team-execution/skills/team-execution/references/validator-registry.md`
+- `team-execution/skills/team-execution/references/validator-criteria.md`
+- `team-execution/skills/team-execution/references/validator-execution-order.md`
+- `team-execution/skills/team-execution/references/validator-evidence-state.md`
+- `team-execution/skills/team-execution/references/validator-spawn-quirks.md`
+- `team-execution/skills/team-execution/references/validator-pane-behavior.md`
 
-Present the worker proposal alongside the reviewer confirmation:
+Select validators by context:
 
-```
-Workers (derived from plan phases):
-  worker-1 — [Phase 1 name]: [key tasks]
-  worker-2 — [Phase 2 name]: [key tasks]
-  [etc.]
+| Group | Agents |
+|-------|--------|
+| Scanners | `security-scanner`, `iac-cost-scanner`, `api-compat-scanner`, `dependency-scanner` |
+| Testers | `smoke-tester`, `scenario-tester`, `api-contract-tester`, `sdk-regression-tester`, `event-flow-tester`, `ui-regression-tester`, `performance-tester`, `concurrency-tester` |
+| Monitors | `github-actions-monitor`, `runtime-monitor` |
+| Operational | `deploy-watcher` |
 
-Reviewers confirmed above.
+Tool candidates are OSS/free where available:
 
-Proceed to embed Team Structure into the plan?
-```
+- Semgrep
+- Bandit
+- pip-audit
+- Trivy
+- Gitleaks
+- detect-secrets
+- Checkov
+- oasdiff
+- Schemathesis
+- Playwright
+- k6
 
-**Hard gate**: Wait for final user confirmation before Step A4.
+If a selected validator requires a missing tool, fail loud with setup guidance. Do not silently
+skip required validators.
 
 ---
 
-## Step A4: Embed Team Structure
+## Step A5: State and Evidence Plan
 
-After confirmation, write the following section at the END of the plan (before any existing
-`## Notes` or `## Review` sections, or at the very end if those don't exist):
+Validator run state is JSON under:
+
+```text
+.claude/team-execution/validators/
+```
+
+Before planning validator state, check whether `.claude/` is ignored in the target repo. If it is
+not ignored, instruct the user to add an ignore rule or use the user-local fallback:
+
+```text
+~/.claude/team-execution/state/<repo>/
+```
+
+Each validator state record includes:
+
+- Validator name and group.
+- Selection reason.
+- Required tool commands and availability.
+- Inputs inspected.
+- Evidence paths.
+- Findings and severity.
+- Gate result: pass, warn, hard-fail, skipped-by-config, or blocked.
+- Remediation loop count.
+
+---
+
+## Step A6: Automation Eligibility
+
+Automation is allowed only when all conditions are true:
+
+- Remote matches `github.com/infiquetra/*`.
+- The plan follows the repo default branch model.
+- Reviewers, selected scanners, CI, and required testers pass.
+- Workflow is explicitly nonprod or publish-nonprod.
+- The action does not touch production, staging, force-push, branch deletion, or credentials.
+
+Any ambiguous or missing signal blocks automation.
+
+---
+
+## Step A7: Embed Team Structure
+
+Append a plan section like this:
 
 ```markdown
 ## Team Structure
 
+### Workers
 | Agent | Role | Mode | Responsibilities |
 |-------|------|------|------------------|
-| `worker-1` | [Phase 1 name] | bypassPermissions | [Tasks from plan] |
-| `worker-2` | [Phase 2 name] | bypassPermissions | [Tasks from plan] |
-| `security-reviewer` | Security Reviewer | general-purpose | OWASP, secrets, auth/authZ, PII |
-| `devils-advocate` | Devil's Advocate | general-purpose | Assumptions, edge cases, failure modes |
-| `architecture-reviewer` | Architecture Reviewer | general-purpose | Design patterns, separation of concerns, conventions |
-[optional reviewers if confirmed...]
+| `worker-1` | [Phase name] | bypassPermissions | [Tasks from plan] |
 
-### Review Protocol
-- Consensus threshold: **>= 9.0/10** from every reviewer
-- Maximum **3 review iterations**
-- Security/auth < 5.0 is a **blocking stop**
-- Workers run in `bypassPermissions` mode — no permission prompts, quality enforced by review cycle
+### Reviewers
+| Agent | Role | Required | Selection Reason |
+|-------|------|----------|------------------|
+| `devils-advocate-reviewer` | Devil's Advocate Reviewer | yes | Base reviewer |
+| `security-reviewer` | Security Reviewer | yes | Base reviewer |
+| `architecture-reviewer` | Architecture Reviewer | yes | Base reviewer |
+
+### Validators
+| Agent | Group | Required | Selection Reason | Blocking |
+|-------|-------|----------|------------------|----------|
+| `security-scanner` | Scanner | yes/no | [Why selected] | hard-fail blocks automation |
+
+### Execution Gates
+- Reviewer consensus threshold: >= 9.0/10 from every reviewer.
+- Reviewer non-consensus blocks validators unless the user explicitly overrides.
+- Scanners run before PR/CI/merge/nonprod coordination.
+- Tester hard-fail blocks completion.
+- Maximum 3 remediation loops before escalation.
 
 ### Reference Files
 - `team-execution/skills/team-execution/references/reviewer-registry.md`
 - `team-execution/skills/team-execution/references/review-criteria.md`
 - `team-execution/skills/team-execution/references/consensus-protocol.md`
+- `team-execution/skills/team-execution/references/validator-registry.md`
+- `team-execution/skills/team-execution/references/validator-criteria.md`
+- `team-execution/skills/team-execution/references/validator-execution-order.md`
+- `team-execution/skills/team-execution/references/validator-evidence-state.md`
+- `team-execution/skills/team-execution/references/validator-spawn-quirks.md`
+- `team-execution/skills/team-execution/references/validator-pane-behavior.md`
 ```
 
-After writing the section, announce:
-
-```
-✅ Team Structure embedded in the plan.
-
-This plan is now complete — it contains the implementation steps, the full team roster,
-and the review protocol. Submitting for your approval now.
-```
-
-**Do NOT call TeamCreate here.**
-**Do NOT spawn any agents here.**
+Then submit the plan for approval. Do not start implementation during Phase A.
 
 ---
 
-## Step A5: Submit the Plan for Approval
+# Phase B: Orchestration Protocol
 
-Call `ExitPlanMode` now.
+Phase B starts only after plan approval.
 
-The plan is the single artifact the user approves. It contains:
-- The implementation plan (phases, tasks, files)
-- The team roster (workers + confirmed reviewers)
-- The review protocol (consensus threshold, blocking rules)
+## Step B0: Parse the Approved Team Plan
 
-When the user approves, your ONLY next action is TeamCreate. See Phase B constraints.
+Read the approved `## Team Structure`, selected validators, reference files, automation
+eligibility, and state location.
 
----
-
-# Phase B: Orchestration Protocol (Claude/Gemini acts as the Team Lead)
-
-> **Phase B is not invoked as a separate agent.** When Phase A calls ExitPlanMode and the
-> user approves, Claude/Gemini reads this section as its operating instructions and acts as the **Team Lead** to orchestrate directly.
-> 
-> **Consensus Role Definition**:
-> - The **Team Lead** (main orchestrator agent) is responsible for the overall execution, routing fixes, and verifying changes.
-> - The **Reviewers** (subagents) evaluate implementation quality.
-> - **Consensus** is strictly a mutual agreement between the **Team Lead** and the **Reviewers** (max 3 rounds, achieving a score of >= 9.0/10).
-> - The **Human User** is a passive stakeholder who is **not** part of the consensus agreement loop or review-revise iterations. Do not prompt the user for approvals or consensus sign-offs between cycles.
+If the plan has no `## Team Structure`, stop and tell the user to run `/team-execute`.
 
 ---
 
-## ⚠️ Critical Constraints — Phase B Entry
+## Step B1: Workers Complete Changes
 
-These rules apply the moment the user approves the plan and ExitPlanMode returns:
-
-1. **Your ONLY permitted next action is TeamCreate.** No exceptions.
-2. **Do NOT use the Agent tool for any implementation work.** All work goes through TeamCreate workers listed in the `## Team Structure` table.
-3. **Do NOT spawn Explore, Plan, or general-purpose agents** for work that belongs to a worker.
-4. **Do NOT read files, analyze code, or do any preparatory work** before calling TeamCreate.
-5. **Parse the `## Team Structure` table → call TeamCreate → THEN proceed to B0.**
-
-If you find yourself about to use the Agent tool to implement something, stop. Route that work to the appropriate worker instead.
+Workers execute approved tasks. Coordinate dependencies and keep work scoped to the plan.
+When all worker tasks are complete, capture changed files and git diff summary for reviewers.
 
 ---
 
-## Step B0: Read the Plan's Team Structure
+## Step B2: Reviewers Reach Consensus
 
-Parse the `## Team Structure` table to identify:
+Run reviewers according to `consensus-protocol.md`.
 
-1. **Workers**: rows with `bypassPermissions` in the Mode column — your implementation
-   agents. Note each worker's name and assigned responsibilities.
-2. **Reviewers**: rows with reviewer role names (Security Reviewer, Devil's Advocate, etc.) —
-   your review agents. Note which are base vs optional.
-3. **Reference files**: the paths listed under `### Reference Files` in the plan — load these
-   before running the review cycle.
-
-If the plan does NOT have a `## Team Structure` section, stop and tell the user:
-```
-The plan does not have a ## Team Structure section. Please run /team-execute to enter
-plan mode and have the team-execution skill embed the team structure first.
-```
+- All confirmed reviewers score the implementation.
+- Consensus requires overall score >= 9.0/10 and no dimension < 7.0.
+- Security/auth/secrets dimension < 5.0 is a blocking stop.
+- Reviewer non-consensus blocks validators unless the user explicitly overrides.
+- Maximum 3 review cycles.
 
 ---
 
-## Step B1: Worker Kickoff
+## Step B3: Scanners Run
 
-Workers are spawned in `mode: "bypassPermissions"` — they have full permissions and begin
-implementing immediately. No permission prompts reach the user; quality is enforced by the
-review cycle in Step B3.
+Run selected scanner validators only after reviewer consensus or explicit user override.
 
-### B1a. Worker Start
+Scanners inspect local artifacts, code, dependency manifests, contracts, and infrastructure.
+Hard-fail scanner findings block auto-merge, nonprod deploy, and completion.
 
-Each worker:
-1. Reads its assigned tasks from the plan's `## Team Structure` table
-2. Reads relevant codebase context (existing files, patterns, conventions)
-3. Implements the assigned work directly
-4. Sends a brief summary to the orchestrator via SendMessage when complete (or if blocked)
-
-### B1b. Orchestrator Oversight
-
-Monitor worker progress via team messages and task status updates. If a worker's approach
-seems off-track, redirect via SendMessage before the work goes too far. Workers should
-acknowledge and adjust.
-
-**No hard approval gate** — the user approved the full plan in Phase A. Workers execute
-their assigned scope. The review cycle (Step B3) is the quality gate.
-
-### B1c. Parallelism
-
-Workers with no dependencies begin simultaneously. Workers with dependencies wait for
-their upstream tasks to reach `completed` status before starting.
+Missing required scanner tools fail loud with setup guidance. Optional scanner tools may be
+reported as skipped only if the validator is not required.
 
 ---
 
-## Step B2: Execution
+## Step B4: PR, CI, Merge, and Nonprod Coordination
 
-Workers implement their approved plans.
+Coordinate automation only if gates pass and automation is eligible:
 
-### B2a. Task Tracking
+1. Confirm remote matches `github.com/infiquetra/*`.
+2. Confirm default branch model.
+3. Confirm no production, staging, force-push, branch deletion, or credential-changing action.
+4. Run or monitor allowed `nonprod` or `publish-nonprod` workflows only.
 
-Workers update task status via `TaskUpdate`:
-- `in_progress` when starting a task
-- `completed` when done
-
-Monitor the task list and:
-- Unblock downstream workers when upstream tasks complete
-- Surface blockers to the user if a worker is stuck
-- Do NOT implement code directly — delegate to workers
-
-### B2b. Parallel Execution
-
-For plans with parallel work streams (marked `[P1]`, `[P2]`, etc. in the plan), workers
-operate simultaneously. Coordinate dependencies between streams.
-
-### B2c. Completion Signal
-
-When all tasks are `completed`, signal readiness for Step B3.
+If any signal is ambiguous, stop automation and report what is missing.
 
 ---
 
-## Step B3: Review Cycle (Team Lead & Reviewer Consensus)
+## Step B5: Testers Validate Deployed Nonprod Result
 
-Read `team-execution/skills/team-execution/references/consensus-protocol.md`
-for the full protocol. Summary below:
-- The **Team Lead** coordinates the review-revise cycles entirely autonomously.
-- Do not request the human user's approval or validation between cycles. 
-- Iteratively apply fixes and re-run reviews until consensus (score >= 9.0/10) is achieved or the 3-cycle cap is met.
+Run selected tester validators after a deploy or publish target is available.
 
-### B3a. Spawn Reviewers in Parallel
+Testers validate smoke targets, scenarios, contracts, SDK compatibility, event flows, UI
+regressions, performance thresholds, and concurrency behavior as applicable.
 
-Spawn ALL confirmed reviewers simultaneously. Provide each with:
-```
-Plan context: [1-3 sentence summary of what was built]
-Intended outcome: [what success looks like]
-Changes made: [git diff or list of changed files]
-Review rubrics: team-execution/skills/team-execution/references/review-criteria.md
-```
-
-### B3b. Collect and Display Scores
-
-After all reviewers complete, display:
-
-```
-## Review Cycle [N] Results
-
-| Reviewer | Score | Verdict | Issues |
-|----------|-------|---------|--------|
-| Devil's Advocate | X.X/10 | ACCEPT / NEEDS REVISION | N fixes |
-| Security Reviewer | X.X/10 | ACCEPT / NEEDS REVISION | N fixes |
-| Architecture Reviewer | X.X/10 | ACCEPT / NEEDS REVISION | N fixes |
-[Optional reviewers...]
-
-Consensus: [REACHED / NOT REACHED]
-```
-
-### B3c. Consensus Check
-
-**If ALL >= 9.0** → consensus reached → proceed to Step B4.
-
-**If any < 9.0**:
-1. Consolidate fix requests from all reviewers scoring < 9.0 (deduplicate overlaps)
-2. Route consolidated fixes to the responsible worker(s)
-3. Workers implement fixes
-4. Re-run Step B3a for ONLY the reviewers that scored < 9.0
-   (reviewers that already ACCEPTED do not re-review)
-5. Increment cycle counter
-
-### B3d. Cycle Cap
-
-After **3 iterations**: proceed to Step B4 regardless of scores. Document final scores and
-any unresolved fix requests in the completion report.
-
-### B3e. Blocking Issues
-
-If any security or auth dimension scores < 5.0:
-- Immediately flag to user
-- Do not wait for cycle to complete
-- Treat as a hard stop until that dimension reaches >= 7.0
+Hard-fail tester findings block completion. Run a maximum 3 remediation loops before escalating
+to the user.
 
 ---
 
-## Step B4: Completion
+## Step B6: Monitors Verify Runtime Signals
 
-### B4a. Final Report
+Run monitor validators:
 
-Present the completion summary:
+- `github-actions-monitor` checks workflow status and relevant logs.
+- `runtime-monitor` checks repository-appropriate observability: CloudWatch for AWS repos,
+  Prometheus/Grafana-style checks for home-lab/local-infra repos, and app health endpoints
+  where configured.
 
-```
-## Team Execution Complete
-
-Plan: [Plan name]
-Date: [Date]
-Iterations: [N] review cycle(s)
-
-### Final Review Scores
-| Reviewer | Score | Status |
-|----------|-------|--------|
-| Devil's Advocate | X.X/10 | ACCEPT |
-| Security Reviewer | X.X/10 | ACCEPT |
-| Architecture Reviewer | X.X/10 | ACCEPT |
-[Optional reviewers...]
-
-Consensus: [REACHED / NOT REACHED after 3 cycles]
-
-### Unresolved Issues
-[List if consensus not reached, otherwise "None"]
-
-### Changes Made
-[Summary of files changed and what was implemented]
-```
-
-### B4b. Commit (if applicable)
-
-If the plan involved code changes and commits are appropriate, prompt:
-```
-Ready to commit. Suggested message:
-  [type(scope): description based on plan]
-
-Proceed with commit, or would you like to adjust the message?
-```
-
-### B4c. Shutdown Team
-
-Gracefully shut down all teammates:
-1. Send `shutdown_request` to each worker
-2. Send `shutdown_request` to each reviewer
+If monitors cannot reach an expected signal, mark the gate blocked or warn based on whether
+the signal was required.
 
 ---
 
-## Error Handling
+## Step B7: Completion
 
-**Worker plan rejected 3+ times**: Escalate to user — the worker may need clarification on scope.
+Report:
 
-**Reviewer cannot access git diff**: Ask user to provide the changes as a summary or file list.
+- Worker changes.
+- Reviewer scores.
+- Scanner, tester, and monitor gate results.
+- Validator state location.
+- Evidence paths.
+- Automation actions taken or blocked.
+- Residual risks.
 
-**Architecture context not found**: Architecture Reviewer scores Architecture Documentation Coverage
-as N/A (8.0 default), notes that no ADR/architecture directory was found.
-
-**Worker stuck / blocked**: Notify user with the blocker details. Do not spin.
-
-**Review cycle > 3 iterations**: Proceed with best version, document scores. Never loop indefinitely.
+Do not claim completion while required validators are hard-failing or blocked unless the user
+explicitly accepts the residual risk.
 
 ---
 
-## Quick Reference: File Paths
+# Quick Reference: File Paths
 
-```
+```text
 team-execution/
 ├── .claude-plugin/plugin.json
-├── skills/team-execution/
-│   ├── SKILL.md                          ← this file (Phase A + Phase B)
-│   └── references/
-│       ├── reviewer-registry.md          ← keyword triggers, base/optional reviewer list
-│       ├── review-criteria.md            ← scoring rubrics for all reviewer types
-│       └── consensus-protocol.md         ← 3-iteration loop, re-review scoping
+├── docs/
+│   ├── agent-overflow.sh
+│   └── example_tmux.conf
+├── skills/
+│   ├── appsec-audit/SKILL.md
+│   └── team-execution/
+│       ├── SKILL.md
+│       └── references/
+│           ├── consensus-protocol.md
+│           ├── review-criteria.md
+│           ├── reviewer-registry.md
+│           ├── validator-criteria.md
+│           ├── validator-evidence-state.md
+│           ├── validator-execution-order.md
+│           ├── validator-pane-behavior.md
+│           ├── validator-registry.md
+│           └── validator-spawn-quirks.md
 ├── agents/
-│   ├── devils-advocate-reviewer.md       ← base (red)
-│   ├── security-reviewer.md              ← base (orange)
-│   ├── architecture-reviewer.md          ← base (purple)
-│   ├── infra-reviewer.md                 ← optional (blue)
-│   ├── api-reviewer.md                   ← optional (green)
-│   ├── testing-reviewer.md               ← optional (yellow)
-│   ├── code-quality-reviewer.md          ← optional (cyan)
-│   ├── privacy-reviewer.md               ← optional (pink)
-│   ├── clarity-reviewer.md               ← optional (teal)
-│   └── ai-usefulness-reviewer.md         ← optional (gold)
-└── commands/team-execute.md              ← /team-execute slash command
+│   ├── devils-advocate-reviewer.md
+│   ├── security-reviewer.md
+│   ├── architecture-reviewer.md
+│   └── [reviewer and validator agents]
+└── commands/
+    ├── team-execute.md
+    └── team-setup.md
 ```

--- a/plugins/team-execution/skills/team-execution/references/validator-criteria.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-criteria.md
@@ -1,0 +1,68 @@
+# Validator Criteria - team-execution
+
+Validators report evidence and gate status. They do not replace reviewer judgment.
+
+---
+
+## Gate Status
+
+| Status | Meaning | Effect |
+|--------|---------|--------|
+| pass | Required checks ran and found no blocking issue | Gate passes |
+| warn | Non-blocking issue or optional missing signal | Report and continue |
+| hard-fail | Blocking scanner/tester finding | Blocks auto-merge, nonprod deploy, and completion |
+| skipped-by-config | Disabled by `.team-execution.json` or explicit user choice | Report as skipped |
+| blocked | Required tool, target, credential, or signal is missing | Blocks required gate until resolved |
+
+---
+
+## Scanners
+
+Scanners must:
+
+- State selected tools and exact commands.
+- Fail loud when a selected required tool is missing.
+- Include setup guidance for missing tools.
+- Report findings with severity, file/path, evidence, and remediation.
+- Distinguish hard-fail from warn.
+
+Recommended hard-fail examples:
+
+- Secret-like value in tracked files.
+- High-confidence SSRF, command injection, SQL/NoSQL injection, or auth bypass risk.
+- Critical dependency or container vulnerability in a reachable path.
+- IaC rule that opens public access or grants broad IAM without justification.
+- Breaking API contract change without explicit versioning or migration.
+
+---
+
+## Testers
+
+Testers must:
+
+- Define target, command, and expected outcome before running.
+- Capture logs, exit codes, URLs, screenshots, or artifacts when applicable.
+- Fail loud when required targets or tools are missing.
+- Treat hard assertion failures as blocking.
+- Treat unreachable optional targets as warn unless marked required.
+
+---
+
+## Monitors
+
+Monitors must:
+
+- Identify the system being observed.
+- Record the time window inspected.
+- Capture current status and relevant failures.
+- Distinguish "healthy", "degraded", "missing signal", and "not applicable".
+
+---
+
+## Operational Agents
+
+Operational agents may coordinate only allowed nonprod automation. They must not perform
+production, staging, force-push, branch deletion, or credential-changing actions.
+
+Any ambiguous workflow name, environment, remote, branch model, or credential action is a
+blocked gate.

--- a/plugins/team-execution/skills/team-execution/references/validator-evidence-state.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-evidence-state.md
@@ -1,0 +1,72 @@
+# Validator Evidence and State - team-execution
+
+Validator evidence is stored as JSON state plus referenced artifacts.
+
+---
+
+## State Location
+
+Default repo-local state:
+
+```text
+.claude/team-execution/validators/
+```
+
+This location is valid only when `.claude/` is ignored by the target repository.
+
+If `.claude/` is not ignored, instruct the user to add an ignore rule or use:
+
+```text
+~/.claude/team-execution/state/<repo>/
+```
+
+---
+
+## State File Shape
+
+Use one JSON file per validator run:
+
+```json
+{
+  "validator": "security-scanner",
+  "group": "scanner",
+  "required": true,
+  "selection_reason": "Python API code and dependency lockfile changed",
+  "tools": [
+    {
+      "name": "bandit",
+      "command": "uv run bandit -r plugins/",
+      "available": true,
+      "setup": "uv add --dev bandit"
+    }
+  ],
+  "inputs": ["plugins/example", "pyproject.toml"],
+  "evidence": ["logs/security-scanner-2026-05-27.txt"],
+  "findings": [],
+  "status": "pass",
+  "remediation_loop": 0
+}
+```
+
+---
+
+## Evidence Rules
+
+- Keep evidence paths relative when they are inside the repo.
+- Do not store secrets, tokens, production identifiers, or sensitive payloads.
+- Prefer summaries plus artifact paths over large pasted logs.
+- Include exact command, exit code, and relevant stdout/stderr summary.
+- Include timestamps for remote CI and runtime checks.
+
+---
+
+## Completion Summary
+
+Final reports include:
+
+- Selected validators and why.
+- Skipped validators and why.
+- Gate result for each validator.
+- State directory.
+- Evidence paths.
+- Remaining warnings or blocked signals.

--- a/plugins/team-execution/skills/team-execution/references/validator-execution-order.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-execution-order.md
@@ -1,0 +1,44 @@
+# Validator Execution Order - team-execution
+
+Validators run after implementation and reviewer consensus.
+
+---
+
+## Phase B Order
+
+1. Workers complete changes.
+2. Reviewers reach consensus.
+3. Scanners run against local artifacts and code.
+4. PR/CI/merge/nonprod coordination happens only if scanner gates pass.
+5. Testers validate deployed nonprod results.
+6. Monitors verify CI and runtime signals.
+7. Completion reports evidence and residual risk.
+
+Reviewer non-consensus blocks validators unless the user explicitly overrides.
+
+---
+
+## Remediation Loops
+
+Scanner and tester hard-fails may enter remediation:
+
+1. Route finding to the responsible worker.
+2. Worker fixes the issue.
+3. Re-run only affected validators and relevant checks.
+4. Record the loop in validator state.
+
+Run a maximum of 3 remediation loops. After the third failed loop, escalate to the user with
+evidence, attempted fixes, and remaining risk.
+
+---
+
+## Blocking Rules
+
+Hard-fail scanner or tester findings block:
+
+- Auto-merge.
+- Nonprod deployment or publish.
+- Completion.
+
+Monitor blocked signals block completion only when the signal was required for the selected
+workflow. Otherwise, report a warning.

--- a/plugins/team-execution/skills/team-execution/references/validator-pane-behavior.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-pane-behavior.md
@@ -1,0 +1,49 @@
+# Validator Pane Behavior - team-execution
+
+This reference describes tmux pane behavior for team-execution sessions. It is guidance for
+display and navigation only; gate logic lives in validator criteria and execution order.
+
+---
+
+## Goals
+
+- Keep worker panes grouped when several workers run concurrently.
+- Keep reviewers readable during consensus.
+- Keep validators easy to inspect without crowding the orchestrator pane.
+
+---
+
+## Suggested Layout
+
+| Agent Type | Window/Panes |
+|------------|--------------|
+| Orchestrator | Main window |
+| Workers | Shared `workers` window, up to 4 panes tiled |
+| Reviewers | Solo windows named by reviewer |
+| Scanners | `scanners` window, up to 4 panes tiled |
+| Testers | `testers` window, up to 4 panes tiled |
+| Monitors | `monitors` window, up to 4 panes tiled |
+| Operational | Solo window named by agent |
+
+---
+
+## Bundled Assets
+
+`/team-setup` may install:
+
+- `docs/example_tmux.conf`
+- `docs/agent-overflow.sh`
+
+The overflow script routes panes by title. If the script cannot determine the agent type,
+it leaves the pane in its current window and prints a warning.
+
+---
+
+## Manual Inspection
+
+Useful tmux controls from the bundled config:
+
+- Prefix + `w`: window tree.
+- Prefix + `f`: find window.
+- Prefix + `z`: zoom current pane.
+- Prefix + arrow keys: move between panes.

--- a/plugins/team-execution/skills/team-execution/references/validator-registry.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-registry.md
@@ -1,0 +1,85 @@
+# Validator Registry - team-execution
+
+Validators provide post-review evidence. Select them by context; do not spawn every
+validator for every plan.
+
+---
+
+## Selection Inputs
+
+Phase A considers:
+
+- Repo type and language/tooling.
+- Changed files and staged files.
+- GitHub workflows.
+- Contracts and schemas.
+- Docs, runbooks, and scenario hints.
+- Existing tests and quality commands.
+- Optional `.team-execution.json`.
+
+Supported `.team-execution.json` keys:
+
+- `required_validators`
+- `disabled_validators`
+- `nonprod_workflows`
+- `scenario_hints`
+- `smoke_targets`
+
+Required validators block completion if they cannot run. Disabled validators do not run unless
+the user explicitly overrides.
+
+---
+
+## Scanners
+
+| Agent | Select When | OSS/Free Tool Candidates |
+|-------|-------------|--------------------------|
+| `security-scanner` | App code, secrets, auth, input handling, or broad code changes | Semgrep, Bandit, Gitleaks, detect-secrets |
+| `iac-cost-scanner` | CDK, CloudFormation, Terraform, Kubernetes, IAM, or cloud cost changes | Checkov, Trivy |
+| `api-compat-scanner` | OpenAPI/AsyncAPI/protobuf/GraphQL contract or endpoint changes | oasdiff, Schemathesis |
+| `dependency-scanner` | Dependency manifest, lockfile, base image, or package publishing changes | pip-audit, Trivy |
+
+Scanner hard-fail findings block auto-merge, nonprod deploy, and completion.
+
+---
+
+## Testers
+
+| Agent | Select When | OSS/Free Tool Candidates |
+|-------|-------------|--------------------------|
+| `smoke-tester` | Nonprod target, service entrypoint, CLI, health endpoint, or smoke target exists | curl/fetch, pytest, repo scripts |
+| `scenario-tester` | `scenario_hints` exist or the plan changes user-visible flows | pytest, repo scripts |
+| `api-contract-tester` | API contracts, schemas, or generated clients change | Schemathesis, oasdiff |
+| `sdk-regression-tester` | SDK package, generated client, or compatibility fixture changes | repo tests, package manager scripts |
+| `event-flow-tester` | Events, queues, webhooks, streams, or async workflows change | repo scripts, pytest |
+| `ui-regression-tester` | Frontend screens, routing, components, or browser workflows change | Playwright |
+| `performance-tester` | Latency, throughput, load, query, or runtime cost claims change | k6, repo benchmarks |
+| `concurrency-tester` | Locks, queues, idempotency, retries, or parallel workers change | pytest, repo stress scripts |
+
+Tester hard-fail findings block completion.
+
+---
+
+## Monitors
+
+| Agent | Select When | Evidence |
+|-------|-------------|----------|
+| `github-actions-monitor` | Any PR, CI, merge, or workflow action is part of the plan | GitHub Actions run status and relevant logs |
+| `runtime-monitor` | Nonprod deploy/publish or runtime health validation is part of the plan | CloudWatch, Prometheus/Grafana-style checks, app health endpoints |
+
+---
+
+## Operational
+
+| Agent | Select When | Evidence |
+|-------|-------------|----------|
+| `deploy-watcher` | A nonprod or publish-nonprod workflow is eligible and selected | Workflow run, artifact, environment URL, rollback notes |
+
+---
+
+## Automation Eligibility
+
+Automation may proceed only for `github.com/infiquetra/*`, only from the repo default branch
+model, only after gates pass, and only for nonprod or publish-nonprod workflows.
+
+Never automate production, staging, force-push, branch deletion, or credential changes.

--- a/plugins/team-execution/skills/team-execution/references/validator-spawn-quirks.md
+++ b/plugins/team-execution/skills/team-execution/references/validator-spawn-quirks.md
@@ -1,0 +1,55 @@
+# Validator Spawn Quirks - team-execution
+
+Validator agents are specialized evidence collectors. Spawn only selected validators.
+
+---
+
+## Context Package
+
+Each validator receives:
+
+- Plan summary and intended outcome.
+- Relevant changed files or diff summary.
+- Selected command/tool candidates.
+- Required vs optional status.
+- State file path.
+- Blocking rules.
+- Safety constraints.
+
+Do not ask validators to rediscover the whole repo when Phase A already selected them for a
+specific reason.
+
+---
+
+## Missing Tools
+
+If a selected required validator needs a missing tool:
+
+1. Mark status `blocked`.
+2. State the missing command.
+3. Provide setup guidance.
+4. Do not silently substitute a weaker check unless the user explicitly approves.
+
+Optional validators may report `warn` or `skipped-by-config` when their tools are absent.
+
+---
+
+## Avoid Duplicate Work
+
+- Scanners run before CI/nonprod coordination.
+- Testers run after a target exists.
+- Monitors inspect external signals after CI or deployment starts.
+- Re-run only validators affected by remediation.
+
+---
+
+## Automation Safety
+
+Before any validator coordinates an external action, confirm:
+
+- Remote is `github.com/infiquetra/*`.
+- Action is nonprod or publish-nonprod.
+- Reviewer, scanner, CI, and required tester gates have passed.
+- No production, staging, force-push, branch deletion, or credential change is involved.
+
+Ambiguity means blocked.

--- a/tests/test_pagerduty_client.py
+++ b/tests/test_pagerduty_client.py
@@ -511,7 +511,7 @@ class TestPagerDutyClient:
         assert output["data"][0]["name"] == "Jeff Cox"
 
     @patch("pagerduty_client.requests.request")
-    def test_vecu_defaults(self, mock_request, monkeypatch, capsys):
+    def test_infiquetra_defaults(self, mock_request, monkeypatch, capsys):
         """Test default team ID is loaded from environment variable."""
         monkeypatch.setenv("PAGERDUTY_API_KEY", "test-token")
         monkeypatch.setenv("PAGERDUTY_DEFAULT_TEAM_ID", "TEST_TEAM_ID")

--- a/tests/test_team_execution_plugin.py
+++ b/tests/test_team_execution_plugin.py
@@ -1,0 +1,123 @@
+"""Contract tests for the team-execution plugin package."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PLUGIN_ROOT = ROOT / "plugins" / "team-execution"
+
+VALIDATOR_AGENTS = {
+    "deploy-watcher",
+    "security-scanner",
+    "iac-cost-scanner",
+    "api-compat-scanner",
+    "dependency-scanner",
+    "smoke-tester",
+    "scenario-tester",
+    "api-contract-tester",
+    "sdk-regression-tester",
+    "event-flow-tester",
+    "ui-regression-tester",
+    "performance-tester",
+    "concurrency-tester",
+    "github-actions-monitor",
+    "runtime-monitor",
+}
+
+BASE_REVIEWERS = {
+    "devils-advocate-reviewer",
+    "security-reviewer",
+    "architecture-reviewer",
+}
+
+VALIDATOR_REFERENCES = {
+    "validator-registry.md",
+    "validator-criteria.md",
+    "validator-execution-order.md",
+    "validator-evidence-state.md",
+    "validator-spawn-quirks.md",
+    "validator-pane-behavior.md",
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _frontmatter_name(path: Path) -> str:
+    lines = _read(path).splitlines()
+    assert lines[0] == "---"
+    for line in lines[1:]:
+        if line.startswith("name: "):
+            return line.removeprefix("name: ").strip()
+    raise AssertionError(f"{path} has no frontmatter name")
+
+
+def test_team_execution_metadata_is_v2_and_marketplace_matches() -> None:
+    plugin_json = json.loads(_read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+    marketplace = json.loads(_read(ROOT / ".claude-plugin" / "marketplace.json"))
+    entry = next(p for p in marketplace["plugins"] if p["name"] == "team-execution")
+
+    assert plugin_json["version"] == "2.0.0"
+    assert entry["version"] == plugin_json["version"]
+    assert entry["source"] == "./plugins/team-execution"
+    assert "validator" in plugin_json["description"].lower()
+    assert "nonprod" in plugin_json["description"].lower()
+    assert {"validators", "automation", "nonprod"} <= set(plugin_json["keywords"])
+
+
+def test_validator_agents_and_base_reviewers_are_packaged() -> None:
+    agent_dir = PLUGIN_ROOT / "agents"
+    expected_agents = VALIDATOR_AGENTS | BASE_REVIEWERS
+
+    for agent_name in expected_agents:
+        path = agent_dir / f"{agent_name}.md"
+        assert path.exists(), f"missing agent file: {path}"
+        assert _frontmatter_name(path) == agent_name
+
+
+def test_validator_references_are_packaged_and_linked() -> None:
+    references_dir = PLUGIN_ROOT / "skills" / "team-execution" / "references"
+    skill_doc = _read(PLUGIN_ROOT / "skills" / "team-execution" / "SKILL.md")
+    readme = _read(PLUGIN_ROOT / "README.md")
+
+    for filename in VALIDATOR_REFERENCES:
+        path = references_dir / filename
+        assert path.exists(), f"missing validator reference: {path}"
+        assert filename in skill_doc
+        assert filename in readme
+
+
+def test_appsec_audit_skill_documents_url_trust_boundaries() -> None:
+    skill_path = PLUGIN_ROOT / "skills" / "appsec-audit" / "SKILL.md"
+    skill_doc = _read(skill_path).lower()
+
+    assert _frontmatter_name(skill_path) == "appsec-audit"
+    for required in ("ssrf", "redirect", "metadata endpoint", "allowlist", "trust boundary"):
+        assert required in skill_doc
+
+
+def test_team_setup_references_existing_assets() -> None:
+    setup_doc = _read(PLUGIN_ROOT / "commands" / "team-setup.md")
+
+    for asset in ("docs/example_tmux.conf", "docs/agent-overflow.sh"):
+        assert asset in setup_doc
+        assert (PLUGIN_ROOT / asset).exists(), f"setup references missing asset: {asset}"
+
+
+def test_skill_documents_validator_state_and_automation_gates() -> None:
+    skill_doc = _read(PLUGIN_ROOT / "skills" / "team-execution" / "SKILL.md")
+
+    for required in (
+        ".team-execution.json",
+        "required_validators",
+        "disabled_validators",
+        "nonprod_workflows",
+        "scenario_hints",
+        "smoke_targets",
+        ".claude/team-execution/validators/",
+        "github.com/infiquetra/*",
+        "nonprod",
+        "maximum 3 remediation loops",
+    ):
+        assert required in skill_doc

--- a/tools/create-plugin.sh
+++ b/tools/create-plugin.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# create-plugin.sh - Create a new VECU Claude plugin from template
+# create-plugin.sh - Create a new Infiquetra Claude plugin from template
 #
 # Usage: ./tools/create-plugin.sh <plugin-id> <plugin-name>
-# Example: ./tools/create-plugin.sh api-tester "VECU API Tester"
+# Example: ./tools/create-plugin.sh api-tester "Infiquetra API Tester"
 
 set -euo pipefail
 
@@ -41,8 +41,8 @@ if [ $# -lt 2 ]; then
     print_error "Usage: $0 <plugin-id> <plugin-name>"
     echo ""
     echo "Examples:"
-    echo "  $0 api-tester \"VECU API Tester\""
-    echo "  $0 log-analyzer \"VECU Log Analyzer\""
+    echo "  $0 api-tester \"Infiquetra API Tester\""
+    echo "  $0 log-analyzer \"Infiquetra Log Analyzer\""
     exit 1
 fi
 
@@ -55,7 +55,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if ! [[ "$PLUGIN_ID" =~ ^[a-z0-9-]+$ ]]; then
     print_error "Plugin ID must be in kebab-case (lowercase letters, numbers, and hyphens only)"
     echo "  Valid: api-tester, log-analyzer"
-    echo "  Invalid: VecuApiTester, vecu_api_tester"
+    echo "  Invalid: InfiquetraApiTester, infiquetra_api_tester"
     exit 1
 fi
 
@@ -65,7 +65,7 @@ if [ -d "$REPO_ROOT/$PLUGIN_DIR" ]; then
     exit 1
 fi
 
-print_header "🚀 Creating new VECU Claude plugin: $PLUGIN_NAME"
+print_header "🚀 Creating new Infiquetra Claude plugin: $PLUGIN_NAME"
 
 # Create directory structure
 print_info "Creating directory structure..."
@@ -82,7 +82,7 @@ cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<EOF
   "name": "$PLUGIN_NAME",
   "description": "Description for $PLUGIN_NAME - update this!",
   "author": {
-    "name": "VECU Team",
+    "name": "Infiquetra Team",
     "email": "hello@infiquetra.com",
     "organization": "your organization"
   },
@@ -110,7 +110,7 @@ cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<EOF
     "mypy": ">=1.8.0"
   },
   "keywords": [
-    "vecu"
+    "infiquetra"
   ],
   "config": {},
   "permissions": [],
@@ -124,7 +124,7 @@ print_info "Generating main script..."
 cat > "$PLUGIN_DIR/src/main.py" <<'EOF'
 #!/usr/bin/env python3
 """
-Main script for VECU Claude plugin.
+Main script for Infiquetra Claude plugin.
 
 This is a template - customize it for your plugin's functionality.
 """
@@ -137,7 +137,7 @@ from pathlib import Path
 def main():
     """Main entry point for the plugin."""
     parser = argparse.ArgumentParser(
-        description="VECU Claude Plugin"
+        description="Infiquetra Claude Plugin"
     )
     parser.add_argument(
         "--verbose",
@@ -148,7 +148,7 @@ def main():
 
     args = parser.parse_args()
 
-    print("Hello from your VECU plugin!")
+    print("Hello from your Infiquetra plugin!")
     print("Implement your plugin logic here.")
 
     if args.verbose:
@@ -204,16 +204,16 @@ python3 src/main.py --verbose
 ### Example 1: Basic Usage
 \`\`\`bash
 $ python3 src/main.py
-Hello from your VECU plugin!
+Hello from your Infiquetra plugin!
 \`\`\`
 
 ## Configuration
 
 Describe any configuration options or environment variables.
 
-## Integration with VECU Workflows
+## Integration with Infiquetra Workflows
 
-Describe how this plugin integrates with VECU development workflows.
+Describe how this plugin integrates with Infiquetra development workflows.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Bump `team-execution` and the marketplace entry to `2.0.0`.
- Add validator orchestration docs, references, appsec audit skill, setup assets, and validator agent roster.
- Remove source-domain residue from tracked plugin docs, examples, templates, and changelog text.

## Verification
- `uv run pytest` passed: 553 tests.
- `uv run ruff check .` passed.
- `uv run bandit -r plugins/team-execution` passed.
- `git diff --check` passed.
- Tracked-file forbidden-term scan passed.

## Notes
- `uv run bandit -r plugins/` still reports pre-existing low-severity findings outside `team-execution`; no medium or high findings were reported.