### PR TITLE
chore: update context library repo names

### DIFF
--- a/plugins/blueprint-reviewer/commands/spec-review.md
+++ b/plugins/blueprint-reviewer/commands/spec-review.md
@@ -15,7 +15,7 @@ appended to the spec's section-embedded review log.
 ## Arguments
 
 - `path` — Path to a spec file (e.g.
-  `campps-blueprint/specs/registration/spec.md`). If omitted, the
+  `campps-context-library/specs/registration/spec.md`). If omitted, the
   skill will ask.
 - `--reviewers <slug,slug,...>` — Run only named reviewers.
 - `--cores-only` — Skip conditional extras.

--- a/plugins/blueprint-reviewer/skills/blueprint-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/blueprint-review/SKILL.md
@@ -11,7 +11,7 @@ when_to_use: |
 
   Direct invocation:
   - "review this blueprint section"
-  - "review section 4 of campps-blueprint"
+  - "review section 4 of campps-context-library"
   - "review adr-001"
   - "review the executive-summary section"
   - "/blueprint-review path/to/file.md"

--- a/plugins/blueprint-reviewer/skills/issue-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/issue-review/SKILL.md
@@ -71,7 +71,7 @@ no spec is named, that's already a `spec_fidelity` finding.
 
 For repos in the working set (e.g. `infiquetra/campps-mvp`), the
 parent spec typically lives in the corresponding blueprint repo
-(e.g. `infiquetra/campps-blueprint/specs/...`).
+(e.g. `infiquetra/campps-context-library/specs/...`).
 
 ### 3. Read existing comments
 

--- a/plugins/blueprint-reviewer/skills/spec-review/SKILL.md
+++ b/plugins/blueprint-reviewer/skills/spec-review/SKILL.md
@@ -54,7 +54,7 @@ should I review?" Specs live at:
 
 - `<blueprint-repo>/specs/<area>/<spec>.md`
 
-E.g. `campps-blueprint/specs/testing/testing-strategy.md`.
+E.g. `campps-context-library/specs/testing/testing-strategy.md`.
 
 ### 2. Read the spec + its parent blueprint section
 
@@ -132,7 +132,7 @@ Notes specific to spec-phase reviewers:
 Same summary-table-first format as blueprint review. Example:
 
 ```
-## Review summary — campps-blueprint/specs/registration/spec.md
+## Review summary — campps-context-library/specs/registration/spec.md
 
 | Reviewer | Score | Verdict | Headline |
 |---|---|---|---|

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -202,7 +202,7 @@ python3 $SCRIPT flow discover-project --repo athena-service
 
 # Link child as native sub-issue of parent (cross-repo, idempotent)
 python3 $SCRIPT flow link-sub-issue \
-    --parent-repo campps-blueprint --parent-number 1 \
+    --parent-repo campps-context-library --parent-number 1 \
     --child-repo campps-mvp --child-number 42
 
 # Self-healing label create (404 → create; exists → no-op; auth/server errors raise)

--- a/plugins/sdlc-manager/agents/sdlc-operator.md
+++ b/plugins/sdlc-manager/agents/sdlc-operator.md
@@ -132,7 +132,7 @@ python "$SCRIPT" issue create --repo <repo> --type <capability|enhancement|defec
 
 # With pre-supplied parent (skips the sub-issue prompt):
 python "$SCRIPT" issue create --repo <repo> --type capability \
-    --parent-ref campps-blueprint#1
+    --parent-ref campps-context-library#1
 ```
 
 This is a 10-step flow (full details in `issue_create` docstring):
@@ -178,7 +178,7 @@ python "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <
 
 # 5. Link as native sub-issue (cross-repo, idempotent)
 python "$SCRIPT" flow link-sub-issue \
-    --parent-repo campps-blueprint --parent-number <P> \
+    --parent-repo campps-context-library --parent-number <P> \
     --child-repo <repo> --child-number <N>
 
 # 6. (Optional) Link to milestone if the parent Objective has one
@@ -282,7 +282,7 @@ python "$SCRIPT" milestones progress --repo <repo> --milestone <N>
 ### Blueprint-Driven Issue Creation (batched)
 
 ```
-1. Read relevant blueprint sections (campps-blueprint, mimir-blueprint, etc.)
+1. Read relevant blueprint sections (campps-context-library, mimir-context-library, etc.)
 2. Identify work items needed (capabilities, enhancements, context updates)
 3. Map each item to the appropriate consumer repo
 4. For each item:
@@ -396,7 +396,7 @@ Step 2: Applied labels (hermes-task, capability, needs-analysis)
 Step 3: Added to Mount Olympus board
 Step 4: Set Initiative=olympus-quality on #142 (project field, not label)
 Step 5: Set Objective=Auth Pilot on #142
-Step 6: Linked as sub-issue of campps-blueprint#1
+Step 6: Linked as sub-issue of campps-context-library#1
 Step 7: Validated card body: PASSED
 ```
 

--- a/plugins/sdlc-manager/config/project-mappings.json
+++ b/plugins/sdlc-manager/config/project-mappings.json
@@ -9,7 +9,7 @@
       "name": "Olympus",
       "_id_note": "Project node id captured 2026-05-04. If it rotates (project rename/recreate), re-fetch via: gh project view 1 --owner infiquetra --format json -q .id",
       "repositories": [
-        "campps-blueprint",
+        "campps-context-library",
         "campps-mvp",
         "github-actions-runners",
         "hermes-extensions",
@@ -17,7 +17,7 @@
         "infiquetra-claude-plugins",
         "infiquetra-sdlc",
         "mimir",
-        "mimir-blueprint"
+        "mimir-context-library"
       ]
     }
   },

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -2535,7 +2535,7 @@ def _prompt_parent_issue() -> tuple[str, int] | None:
     'free-floating' / 'no parent'. Default is 'yes — paste a ref'; the
     operator types 'no' (or 'n') to skip."""
     print("\nSub-issue first: every new card has a parent by default.")
-    print("Paste a parent ref like 'campps-blueprint#42' or type 'no' to skip.")
+    print("Paste a parent ref like 'campps-context-library#42' or type 'no' to skip.")
     raw = _safe_input("Parent issue? (yes/no/<repo#N>) [yes]: ")
     if raw is None:
         return None  # Ctrl+D / Ctrl+C → treat as no-parent
@@ -2545,7 +2545,7 @@ def _prompt_parent_issue() -> tuple[str, int] | None:
         return None
     if answer in ("yes", "y", ""):
         # Operator confirmed but didn't paste a ref — re-prompt for the ref
-        ref = _safe_input("Parent ref (e.g., campps-blueprint#42): ")
+        ref = _safe_input("Parent ref (e.g., campps-context-library#42): ")
         if ref is None:
             return None
         match = _PARENT_REF_RE.match(ref)

--- a/plugins/sdlc-manager/skills/sdlc-flow/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-flow/SKILL.md
@@ -26,7 +26,7 @@ when_to_use: |
 
   Link a child issue as a sub-issue of a parent:
   - "Link #43 as a sub-issue of #42"
-  - "Make this a child of campps-blueprint#1"
+  - "Make this a child of campps-context-library#1"
   - "Set up the parent/child relationship between these issues"
 
   Self-heal missing labels (so other operations don't fail mid-flow):
@@ -71,7 +71,7 @@ sdlc_manager.py flow discover-project --repo athena-service
 
 # Link child as native sub-issue of parent (cross-repo OK; idempotent)
 sdlc_manager.py flow link-sub-issue \
-  --parent-repo campps-blueprint --parent-number 1 \
+  --parent-repo campps-context-library --parent-number 1 \
   --child-repo campps-mvp --child-number 42
 
 # Self-healing label: 404 → create; exists → no-op; other errors raise

--- a/plugins/sdlc-manager/tests/test_flow_subcommands.py
+++ b/plugins/sdlc-manager/tests/test_flow_subcommands.py
@@ -43,7 +43,7 @@ def test_link_sub_issue_idempotent_on_already_exists() -> None:
             status_code=422,
         )
 
-        sdlc_manager.flow_link_sub_issue("campps-blueprint", 1, "campps-mvp", 42, fmt="text")
+        sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
 
         # Should NOT have raised; should have called _out with idempotent message
         msgs = [c.args[0] for c in mock_out.call_args_list]
@@ -66,7 +66,7 @@ def test_link_sub_issue_raises_on_real_error() -> None:
         mock_post.side_effect = RuntimeError("API call failed: 500 Internal Server Error")
 
         with pytest.raises(RuntimeError, match="500"):
-            sdlc_manager.flow_link_sub_issue("campps-blueprint", 1, "campps-mvp", 42, fmt="text")
+            sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
 
 
 def test_link_sub_issue_rejects_pr_as_parent() -> None:

--- a/plugins/sdlc-manager/tests/test_flow_subcommands.py
+++ b/plugins/sdlc-manager/tests/test_flow_subcommands.py
@@ -66,7 +66,9 @@ def test_link_sub_issue_raises_on_real_error() -> None:
         mock_post.side_effect = RuntimeError("API call failed: 500 Internal Server Error")
 
         with pytest.raises(RuntimeError, match="500"):
-            sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
+            sdlc_manager.flow_link_sub_issue(
+                "campps-context-library", 1, "campps-mvp", 42, fmt="text"
+            )
 
 
 def test_link_sub_issue_rejects_pr_as_parent() -> None:

--- a/plugins/sdlc-manager/tests/test_issue_create_interactive.py
+++ b/plugins/sdlc-manager/tests/test_issue_create_interactive.py
@@ -47,9 +47,9 @@ def test_select_issue_type_handles_eof_returns_default() -> None:
 
 
 def test_parent_prompt_parses_direct_ref() -> None:
-    """Operator pastes 'campps-blueprint#42' directly at the prompt."""
-    with patch("builtins.input", return_value="campps-blueprint#42"):
-        assert sdlc_manager._prompt_parent_issue() == ("campps-blueprint", 42)
+    """Operator pastes 'campps-context-library#42' directly at the prompt."""
+    with patch("builtins.input", return_value="campps-context-library#42"):
+        assert sdlc_manager._prompt_parent_issue() == ("campps-context-library", 42)
 
 
 def test_parent_prompt_yes_then_ref() -> None:
@@ -234,7 +234,7 @@ def test_metadata_applies_hermes_not_actionable_for_objective() -> None:
         patch.object(sdlc_manager, "load_config", return_value={}),
     ):
         sdlc_manager._apply_post_create_metadata(
-            repo="campps-blueprint",
+            repo="campps-context-library",
             issue_number=1,
             issue_type="objective",
             project_name=None,
@@ -270,7 +270,7 @@ def test_metadata_label_failure_does_not_abort_other_steps() -> None:
             issue_number=42,
             issue_type="capability",
             project_name="mount-olympus",
-            parent=("campps-blueprint", 1),
+            parent=("campps-context-library", 1),
             field_values={"Initiative": "olympus-quality"},
             fmt="text",
         )
@@ -297,7 +297,7 @@ def test_metadata_skips_field_apply_when_no_project() -> None:
             issue_number=42,
             issue_type="capability",
             project_name=None,
-            parent=("campps-blueprint", 1),
+            parent=("campps-context-library", 1),
             field_values={"Initiative": "olympus-quality"},
             fmt="text",
         )
@@ -313,7 +313,7 @@ def test_parent_ref_regex_accepts_realistic_refs() -> None:
     def parse(s: str):
         return sdlc_manager._PARENT_REF_RE.match(s)
 
-    assert parse("campps-blueprint#42") is not None
+    assert parse("campps-context-library#42") is not None
     assert parse("infiquetra-sdlc#7") is not None
     assert parse("a.b.c#99") is not None  # dots allowed for completeness
     assert parse("repo#0") is not None  # not pretty but valid syntactically

--- a/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
+++ b/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
@@ -125,7 +125,7 @@ def test_vendored_project_mappings_has_expected_canonical_state() -> None:
     # file needs updating + this test needs updating in the same PR — the
     # symmetry forces the operator to re-verify.
     expected_repos = {
-        "campps-blueprint",
+        "campps-context-library",
         "campps-mvp",
         "github-actions-runners",
         "hermes-extensions",
@@ -133,7 +133,7 @@ def test_vendored_project_mappings_has_expected_canonical_state() -> None:
         "infiquetra-claude-plugins",
         "infiquetra-sdlc",
         "mimir",
-        "mimir-blueprint",
+        "mimir-context-library",
     }
     actual_repos = set(olympus["repositories"])
     assert actual_repos == expected_repos, (

--- a/plugins/sdlc-manager/tests/test_typed_exceptions.py
+++ b/plugins/sdlc-manager/tests/test_typed_exceptions.py
@@ -210,7 +210,7 @@ def test_flow_link_sub_issue_idempotent_via_ApiAlreadyExists() -> None:
             stderr="HTTP 422: Validation Failed ... already exists",
         )
 
-        sdlc_manager.flow_link_sub_issue("campps-blueprint", 1, "campps-mvp", 42, fmt="text")
+        sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
 
         msgs = [c.args[0] for c in mock_out.call_args_list]
         assert any("Already linked" in m for m in msgs), (
@@ -236,7 +236,7 @@ def test_flow_link_sub_issue_raises_on_non_duplicate_422() -> None:
             status_code=422,
         )
         with pytest.raises(sdlc_manager.GhApiError) as exc_info:
-            sdlc_manager.flow_link_sub_issue("campps-blueprint", 1, "campps-mvp", 42, fmt="text")
+            sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
         # Confirm it's not the ApiAlreadyExists subclass
         assert not isinstance(exc_info.value, sdlc_manager.ApiAlreadyExists)
 

--- a/plugins/sdlc-manager/tests/test_typed_exceptions.py
+++ b/plugins/sdlc-manager/tests/test_typed_exceptions.py
@@ -236,7 +236,9 @@ def test_flow_link_sub_issue_raises_on_non_duplicate_422() -> None:
             status_code=422,
         )
         with pytest.raises(sdlc_manager.GhApiError) as exc_info:
-            sdlc_manager.flow_link_sub_issue("campps-context-library", 1, "campps-mvp", 42, fmt="text")
+            sdlc_manager.flow_link_sub_issue(
+                "campps-context-library", 1, "campps-mvp", 42, fmt="text"
+            )
         # Confirm it's not the ApiAlreadyExists subclass
         assert not isinstance(exc_info.value, sdlc_manager.ApiAlreadyExists)
 


### PR DESCRIPTION
## Summary

- Update tracked references from the old blueprint repository names to the renamed context-library repositories.
- Replace GitHub URLs, local path examples, mappings, tests, and docs that used `campps-blueprint` or `mimir-blueprint`.
- Leave generic blueprint terminology intact where it refers to an artifact type rather than the renamed repositories.

## Verification

- `git diff --check`
- `git grep -n -I -e 'campps-blueprint' -e 'mimir-blueprint' -- .` returned no tracked matches
- Repo-specific checks were run where applicable: docs validation, targeted SDLC-manager tests, and Python syntax compilation.
