### PR TITLE
Add Infiquetra loop and deploy plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -273,6 +273,51 @@
       "category": "infrastructure"
     },
     {
+      "name": "infiquetra-deploy",
+      "source": "./plugins/infiquetra-deploy",
+      "version": "0.1.0",
+      "description": "tag-promotion deployment operations for Infiquetra repositories.",
+      "author": {
+        "name": "Infiquetra",
+        "email": "hello@infiquetra.com"
+      },
+      "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+      "license": "MIT",
+      "keywords": [
+        "deploy",
+        "tag-promotion",
+        "rollback",
+        "hotfix",
+        "release-notes",
+        "infiquetra"
+      ],
+      "category": "automation"
+    },
+    {
+      "name": "infiquetra-loop",
+      "source": "./plugins/infiquetra-loop",
+      "version": "0.1.0",
+      "description": "Infiquetra lifecycle workflow plugin for strategy, planning, work execution, review, QA, and resume.",
+      "author": {
+        "name": "Infiquetra",
+        "email": "hello@infiquetra.com"
+      },
+      "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+      "license": "MIT",
+      "keywords": [
+        "loop",
+        "lifecycle",
+        "strategy",
+        "ideation",
+        "brainstorm",
+        "code-review",
+        "optimize",
+        "qa",
+        "sdlc"
+      ],
+      "category": "development"
+    },
+    {
       "name": "team-execution",
       "source": "./plugins/team-execution",
       "version": "2.0.0",
@@ -366,5 +411,5 @@
       "category": "development"
     }
   ],
-  "version": "2.1.0"
+  "version": "2.2.0"
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Claude Code plugins for Infiquetra development workflows.
 | [docs-generator](plugins/docs-generator/) | Automated README, API spec, and architecture documentation generation | Development |
 | [python-toolkit](plugins/python-toolkit/) | Python patterns for serverless apps: Lambda Powertools, DynamoDB, error handling | Development |
 | [sdk-lifecycle](plugins/sdk-lifecycle/) | SDK scaffolding, documentation, security review, and registry publishing | Development |
+| [infiquetra-deploy](plugins/infiquetra-deploy/) | Tag-promotion deploy, status, rollback, hotfix, and release-note workflows | Operations |
+| [infiquetra-loop](plugins/infiquetra-loop/) | Infiquetra lifecycle loop for strategy, planning, work, review, QA, retro, and resume | Development |
 
 ## Installation
 
@@ -80,6 +82,19 @@ python3 plugins/test-suite/skills/run-quality-checks/scripts/test_runner.py \
 # Generate all documentation
 python3 plugins/docs-generator/skills/generate-docs/scripts/docs_generator.py generate --all --service my-service
 ```
+
+### Infiquetra Deploy
+```bash
+python3 plugins/infiquetra-deploy/scripts/mint_tag.py \
+    --env nonprod \
+    --version 1.2.3 \
+    --dry-run
+```
+
+### Infiquetra Loop
+Use `/loop` to route work to plan only, PR, merge, or nonprod deploy. Durable artifacts live in
+repo docs such as `docs/plans/`, `docs/work-sessions/`, and `docs/engineering-journal/`; raw
+runtime state stays under ignored `.claude/infiquetra-loop/`.
 
 ### Splunk
 ```bash

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,42 @@
 
 ---
 
+## 2026-05-29
+
+### Split Infiquetra lifecycle orchestration from deployment mutation (commit pending)  {#infiquetra-loop-deploy-boundary}
+
+**Decision.** Add `infiquetra-loop` as the daily lifecycle orchestration plugin and
+`infiquetra-deploy` as a separate deployment plugin. `infiquetra-loop` owns office-hours,
+strategy, ideation, brainstorm, planning, work execution, code review, optimization, QA, SDLC
+issue progress, engineering-journal prompts, retro, and resume. `infiquetra-deploy` owns
+tag-promotion deployment, status, release notes, rollback, and hotfix helpers. `team-execution`
+remains independent and is offered only when risk, size, or parallelism justify the cost.
+
+**Rejected alternatives.**
+- *One merged super-plugin.* Rejected: deployment mutation has a higher blast radius than
+  lifecycle coaching and should keep a hard operational boundary.
+- *Copy Superpowers, Compound Engineering, gstack, and VECU workflows wholesale.* Rejected:
+  the useful pieces need to be adapted to Infiquetra docs, SDLC, and context-library references;
+  generic cleanup, GitHub helper, and plugin-management utilities are intentionally out of scope.
+- *Version raw loop state as repo artifacts.* Rejected: durable plans and work-session summaries
+  belong in repo docs, but raw checkpoint state, API caches, validator JSON, and resume scratch
+  are local session data and already covered by the `.claude/` ignore convention.
+
+**Rationale.** The split lets the daily loop replace recurring Superpowers and Compound
+Engineering lifecycle use while still enforcing a clear deployment safety boundary. Durable docs
+give session-to-session continuity without committing stale runtime state. Keeping `team-execution`
+separate preserves its validator and nonprod automation contract without forcing every loop to pay
+that token or coordination cost.
+
+**Revisit when.** Deployment policy moves out of tag-promotion, loop usage shows deployment
+handoff friction dominates safety value, or `team-execution` becomes cheap enough to run by
+default on normal work.
+
+**Refs.** `plugins/infiquetra-loop/`, `plugins/infiquetra-deploy/`,
+[team-execution v2 decision](#team-execution-v2-validators).
+
+---
+
 ## 2026-05-27
 
 ### `team-execution` v2 uses context-selected validators and guarded nonprod automation (commit pending)  {#team-execution-v2-validators}

--- a/plugins/infiquetra-deploy/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-deploy/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "infiquetra-deploy",
+  "version": "0.1.0",
+  "description": "tag-promotion deployment operations for Infiquetra repositories.",
+  "author": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+  "keywords": [
+    "deploy",
+    "tag-promotion",
+    "rollback",
+    "hotfix",
+    "release-notes",
+    "infiquetra"
+  ]
+}

--- a/plugins/infiquetra-deploy/CHANGELOG.md
+++ b/plugins/infiquetra-deploy/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-05-29
+
+- Add Infiquetra tag-promotion deploy commands and deploy-state skill.
+- Add release orchestrator guidance for rollback, hotfix, status, and release notes.
+- Add deterministic helpers for tag naming, deployment status drift, and release-note preview.
+- Preserve VECU deploy safety mechanics source-neutrally: version inference, hotfix refs,
+  rollback tags, existing-tag rejection, dry-run protection, and unhealthy snapshot quarantine.

--- a/plugins/infiquetra-deploy/README.md
+++ b/plugins/infiquetra-deploy/README.md
@@ -1,0 +1,34 @@
+# infiquetra-deploy
+
+Deployment commands for Infiquetra repositories that use tag-promotion workflows.
+
+## Commands
+
+- `/deploy` previews or pushes `nonprod`, `staging`, `production`, and rollback tags.
+- `/deploy-status` reports environment status and version drift.
+- `/deploy-notes` previews release notes for a candidate range.
+- `/deploy-hotfix` prepares hotfix tags and evidence.
+
+## Guardrails
+
+- Mutating commands must resolve the target repository to `github.com/infiquetra/*`.
+- Dry runs never push tags.
+- Staging, production, rollback, and hotfix promotions require explicit confirmation.
+- Long-lived policy is linked from the Infiquetra context library, especially ADR-0004.
+- Forward promotions refuse snapshots marked with `unhealthy-v<version>` unless an explicit
+  audited override is supplied.
+- If no version is supplied, nonprod infers from the latest `v*` snapshot, staging infers from
+  current nonprod, and production infers from current staging.
+
+## Helpers
+
+```bash
+python3 plugins/infiquetra-deploy/scripts/mint_tag.py \
+  --env nonprod \
+  --version 1.2.3 \
+  --dry-run
+```
+
+```bash
+python3 plugins/infiquetra-deploy/scripts/query_deployments.py --repo campps-service
+```

--- a/plugins/infiquetra-deploy/agents/release-orchestrator.md
+++ b/plugins/infiquetra-deploy/agents/release-orchestrator.md
@@ -1,0 +1,24 @@
+---
+name: release-orchestrator
+description: Coordinate Infiquetra tag-promotion releases, rollback evidence, and hotfix gates
+tools: Read, Glob, Bash, WebFetch
+---
+
+# Release Orchestrator
+
+Coordinate Infiquetra deployment work without owning product or code-review decisions.
+
+## Responsibilities
+
+- Verify repository ownership before mutation.
+- Classify available deployment workflows and tag-promotion coverage.
+- Prepare deployment notes, rollback notes, and workflow links.
+- Ask for explicit approval before pushing staging, production, rollback, or hotfix tags.
+- Keep issue and PR deployment comments concise and evidence-backed.
+
+## Boundaries
+
+- Do not deploy non-Infiquetra repositories.
+- Do not bypass repository checks, branch protection, or SDLC gates.
+- Do not turn deployment state into committed raw cache files.
+- Do not replace `team-execution`; invoke it only when the release needs broader validation.

--- a/plugins/infiquetra-deploy/commands/deploy-hotfix.md
+++ b/plugins/infiquetra-deploy/commands/deploy-hotfix.md
@@ -1,0 +1,20 @@
+---
+name: deploy-hotfix
+description: Prepare and promote an Infiquetra hotfix tag through the deployment workflow
+argument-hint: "[staging|production] [hotfix-version] [--dry-run]"
+---
+
+Prepare an Infiquetra hotfix deployment.
+
+## Instructions
+
+1. Load `infiquetra-deploy/skills/deploy-state/SKILL.md`.
+2. Verify the issue, regression scope, rollback path, and target environment.
+3. Use the same tag-promotion script as `/deploy`; hotfix versions normally use an extra patch
+   segment such as `1.2.3.1`.
+4. For production hotfixes, require explicit user approval before tag push.
+5. Update the related issue with the tag, workflow URL, checks, and follow-up risks.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-deploy/commands/deploy-notes.md
+++ b/plugins/infiquetra-deploy/commands/deploy-notes.md
@@ -1,0 +1,19 @@
+---
+name: deploy-notes
+description: Preview release notes for an Infiquetra tag-promotion deployment
+argument-hint: "[base-ref] [head-ref]"
+---
+
+Preview deployment notes before promotion.
+
+## Instructions
+
+1. Load `infiquetra-deploy/skills/deploy-state/SKILL.md`.
+2. Use `plugins/infiquetra-deploy/scripts/preview_release_notes.py` to inspect the commit
+   range and produce a concise operator-facing summary.
+3. Include issue links, PR links, deployment tags, checks, and risk notes when available.
+4. Do not create GitHub releases unless the user explicitly asks for that mutation.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-deploy/commands/deploy-status.md
+++ b/plugins/infiquetra-deploy/commands/deploy-status.md
@@ -1,0 +1,19 @@
+---
+name: deploy-status
+description: Show Infiquetra deployment status and version drift across environments
+argument-hint: "[repo]"
+---
+
+Show deployment status for an Infiquetra repository.
+
+## Instructions
+
+1. Load `infiquetra-deploy/skills/deploy-state/SKILL.md`.
+2. Resolve the repository through `plugins/infiquetra-deploy/scripts/query_deployments.py`.
+3. Report the latest `nonprod`, `staging`, and `production` deployments.
+4. Strip environment prefixes when comparing versions.
+5. Call out drift, missing environments, and the GitHub Actions workflow URL when available.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-deploy/commands/deploy.md
+++ b/plugins/infiquetra-deploy/commands/deploy.md
@@ -1,0 +1,30 @@
+---
+name: deploy
+description: Promote an Infiquetra repository by minting a policy-compliant deployment tag
+argument-hint: "[nonprod|staging|production] [version] [--dry-run]"
+---
+
+Promote an Infiquetra repository through the tag-promotion deployment workflow.
+
+## Instructions
+
+1. Load `infiquetra-deploy/skills/deploy-state/SKILL.md`.
+2. Confirm the target repository resolves to `github.com/infiquetra/*`.
+3. Confirm the target environment is `nonprod`, `staging`, or `production`.
+4. Preview the tag and workflow URL before mutating anything.
+5. Use `plugins/infiquetra-deploy/scripts/mint_tag.py` for deterministic tag naming.
+6. For production, rollback, or hotfix work, state the blast radius and ask for explicit
+   confirmation before pushing a tag.
+
+## Quick Reference
+
+```bash
+python3 plugins/infiquetra-deploy/scripts/mint_tag.py \
+  --env nonprod \
+  --version 1.2.3 \
+  --dry-run
+```
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-deploy/scripts/mint_tag.py
+++ b/plugins/infiquetra-deploy/scripts/mint_tag.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Mint Infiquetra tag-promotion deployment tags."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess  # nosec B404
+import sys
+from collections.abc import Sequence
+
+ENV_TO_PREFIX = {
+    "nonprod": "nonprod",
+    "staging": "staging",
+    "production": "production",
+}
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:\.\d+)?$")
+
+
+def run(cmd: list[str], *, check: bool = True, capture: bool = True) -> str:
+    """Run a command and return stdout."""
+
+    result = subprocess.run(  # nosec B603
+        cmd,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else "command failed"
+        raise SystemExit(f"ERROR: {detail}")
+    return result.stdout.strip() if result.stdout else ""
+
+
+def _remote_to_repo(remote_url: str) -> str:
+    remote = remote_url.strip().removesuffix(".git")
+    if "github.com:" in remote:
+        path = remote.split("github.com:", 1)[1]
+    elif "github.com/" in remote:
+        path = remote.split("github.com/", 1)[1]
+    else:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
+        )
+
+    parts = path.strip("/").split("/")
+    if len(parts) < 2:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
+        )
+    return f"{parts[0]}/{parts[1]}"
+
+
+def resolve_repo(repo: str | None) -> str:
+    """Resolve a repository name and reject non-Infiquetra owners."""
+
+    if repo:
+        resolved = repo if "/" in repo else f"infiquetra/{repo}"
+    else:
+        resolved = _remote_to_repo(run(["git", "remote", "get-url", "origin"]))
+
+    owner, _, name = resolved.partition("/")
+    if owner.lower() != "infiquetra" or not name:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}"
+        )
+    return f"infiquetra/{name}"
+
+
+def build_tag_name(env: str, version: str, *, rollback: bool = False) -> str:
+    """Build an Infiquetra deployment tag name."""
+
+    normalized_env = env.strip().lower()
+    if normalized_env not in ENV_TO_PREFIX:
+        allowed = ", ".join(ENV_TO_PREFIX)
+        raise SystemExit(f"ERROR: unknown environment {env!r}; expected one of {allowed}")
+
+    normalized_version = version.strip().removeprefix("v")
+    if not VERSION_RE.match(normalized_version):
+        raise SystemExit(
+            "ERROR: version must look like 1.2.3 or hotfix form 1.2.3.1"
+        )
+
+    prefix = ENV_TO_PREFIX[normalized_env]
+    if rollback:
+        prefix = f"rollback-{prefix}"
+    return f"{prefix}-v{normalized_version}"
+
+
+def strip_prefix(tag: str) -> str:
+    """Strip Infiquetra deployment tag prefixes and return the version."""
+
+    for prefix in (
+        "rollback-production-v",
+        "rollback-staging-v",
+        "rollback-nonprod-v",
+        "production-v",
+        "staging-v",
+        "nonprod-v",
+        "v",
+    ):
+        if tag.startswith(prefix):
+            return tag.removeprefix(prefix)
+    return tag
+
+
+def current_env_version(repo: str, env: str) -> str | None:
+    """Return the currently deployed version for an environment."""
+
+    ref = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/deployments?environment={env}&per_page=1",
+            "--jq",
+            ".[0].ref // empty",
+        ],
+        check=False,
+    )
+    return strip_prefix(ref) if ref else None
+
+
+def tag_exists(tag: str) -> bool:
+    """Return whether a tag exists locally or on origin."""
+
+    local = run(["git", "tag", "-l", tag], check=False)
+    if local == tag:
+        return True
+    remote = run(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}"],
+        check=False,
+    )
+    return tag in remote
+
+
+def latest_snapshot_version() -> str | None:
+    """Return the latest local or remote snapshot version."""
+
+    latest = run(["git", "tag", "-l", "v[0-9]*", "--sort=-version:refname"], check=False)
+    if not latest:
+        run(["git", "fetch", "--tags", "origin"], check=False, capture=False)
+        latest = run(["git", "tag", "-l", "v[0-9]*", "--sort=-version:refname"], check=False)
+    if not latest:
+        return None
+    return latest.splitlines()[0].removeprefix("v")
+
+
+def resolve_version(*, env: str, version: str | None, ref: str | None, repo: str) -> str:
+    """Resolve explicit or inferred deployment version."""
+
+    if version:
+        return version.strip().removeprefix("v")
+    if ref and ref != "HEAD":
+        raise SystemExit("ERROR: --ref requires --version in hotfix mode.")
+
+    if env == "nonprod":
+        latest = latest_snapshot_version()
+        if not latest:
+            raise SystemExit("ERROR: no snapshot tags found; pass --version explicitly.")
+        return latest
+
+    prior_env = {"staging": "nonprod", "production": "staging"}[env]
+    current = current_env_version(repo, prior_env)
+    if not current:
+        raise SystemExit(
+            f"ERROR: cannot infer version: no current deployment in {prior_env}; "
+            "pass --version explicitly."
+        )
+    return current
+
+
+def assert_snapshot_not_unhealthy(
+    *,
+    tag: str,
+    version: str,
+    rollback: bool,
+    ref: str | None,
+    force_unhealthy: bool,
+) -> None:
+    """Refuse to promote snapshots marked unhealthy unless explicitly overridden."""
+
+    if rollback or (ref and ref != "HEAD"):
+        return
+    unhealthy_tag = f"unhealthy-v{version}"
+    if not tag_exists(unhealthy_tag):
+        return
+    if force_unhealthy:
+        print(f">>> UNHEALTHY-OVERRIDE: minting {tag} despite {unhealthy_tag}")
+        return
+    raise SystemExit(
+        f"ERROR: refusing to promote v{version} to {tag}: {unhealthy_tag} exists on origin. "
+        "Fix forward, promote a newer healthy snapshot, or pass --force-unhealthy after "
+        "manual verification."
+    )
+
+
+def _print_plan(repo: str, tag: str, ref: str, *, dry_run: bool) -> None:
+    mode = "DRY RUN" if dry_run else "MUTATING"
+    print(f"{mode}: {repo}")
+    print(f"tag: {tag}")
+    print(f"ref: {ref}")
+    print(f"workflow: https://github.com/{repo}/actions")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", required=True, choices=sorted(ENV_TO_PREFIX))
+    parser.add_argument("--version")
+    parser.add_argument("--repo", help="Repository as name or owner/name")
+    parser.add_argument("--ref", default="HEAD", help="Commit-ish to tag")
+    parser.add_argument("--rollback", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--force-unhealthy",
+        action="store_true",
+        help="Override the unhealthy-v<version> quarantine marker after manual verification.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo = resolve_repo(args.repo)
+    version = resolve_version(env=args.env, version=args.version, ref=args.ref, repo=repo)
+    tag = build_tag_name(args.env, version, rollback=args.rollback)
+    source = args.ref if args.ref != "HEAD" else f"v{version}"
+    _print_plan(repo, tag, source, dry_run=args.dry_run)
+
+    if not args.rollback and args.ref == "HEAD" and not tag_exists(source):
+        raise SystemExit(
+            f"ERROR: snapshot {source} not found locally or on origin; cannot mint {tag}."
+        )
+
+    assert_snapshot_not_unhealthy(
+        tag=tag,
+        version=version,
+        rollback=args.rollback,
+        ref=args.ref,
+        force_unhealthy=args.force_unhealthy,
+    )
+
+    if tag_exists(tag):
+        raise SystemExit(f"ERROR: tag {tag} already exists locally or on origin.")
+
+    if args.dry_run:
+        print(f"[dry-run] would: git tag -a {tag} {source}^{{commit}} -m '...'")
+        print(f"[dry-run] would: git push origin {tag}")
+        return 0
+
+    target_commit = run(["git", "rev-parse", f"{source}^{{commit}}"])
+    message = f"Infiquetra {args.env} deployment {tag}"
+    if args.rollback:
+        message = f"Infiquetra {args.env} rollback {tag}"
+    elif args.ref != "HEAD":
+        message = f"Infiquetra {args.env} hotfix {tag}"
+
+    run(["git", "fetch", "--tags", "origin"], capture=False)
+    run(["git", "tag", "-a", tag, target_commit, "-m", message], capture=False)
+    run(["git", "push", "origin", tag], capture=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-deploy/scripts/mint_tag.py
+++ b/plugins/infiquetra-deploy/scripts/mint_tag.py
@@ -41,15 +41,11 @@ def _remote_to_repo(remote_url: str) -> str:
     elif "github.com/" in remote:
         path = remote.split("github.com/", 1)[1]
     else:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}")
 
     parts = path.strip("/").split("/")
     if len(parts) < 2:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}")
     return f"{parts[0]}/{parts[1]}"
 
 
@@ -63,9 +59,7 @@ def resolve_repo(repo: str | None) -> str:
 
     owner, _, name = resolved.partition("/")
     if owner.lower() != "infiquetra" or not name:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}")
     return f"infiquetra/{name}"
 
 
@@ -79,9 +73,7 @@ def build_tag_name(env: str, version: str, *, rollback: bool = False) -> str:
 
     normalized_version = version.strip().removeprefix("v")
     if not VERSION_RE.match(normalized_version):
-        raise SystemExit(
-            "ERROR: version must look like 1.2.3 or hotfix form 1.2.3.1"
-        )
+        raise SystemExit("ERROR: version must look like 1.2.3 or hotfix form 1.2.3.1")
 
     prefix = ENV_TO_PREFIX[normalized_env]
     if rollback:

--- a/plugins/infiquetra-deploy/scripts/preview_release_notes.py
+++ b/plugins/infiquetra-deploy/scripts/preview_release_notes.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preview release notes for an Infiquetra deployment candidate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+
+def run(cmd: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(  # nosec B603
+        cmd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else "command failed"
+        raise SystemExit(f"ERROR: {detail}")
+    return result.stdout.strip()
+
+
+def render_notes(base_ref: str, head_ref: str, compare: dict[str, Any]) -> str:
+    commits = compare.get("commits") or []
+    files = compare.get("files") or []
+    lines = [
+        f"release notes preview: {base_ref}...{head_ref}",
+        f"commits: {len(commits)}",
+        f"files changed: {len(files)}",
+        "",
+        "notable commits:",
+    ]
+    for commit in commits[:10]:
+        sha = str(commit.get("sha", ""))[:7]
+        message = commit.get("commit", {}).get("message", "").splitlines()[0]
+        lines.append(f"- {sha} {message}")
+    if len(commits) > 10:
+        lines.append(f"- ... {len(commits) - 10} more commits")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Repository as owner/name")
+    parser.add_argument("--base", required=True, help="Base ref or tag")
+    parser.add_argument("--head", required=True, help="Head ref or tag")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = run(["gh", "api", f"repos/{args.repo}/compare/{args.base}...{args.head}"])
+    print(render_notes(args.base, args.head, json.loads(payload)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-deploy/scripts/query_deployments.py
+++ b/plugins/infiquetra-deploy/scripts/query_deployments.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Query Infiquetra deployment status and report version drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+ENVIRONMENTS = ("nonprod", "staging", "production")
+TAG_PREFIXES = (
+    "rollback-production-v",
+    "rollback-staging-v",
+    "rollback-nonprod-v",
+    "production-v",
+    "staging-v",
+    "nonprod-v",
+    "v",
+)
+
+
+def run(cmd: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(  # nosec B603
+        cmd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else "command failed"
+        raise SystemExit(f"ERROR: {detail}")
+    return result.stdout.strip()
+
+
+def strip_prefix(tag: str) -> str:
+    """Strip Infiquetra deployment tag prefixes for drift comparison."""
+
+    value = tag.strip()
+    for prefix in TAG_PREFIXES:
+        if value.startswith(prefix):
+            return value.removeprefix(prefix)
+    return value
+
+
+def _remote_to_repo(remote_url: str) -> str:
+    remote = remote_url.strip().removesuffix(".git")
+    if "github.com:" in remote:
+        path = remote.split("github.com:", 1)[1]
+    elif "github.com/" in remote:
+        path = remote.split("github.com/", 1)[1]
+    else:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
+        )
+
+    parts = path.strip("/").split("/")
+    if len(parts) < 2:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
+        )
+    return f"{parts[0]}/{parts[1]}"
+
+
+def resolve_repo(repo: str | None) -> str:
+    if repo:
+        resolved = repo if "/" in repo else f"infiquetra/{repo}"
+    else:
+        resolved = _remote_to_repo(run(["git", "remote", "get-url", "origin"]))
+
+    owner, _, name = resolved.partition("/")
+    if owner.lower() != "infiquetra" or not name:
+        raise SystemExit(
+            f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}"
+        )
+    return f"infiquetra/{name}"
+
+
+def detect_drift(tags_by_env: Mapping[str, str | None]) -> list[str]:
+    versions = {
+        env: strip_prefix(tag)
+        for env, tag in tags_by_env.items()
+        if tag is not None and tag.strip()
+    }
+    if len(set(versions.values())) <= 1:
+        return []
+    return [f"{env}: {version}" for env, version in versions.items()]
+
+
+def latest_deployment(repo: str, env: str) -> dict[str, Any] | None:
+    payload = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/deployments",
+            "-f",
+            f"environment={env}",
+            "-f",
+            "per_page=1",
+        ]
+    )
+    data = json.loads(payload or "[]")
+    return data[0] if data else None
+
+
+def render_status(repo: str, deployments: Mapping[str, dict[str, Any] | None]) -> str:
+    lines = [f"deployment status: {repo}"]
+    tags_by_env: dict[str, str | None] = {}
+    for env in ENVIRONMENTS:
+        deployment = deployments.get(env)
+        if not deployment:
+            lines.append(f"- {env}: no deployment found")
+            tags_by_env[env] = None
+            continue
+
+        ref = str(deployment.get("ref") or deployment.get("sha") or "unknown")
+        tags_by_env[env] = ref
+        lines.append(f"- {env}: {ref} (version {strip_prefix(ref)})")
+
+    drift = detect_drift(tags_by_env)
+    if drift:
+        lines.append("drift:")
+        lines.extend(f"- {item}" for item in drift)
+    else:
+        lines.append("drift: none detected")
+    lines.append(f"workflow: https://github.com/{repo}/actions")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="Repository as name or owner/name")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo = resolve_repo(args.repo)
+    deployments = {env: latest_deployment(repo, env) for env in ENVIRONMENTS}
+    print(render_status(repo, deployments))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-deploy/scripts/query_deployments.py
+++ b/plugins/infiquetra-deploy/scripts/query_deployments.py
@@ -52,15 +52,11 @@ def _remote_to_repo(remote_url: str) -> str:
     elif "github.com/" in remote:
         path = remote.split("github.com/", 1)[1]
     else:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}")
 
     parts = path.strip("/").split("/")
     if len(parts) < 2:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* remote, got {remote_url!r}")
     return f"{parts[0]}/{parts[1]}"
 
 
@@ -72,9 +68,7 @@ def resolve_repo(repo: str | None) -> str:
 
     owner, _, name = resolved.partition("/")
     if owner.lower() != "infiquetra" or not name:
-        raise SystemExit(
-            f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}"
-        )
+        raise SystemExit(f"ERROR: expected github.com/infiquetra/* repository, got {resolved!r}")
     return f"infiquetra/{name}"
 
 

--- a/plugins/infiquetra-deploy/skills/deploy-state/SKILL.md
+++ b/plugins/infiquetra-deploy/skills/deploy-state/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: deploy-state
+description: |
+  Infiquetra deployment state and tag-promotion guidance. Use for /deploy, /deploy-status,
+  /deploy-notes, /deploy-hotfix, rollback planning, hotfix promotion, and deployment evidence.
+---
+
+# Deploy State
+
+Use this skill for Infiquetra repository deployment work. It is intentionally separate from
+`infiquetra-loop` because deployment mutation deserves a hard boundary.
+
+## Source Of Truth
+
+- Link to the Infiquetra context library instead of copying long-lived policy text.
+- Search the context library for ADR-0004 before changing deployment behavior.
+- Also reference the current CI/CD standards and repository-local workflow files under
+  `.github/workflows/`.
+- If the target repository does not resolve to `github.com/infiquetra/*`, stop before mutation.
+
+## Environments
+
+Infiquetra tag-promotion environments:
+
+| Environment | Tag Prefix | Purpose |
+|-------------|------------|---------|
+| `nonprod` | `nonprod-v` | First automated integration environment. |
+| `staging` | `staging-v` | Candidate validation before production. |
+| `production` | `production-v` | Customer-facing production promotion. |
+
+Rollback tags use `rollback-<environment>-v<version>`. Hotfix tags use the same environment
+prefix with an explicit hotfix version such as `production-v1.2.3.1`.
+
+## Deployment Workflow
+
+1. Resolve the repository and reject non-Infiquetra owners.
+2. Inspect `.github/workflows/` and classify whether tag-promotion is full, partial, or absent.
+3. Infer versions only from policy-safe sources: latest snapshot for nonprod, current nonprod for
+   staging, current staging for production.
+4. Refuse forward promotion when `unhealthy-v<version>` exists unless the user explicitly chooses
+   an audited override after manual verification.
+5. Preview the tag, target ref, workflow URL, and release notes.
+6. Require explicit confirmation before pushing tags for staging, production, rollback, or hotfix.
+7. Push the tag only after checks and approval are clear.
+8. Capture the GitHub Actions URL, deployment status, tag, commit SHA, and issue or PR links.
+
+## State Model
+
+Durable evidence belongs in the repository:
+
+- Release notes or deployment notes in repo docs when the repo already has that convention.
+- Issue comments through `sdlc-manager` when an SDLC issue exists.
+- PR comments when deployment is tied to a PR.
+
+Runtime scratch belongs under ignored local state such as `.claude/infiquetra-loop/` or a
+deployment-specific cache. Do not commit raw API responses or validator JSON.
+
+## Script Helpers
+
+- `plugins/infiquetra-deploy/scripts/mint_tag.py`: build and optionally push policy tags.
+- `plugins/infiquetra-deploy/scripts/query_deployments.py`: show status and drift.
+- `plugins/infiquetra-deploy/scripts/preview_release_notes.py`: summarize candidate changes.

--- a/plugins/infiquetra-loop/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-loop/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "infiquetra-loop",
+  "version": "0.1.0",
+  "description": "Infiquetra lifecycle workflow plugin for strategy, planning, work execution, review, QA, and resume.",
+  "author": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+  "keywords": [
+    "loop",
+    "lifecycle",
+    "strategy",
+    "ideation",
+    "brainstorm",
+    "code-review",
+    "optimize",
+    "qa",
+    "sdlc"
+  ]
+}

--- a/plugins/infiquetra-loop/CHANGELOG.md
+++ b/plugins/infiquetra-loop/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0 - 2026-05-29
+
+- Add the Infiquetra lifecycle command set from office-hours through resume.
+- Add durable repository artifact guidance and ignored local runtime-state guidance.
+- Add helper scripts for destination selection, issue progress comments, deploy strategy
+  detection, team-execution escalation, and engineering-journal triggers.
+- Preserve VECU work-loop mechanics source-neutrally: issue parsing, ignored checkpoints,
+  inflight resume discovery, saga context loading, sub-issue discovery, and cached deploy
+  strategy detection.

--- a/plugins/infiquetra-loop/README.md
+++ b/plugins/infiquetra-loop/README.md
@@ -1,0 +1,45 @@
+# infiquetra-loop
+
+Infiquetra lifecycle workflow plugin for day-to-day engineering work.
+
+## Commands
+
+- `/loop` routes work to plan only, PR, merge, or nonprod deploy.
+- `/office-hours`, `/ideate`, and `/brainstorm` support early thinking.
+- `/strategy` maintains the root `STRATEGY.md`.
+- `/plan`, `/work`, `/qa`, `/retro`, and `/resume` run the durable work loop.
+- `/founder-review` and `/ceo-review` review ambition, scope, and operator risk.
+- `/code-review` runs a structured pre-PR review.
+- `/optimize` runs metric-driven improvement loops.
+
+## Artifact Model
+
+Durable artifacts are repo docs:
+
+- `STRATEGY.md`
+- `docs/ideation/`
+- `docs/brainstorms/`
+- `docs/plans/`
+- `docs/reviews/`
+- `docs/qa/`
+- `docs/work-sessions/`
+- `docs/retros/`
+- `docs/engineering-journal/`
+
+Ignored local state belongs under `.claude/infiquetra-loop/`.
+
+## Boundaries
+
+- `infiquetra-deploy` owns deployment mutation.
+- `team-execution` stays independent and is offered when risk, size, or parallelism justify it.
+- `sdlc-manager` owns SDLC issue creation, issue comments, and board movement.
+
+## Deterministic Helpers
+
+- `scripts/parse_issue.py` extracts ADR, acceptance-criteria, round, and risk hints.
+- `scripts/scaffold_checkpoint.py` writes ignored resume checkpoints under
+  `.claude/infiquetra-loop/`.
+- `scripts/find_inflight_work.py` ranks resumable loop state.
+- `scripts/load_saga_context.py` reconstructs prior issue, PR, checkpoint, and journal context.
+- `scripts/discover_subissues.py` discovers GitHub sub-issues through GraphQL.
+- `scripts/detect_deploy_strategy.py` classifies tag-promotion workflow coverage.

--- a/plugins/infiquetra-loop/commands/brainstorm.md
+++ b/plugins/infiquetra-loop/commands/brainstorm.md
@@ -1,0 +1,12 @@
+---
+name: brainstorm
+description: Explore requirements, constraints, and candidate approaches before planning
+argument-hint: "[topic]"
+---
+
+Load `infiquetra-loop/skills/brainstorm/SKILL.md`. Use collaborative discovery before narrowing
+to a plan, issue, or strategy update.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/ceo-review.md
+++ b/plugins/infiquetra-loop/commands/ceo-review.md
@@ -1,0 +1,13 @@
+---
+name: ceo-review
+description: Alias for /founder-review
+argument-hint: "[plan, strategy, feature, or PR]"
+---
+
+This command is an alias for `/founder-review`.
+
+Load `infiquetra-loop/skills/founder-review/SKILL.md` and run the same founder/operator review.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/code-review.md
+++ b/plugins/infiquetra-loop/commands/code-review.md
@@ -1,0 +1,12 @@
+---
+name: code-review
+description: Run a structured Infiquetra code review and pre-PR gate
+argument-hint: "[diff, branch, PR, or scope]"
+---
+
+Load `infiquetra-loop/skills/code-review/SKILL.md`. Prioritize correctness, security,
+regression, missing-test, and operational risks with file and line references.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/founder-review.md
+++ b/plugins/infiquetra-loop/commands/founder-review.md
@@ -1,0 +1,12 @@
+---
+name: founder-review
+description: Review strategy, ambition, positioning, and scope from a founder/operator perspective
+argument-hint: "[plan, strategy, feature, or PR]"
+---
+
+Load `infiquetra-loop/skills/founder-review/SKILL.md`. Keep this separate from `/strategy`:
+the review challenges scope, ambition, timing, market clarity, and operator risk.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/ideate.md
+++ b/plugins/infiquetra-loop/commands/ideate.md
@@ -1,0 +1,12 @@
+---
+name: ideate
+description: Generate and evaluate grounded Infiquetra implementation or product ideas
+argument-hint: "[topic]"
+---
+
+Load `infiquetra-loop/skills/ideate/SKILL.md`. Produce a small set of options, lead the user
+through tradeoffs one at a time when useful, and persist chosen directions under `docs/ideation/`.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/loop.md
+++ b/plugins/infiquetra-loop/commands/loop.md
@@ -1,0 +1,19 @@
+---
+name: loop
+description: Route Infiquetra work through the lifecycle from idea to plan, PR, merge, or nonprod deploy
+argument-hint: "[issue, plan, or work description]"
+---
+
+Start or continue the Infiquetra lifecycle loop.
+
+## Instructions
+
+1. Load `infiquetra-loop/skills/loop/SKILL.md`.
+2. Ask for the destination if it is not already clear: plan only, PR, merge, or nonprod deploy.
+3. Ask whether to file an SDLC issue first for non-trivial ad-hoc work.
+4. Persist durable artifacts in repo docs and raw runtime state under `.claude/infiquetra-loop/`.
+5. Use `infiquetra-deploy` only when the chosen destination includes deployment.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/office-hours.md
+++ b/plugins/infiquetra-loop/commands/office-hours.md
@@ -1,0 +1,13 @@
+---
+name: office-hours
+description: Thought-partner session for early Infiquetra product, architecture, and workflow ideas
+argument-hint: "[topic]"
+---
+
+Load `infiquetra-loop/skills/office-hours/SKILL.md` and run a guided thought-partner
+conversation. Keep the interaction question-led and persist promising outputs under
+`docs/ideation/` or `docs/brainstorms/` when they become concrete.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/optimize.md
+++ b/plugins/infiquetra-loop/commands/optimize.md
@@ -1,0 +1,12 @@
+---
+name: optimize
+description: Run a metric-driven Infiquetra optimization loop
+argument-hint: "[metric, workflow, or bottleneck]"
+---
+
+Load `infiquetra-loop/skills/optimize/SKILL.md`. Define the metric, baseline it, run bounded
+experiments, and keep durable conclusions in repo docs.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/plan.md
+++ b/plugins/infiquetra-loop/commands/plan.md
@@ -1,0 +1,12 @@
+---
+name: plan
+description: Create a durable Infiquetra implementation plan
+argument-hint: "[issue, spec, or request]"
+---
+
+Load `infiquetra-loop/skills/plan/SKILL.md`. Store non-trivial plans under `docs/plans/` and
+record the current pointer under `.claude/infiquetra-loop/`.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/qa.md
+++ b/plugins/infiquetra-loop/commands/qa.md
@@ -1,0 +1,12 @@
+---
+name: qa
+description: Run Infiquetra quality, browser, deployment, and acceptance checks
+argument-hint: "[scope]"
+---
+
+Load `infiquetra-loop/skills/qa/SKILL.md`. Build an evidence-backed QA pass from repo-local
+test commands and selected lifecycle gates.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/resume.md
+++ b/plugins/infiquetra-loop/commands/resume.md
@@ -1,0 +1,12 @@
+---
+name: resume
+description: Reconstruct and continue an Infiquetra work loop from durable artifacts and local state
+argument-hint: "[issue, plan, or session]"
+---
+
+Load `infiquetra-loop/skills/resume/SKILL.md`. Prefer committed summaries and repo docs as the
+source of truth, then use ignored local state only to recover raw scratch details.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/retro.md
+++ b/plugins/infiquetra-loop/commands/retro.md
@@ -1,0 +1,12 @@
+---
+name: retro
+description: Capture Infiquetra lifecycle retrospective notes and journal-worthy learnings
+argument-hint: "[completed work]"
+---
+
+Load `infiquetra-loop/skills/retro/SKILL.md`. Write durable retros under `docs/retros/` and
+update the engineering journal when the work produced generalizable knowledge.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/strategy.md
+++ b/plugins/infiquetra-loop/commands/strategy.md
@@ -1,0 +1,12 @@
+---
+name: strategy
+description: Create or maintain the repository root STRATEGY.md
+argument-hint: "[product or repository strategy topic]"
+---
+
+Load `infiquetra-loop/skills/strategy/SKILL.md`. Maintain the root `STRATEGY.md` as a durable
+repo artifact and link relevant context-library material instead of embedding stale copies.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/work.md
+++ b/plugins/infiquetra-loop/commands/work.md
@@ -1,0 +1,12 @@
+---
+name: work
+description: Execute an approved Infiquetra plan with checkpoints, issue updates, and test gates
+argument-hint: "[plan path or issue]"
+---
+
+Load `infiquetra-loop/skills/work/SKILL.md`. Execute from durable plan artifacts, update issue
+progress, write work-session summaries, and run risk-based test gates.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/scripts/detect_deploy_strategy.py
+++ b/plugins/infiquetra-loop/scripts/detect_deploy_strategy.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Detect Infiquetra deployment strategy from workflow filenames."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+ENV_ORDER = ("nonprod", "staging", "production")
+CACHE_TTL_SECONDS = 24 * 60 * 60
+CACHE_DIR = Path(".claude/infiquetra-loop")
+
+
+def _detect_env(workflow: str) -> str | None:
+    lowered = workflow.lower()
+    if "deploy" not in lowered and "promotion" not in lowered:
+        return None
+    for env in ENV_ORDER:
+        if env in lowered:
+            return env
+    return None
+
+
+def classify(workflows: Sequence[str]) -> dict[str, object]:
+    """Classify tag-promotion coverage from workflow filenames."""
+
+    envs = sorted(
+        {env for workflow in workflows if (env := _detect_env(workflow))},
+        key=ENV_ORDER.index,
+    )
+    if set(envs) == set(ENV_ORDER):
+        strategy = "tag-promotion"
+    elif envs:
+        strategy = "tag-promotion-partial"
+    else:
+        strategy = "unknown"
+
+    return {
+        "strategy": strategy,
+        "envs_available": envs,
+        "workflows": list(workflows),
+    }
+
+
+def get_repo_slug(explicit_repo: str | None) -> str:
+    if explicit_repo:
+        return explicit_repo if "/" in explicit_repo else f"infiquetra/{explicit_repo}"
+    result = subprocess.run(  # nosec B603 B607
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def cache_path(repo_slug: str) -> Path:
+    return CACHE_DIR / f"deploy-strategy-{repo_slug.replace('/', '_')}.json"
+
+
+def read_cache(repo_slug: str) -> dict[str, object] | None:
+    path = cache_path(repo_slug)
+    if not path.exists() or time.time() - path.stat().st_mtime > CACHE_TTL_SECONDS:
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def write_cache(repo_slug: str, payload: dict[str, object]) -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path(repo_slug).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def list_workflow_files(repo_slug: str) -> list[str]:
+    result = subprocess.run(  # nosec B603 B607
+        ["gh", "api", f"repos/{repo_slug}/contents/.github/workflows", "--jq", ".[].name"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workflows", nargs="*")
+    parser.add_argument("--repo", help="Infiquetra repo slug or name")
+    parser.add_argument("--no-cache", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.workflows:
+        print(json.dumps(classify(args.workflows), indent=2, sort_keys=True))
+        return 0
+
+    repo_slug = get_repo_slug(args.repo)
+    if not args.no_cache:
+        cached = read_cache(repo_slug)
+        if cached is not None:
+            cached["_cache_hit"] = True
+            print(json.dumps(cached, indent=2, sort_keys=True))
+            return 0
+
+    result = classify(list_workflow_files(repo_slug))
+    result["repo"] = repo_slug
+    result["_cache_hit"] = False
+    write_cache(repo_slug, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/discover_subissues.py
+++ b/plugins/infiquetra-loop/scripts/discover_subissues.py
@@ -61,11 +61,7 @@ def fetch_subissues(owner: str, repo: str, number: int) -> dict[str, object]:
 
 
 def normalize(payload: dict[str, object]) -> dict[str, object]:
-    issue = (
-        payload.get("data", {})
-        .get("repository", {})
-        .get("issue", {})
-    )
+    issue = payload.get("data", {}).get("repository", {}).get("issue", {})
     subissues = issue.get("subIssues", {}) if isinstance(issue, dict) else {}
     nodes = subissues.get("nodes", []) if isinstance(subissues, dict) else []
     return {
@@ -82,8 +78,7 @@ def normalize(payload: dict[str, object]) -> dict[str, object]:
                 "state": node.get("state"),
                 "url": node.get("url"),
                 "labels": [
-                    label.get("name")
-                    for label in (node.get("labels", {}).get("nodes") or [])
+                    label.get("name") for label in (node.get("labels", {}).get("nodes") or [])
                 ],
                 "assignees": [
                     assignee.get("login")

--- a/plugins/infiquetra-loop/scripts/discover_subissues.py
+++ b/plugins/infiquetra-loop/scripts/discover_subissues.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Discover GitHub sub-issues for an Infiquetra issue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+
+GRAPHQL_QUERY = """
+query SubIssues($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      number
+      title
+      state
+      subIssues(first: 50) {
+        totalCount
+        nodes {
+          number
+          title
+          state
+          url
+          labels(first: 10) { nodes { name } }
+          assignees(first: 5) { nodes { login } }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def parse_repo(value: str) -> tuple[str, str]:
+    if "/" in value:
+        owner, repo = value.split("/", 1)
+        return owner, repo
+    return "infiquetra", value
+
+
+def fetch_subissues(owner: str, repo: str, number: int) -> dict[str, object]:
+    cmd = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"owner={owner}",
+        "-f",
+        f"repo={repo}",
+        "-F",
+        f"number={number}",
+        "-f",
+        f"query={GRAPHQL_QUERY}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603
+    if result.returncode != 0:
+        print(f"gh api graphql failed: {result.stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return json.loads(result.stdout)
+
+
+def normalize(payload: dict[str, object]) -> dict[str, object]:
+    issue = (
+        payload.get("data", {})
+        .get("repository", {})
+        .get("issue", {})
+    )
+    subissues = issue.get("subIssues", {}) if isinstance(issue, dict) else {}
+    nodes = subissues.get("nodes", []) if isinstance(subissues, dict) else []
+    return {
+        "parent": {
+            "number": issue.get("number"),
+            "title": issue.get("title"),
+            "state": issue.get("state"),
+        },
+        "totalCount": subissues.get("totalCount", 0),
+        "subissues": [
+            {
+                "number": node.get("number"),
+                "title": node.get("title"),
+                "state": node.get("state"),
+                "url": node.get("url"),
+                "labels": [
+                    label.get("name")
+                    for label in (node.get("labels", {}).get("nodes") or [])
+                ],
+                "assignees": [
+                    assignee.get("login")
+                    for assignee in (node.get("assignees", {}).get("nodes") or [])
+                ],
+            }
+            for node in nodes
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="<owner>/<repo> or repo name")
+    parser.add_argument("--issue", type=int, required=True, help="Parent issue number")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    owner, repo = parse_repo(args.repo)
+    print(json.dumps(normalize(fetch_subissues(owner, repo, args.issue)), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/find_inflight_work.py
+++ b/plugins/infiquetra-loop/scripts/find_inflight_work.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Find recent ignored Infiquetra loop checkpoints and active state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+STATE_DIR = Path(".claude/infiquetra-loop")
+CHECKPOINT_RE = re.compile(
+    r"^(?P<kind>issue|task)-(?P<id>[a-zA-Z0-9_-]+?)"
+    r"(?:-round-(?P<round>\d+))?"
+    r"-phase(?P<phase>\d+)(?:-(?P<status>complete|pending|in_progress))?\.md$"
+)
+
+
+def read_state_json() -> dict[str, object] | None:
+    state_path = STATE_DIR / "state.json"
+    if not state_path.exists():
+        return None
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def humanize_age(mtime: float) -> str:
+    delta = time.time() - mtime
+    if delta < 60:
+        return f"{int(delta)} seconds ago"
+    if delta < 3600:
+        return f"{int(delta // 60)} minutes ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)} hours ago"
+    return f"{int(delta // 86400)} days ago"
+
+
+def next_phase(checkpoint: dict[str, object]) -> int:
+    phase = int(checkpoint.get("phase", 0))
+    return phase + 1 if checkpoint.get("phase_status") == "complete" else phase
+
+
+def scan_checkpoints() -> list[dict[str, object]]:
+    checkpoint_dir = STATE_DIR / "checkpoints"
+    if not checkpoint_dir.exists():
+        return []
+    candidates: list[dict[str, object]] = []
+    for path in checkpoint_dir.glob("*.md"):
+        match = CHECKPOINT_RE.match(path.name)
+        if not match:
+            continue
+        status = match.group("status") or "pending"
+        record = {
+            "path": str(path),
+            "name": path.name,
+            "mtime": path.stat().st_mtime,
+            "kind": match.group("kind"),
+            "id": match.group("id"),
+            "round": int(match.group("round")) if match.group("round") else None,
+            "phase": int(match.group("phase")),
+            "phase_status": status,
+        }
+        record["next_phase"] = next_phase(record)
+        record["age"] = humanize_age(float(record["mtime"]))
+        candidates.append(record)
+    return sorted(candidates, key=lambda candidate: float(candidate["mtime"]), reverse=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-candidates", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    state = read_state_json()
+    checkpoints = scan_checkpoints()
+    print(
+        json.dumps(
+            {
+                "found": bool(state and state.get("current_work")) or bool(checkpoints),
+                "state": state,
+                "candidates": checkpoints[: args.max_candidates],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/issue_progress.py
+++ b/plugins/infiquetra-loop/scripts/issue_progress.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Render Infiquetra lifecycle issue progress comments."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+EVENT_TITLES = {
+    "start": "Loop started",
+    "phase": "Phase completed",
+    "pr": "PR ready",
+    "deploy": "Nonprod deployment",
+    "completion": "Loop completed",
+}
+
+
+def _line(label: str, value: object | None) -> str | None:
+    if value is None or value == "":
+        return None
+    return f"- {label}: {value}"
+
+
+def _checks_lines(checks_run: Sequence[str] | None) -> list[str]:
+    if not checks_run:
+        return []
+    lines = ["- checks run:"]
+    lines.extend(f"  - `{check}`" for check in checks_run)
+    return lines
+
+
+def render_issue_comment(
+    *,
+    event: str,
+    issue_ref: str,
+    destination: str,
+    summary: str | None = None,
+    plan_path: str | None = None,
+    work_session_path: str | None = None,
+    commit_sha: str | None = None,
+    checks_run: Sequence[str] | None = None,
+    blockers: str | None = None,
+    pr_url: str | None = None,
+    review_status: str | None = None,
+    deploy_status: str | None = None,
+    workflow_url: str | None = None,
+    evidence_link: str | None = None,
+) -> str:
+    """Render a concise markdown issue progress update."""
+
+    title = EVENT_TITLES.get(event, event.replace("-", " ").title())
+    lines = [f"### {title}", "", f"- issue: {issue_ref}", f"- selected destination: {destination}"]
+    for candidate in (
+        _line("summary", summary),
+        _line("plan", plan_path),
+        _line("work session", work_session_path),
+        _line("commit", commit_sha),
+        _line("PR", pr_url),
+        _line("review status", review_status),
+        _line("deployment status", deploy_status),
+        _line("workflow", workflow_url),
+        _line("evidence", evidence_link),
+        _line("blockers", blockers),
+    ):
+        if candidate:
+            lines.append(candidate)
+    lines.extend(_checks_lines(checks_run))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--issue-ref", required=True)
+    parser.add_argument("--destination", required=True)
+    parser.add_argument("--summary")
+    parser.add_argument("--plan-path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(
+        render_issue_comment(
+            event=args.event,
+            issue_ref=args.issue_ref,
+            destination=args.destination,
+            summary=args.summary,
+            plan_path=args.plan_path,
+        ),
+        end="",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/journal_triggers.py
+++ b/plugins/infiquetra-loop/scripts/journal_triggers.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Detect likely Infiquetra engineering-journal update targets."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+LEARNING_TERMS = {"surprise", "root cause", "mechanism", "validation", "gotcha"}
+DECISION_TERMS = {"decision", "adopt", "choose", "reject", "revisit", "standard"}
+QUEUED_TERMS = {"defer", "later", "future", "queue", "not now", "follow-up"}
+
+
+def detect_targets(summary: str, changed_files: Sequence[str]) -> list[str]:
+    """Return engineering-journal files likely needing updates."""
+
+    text = " ".join([summary, *changed_files]).lower()
+    targets: list[str] = []
+    if any(term in text for term in LEARNING_TERMS):
+        targets.append("docs/engineering-journal/LEARNINGS.md")
+    if any(term in text for term in DECISION_TERMS):
+        targets.append("docs/engineering-journal/DECISIONS.md")
+    if any(term in text for term in QUEUED_TERMS):
+        targets.append("docs/engineering-journal/QUEUED.md")
+    return targets

--- a/plugins/infiquetra-loop/scripts/lifecycle_state.py
+++ b/plugins/infiquetra-loop/scripts/lifecycle_state.py
@@ -31,9 +31,7 @@ def normalize_destination(value: str) -> str:
     key = key.replace("nonprod-deployment", "nonprod-deploy")
     if key in DESTINATION_ALIASES:
         return DESTINATION_ALIASES[key]
-    raise ValueError(
-        "destination must be one of: plan-only, pr, merge, nonprod-deploy"
-    )
+    raise ValueError("destination must be one of: plan-only, pr, merge, nonprod-deploy")
 
 
 def destination_includes_deploy(destination: str) -> bool:

--- a/plugins/infiquetra-loop/scripts/lifecycle_state.py
+++ b/plugins/infiquetra-loop/scripts/lifecycle_state.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Infiquetra lifecycle destination and escalation helpers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+DESTINATION_ALIASES = {
+    "plan": "plan-only",
+    "plan only": "plan-only",
+    "plan-only": "plan-only",
+    "planning": "plan-only",
+    "pr": "pr",
+    "pull request": "pr",
+    "pull-request": "pr",
+    "merge": "merge",
+    "merged": "merge",
+    "nonprod": "nonprod-deploy",
+    "nonprod deploy": "nonprod-deploy",
+    "nonprod-deploy": "nonprod-deploy",
+    "deploy": "nonprod-deploy",
+}
+
+
+def normalize_destination(value: str) -> str:
+    """Normalize user-facing destination labels."""
+
+    key = " ".join(value.strip().lower().replace("_", "-").split())
+    key = key.replace("nonprod-deployment", "nonprod-deploy")
+    if key in DESTINATION_ALIASES:
+        return DESTINATION_ALIASES[key]
+    raise ValueError(
+        "destination must be one of: plan-only, pr, merge, nonprod-deploy"
+    )
+
+
+def destination_includes_deploy(destination: str) -> bool:
+    """Return whether the selected destination needs deployment orchestration."""
+
+    return normalize_destination(destination) == "nonprod-deploy"
+
+
+def should_offer_team_execution(
+    *,
+    file_count: int,
+    phase_count: int,
+    has_security: bool,
+    has_infra: bool,
+    cross_repo: bool,
+    deployment_sensitive: bool,
+) -> bool:
+    """Decide whether the loop should offer team-execution."""
+
+    return any(
+        (
+            file_count >= 8,
+            phase_count >= 4,
+            has_security,
+            has_infra,
+            cross_repo,
+            deployment_sensitive,
+        )
+    )
+
+
+def should_prompt_for_issue(*, has_issue: bool, is_trivial: bool, user_declined: bool) -> bool:
+    """Ask whether to file an SDLC issue for non-trivial ad-hoc work."""
+
+    return not has_issue and not is_trivial and not user_declined
+
+
+def requires_hard_test_gate(change_kinds: Sequence[str]) -> bool:
+    """Return whether a change kind requires explicit tests before shipping."""
+
+    risky = {"behavior", "security", "infra", "api", "deployment", "data"}
+    return bool(risky.intersection(kind.lower() for kind in change_kinds))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("destination")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(normalize_destination(args.destination))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/load_saga_context.py
+++ b/plugins/infiquetra-loop/scripts/load_saga_context.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Load prior issue, PR, checkpoint, and journal context for loop resume."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+STATE_DIR = Path(".claude/infiquetra-loop")
+ROUND_RE = re.compile(r"round-(\d+)", re.IGNORECASE)
+
+
+def parse_repo(value: str) -> tuple[str, str]:
+    if "/" in value:
+        owner, repo = value.split("/", 1)
+        return owner, repo
+    return "infiquetra", value
+
+
+def latest_checkpoint(issue: int) -> dict[str, object] | None:
+    checkpoint_dir = STATE_DIR / "checkpoints"
+    if not checkpoint_dir.exists():
+        return None
+    matches = sorted(
+        checkpoint_dir.glob(f"issue-{issue}-*.md"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if not matches:
+        return None
+    latest = matches[0]
+    content = latest.read_text(encoding="utf-8")
+    return {
+        "path": str(latest),
+        "name": latest.name,
+        "mtime": latest.stat().st_mtime,
+        "content_preview": content[:2000],
+    }
+
+
+def prior_prs(owner: str, repo: str, issue: int) -> list[dict[str, object]]:
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        f"{owner}/{repo}",
+        "--state",
+        "all",
+        "--search",
+        f"in:title #{issue} round",
+        "--json",
+        "number,title,state,mergedAt,url,reviewDecision,body",
+        "--limit",
+        "50",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603
+    if result.returncode != 0:
+        return []
+    records: list[dict[str, object]] = []
+    for pr in json.loads(result.stdout or "[]"):
+        round_match = ROUND_RE.search(pr.get("title", "") or "")
+        records.append(
+            {
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "state": pr.get("state"),
+                "mergedAt": pr.get("mergedAt"),
+                "url": pr.get("url"),
+                "reviewDecision": pr.get("reviewDecision"),
+                "round": int(round_match.group(1)) if round_match else None,
+                "body_preview": (pr.get("body") or "")[:500],
+            }
+        )
+    return sorted(records, key=lambda record: int(record.get("round") or 0))
+
+
+def journal_entries(issue: int, adr_refs: list[str]) -> dict[str, list[dict[str, str]]]:
+    output: dict[str, list[dict[str, str]]] = {"learnings": [], "decisions": []}
+    journal_dir = Path("docs/engineering-journal")
+    if not journal_dir.exists():
+        return output
+
+    refs_to_search = [f"#{issue}", *adr_refs]
+    for filename, key in (("LEARNINGS.md", "learnings"), ("DECISIONS.md", "decisions")):
+        path = journal_dir / filename
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8")
+        sections = re.split(r"^## ", content, flags=re.MULTILINE)
+        for section in sections[1:]:
+            if any(ref in section for ref in refs_to_search):
+                output[key].append(
+                    {
+                        "file": str(path),
+                        "title": section.splitlines()[0].strip() if section else "",
+                        "preview": section[:600],
+                    }
+                )
+    return output
+
+
+def adr_refs_from_text(content: str | None) -> list[str]:
+    if not content:
+        return []
+    matches = re.findall(r"\bADR[-\s]?(\d{2,4})\b", content, flags=re.IGNORECASE)
+    return [f"ADR-{int(number):04d}" for number in matches]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue", type=int, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    owner, repo = parse_repo(args.repo)
+    checkpoint = latest_checkpoint(args.issue)
+    prs = prior_prs(owner, repo, args.issue)
+    adrs = adr_refs_from_text(checkpoint["content_preview"] if checkpoint else None)
+    rounds_seen = sorted(
+        {int(pr["round"]) for pr in prs if pr.get("round") is not None}
+    )
+    print(
+        json.dumps(
+            {
+                "repo": f"{owner}/{repo}",
+                "issue": args.issue,
+                "rounds_seen": rounds_seen,
+                "next_round": (max(rounds_seen) + 1) if rounds_seen else 1,
+                "checkpoint": checkpoint,
+                "prior_prs": prs,
+                "adr_refs": adrs,
+                "journal": journal_entries(args.issue, adrs),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/load_saga_context.py
+++ b/plugins/infiquetra-loop/scripts/load_saga_context.py
@@ -124,9 +124,7 @@ def main() -> int:
     checkpoint = latest_checkpoint(args.issue)
     prs = prior_prs(owner, repo, args.issue)
     adrs = adr_refs_from_text(checkpoint["content_preview"] if checkpoint else None)
-    rounds_seen = sorted(
-        {int(pr["round"]) for pr in prs if pr.get("round") is not None}
-    )
+    rounds_seen = sorted({int(pr["round"]) for pr in prs if pr.get("round") is not None})
     print(
         json.dumps(
             {

--- a/plugins/infiquetra-loop/scripts/parse_issue.py
+++ b/plugins/infiquetra-loop/scripts/parse_issue.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Parse an issue body for context refs, acceptance criteria, and scope hints."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+ADR_RE = re.compile(r"\bADR[-\s]?(\d{2,4})\b", re.IGNORECASE)
+AC_RE = re.compile(r"\bAC[-\s]?(\d{1,3})\b", re.IGNORECASE)
+ROUND_RE = re.compile(r"\b[Rr]ound[-\s]?(\d+)\b")
+SECURITY_RE = re.compile(
+    r"\b(auth|jwt|oauth|secret|credential|crypto|kms|iam|encrypt|decrypt|signing)\b",
+    re.IGNORECASE,
+)
+API_RE = re.compile(r"\b(endpoint|rest|openapi|api/|/api|handler|route|sdk|contract)\b")
+INFRA_RE = re.compile(r"\b(cdk|cloudformation|terraform|lambda|dynamodb|s3|vpc)\b")
+PRIVACY_RE = re.compile(r"\b(pii|gdpr|consent|retention|personal data|anonymize|hipaa)\b")
+REFACTOR_RE = re.compile(r"\b(refactor|dry|solid|complexity|technical debt|cleanup)\b")
+
+
+def unique_sorted_ints(values: Iterable[str]) -> list[int]:
+    return sorted({int(value) for value in values})
+
+
+def extract(body: str) -> dict[str, object]:
+    adrs = unique_sorted_ints(ADR_RE.findall(body))
+    acceptance = unique_sorted_ints(AC_RE.findall(body))
+    rounds = unique_sorted_ints(ROUND_RE.findall(body))
+    lowered = body.lower()
+
+    test_name_parts: list[str] = []
+    if adrs:
+        test_name_parts.append(f"ADR_{adrs[0]:03d}")
+    if acceptance:
+        test_name_parts.append(f"AC_{acceptance[0]}")
+
+    test_naming_pattern = "test_<module>_<scenario>"
+    if test_name_parts:
+        test_naming_pattern = f"test_{'_'.join(test_name_parts)}_<scenario>"
+
+    return {
+        "adr_refs": [f"ADR-{number:04d}" for number in adrs],
+        "ac_refs": [f"AC-{number}" for number in acceptance],
+        "round_refs": rounds,
+        "flags": {
+            "has_security": bool(SECURITY_RE.search(body)),
+            "has_api": bool(API_RE.search(lowered)),
+            "has_infra": bool(INFRA_RE.search(lowered)),
+            "has_privacy": bool(PRIVACY_RE.search(lowered)),
+            "has_refactor": bool(REFACTOR_RE.search(lowered)),
+        },
+        "test_naming_pattern": test_naming_pattern,
+        "first_line": body.splitlines()[0].strip()[:200] if body else "",
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", default="-", help='Path to issue body, or "-" for stdin')
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.body_file == "-":
+        body = sys.stdin.read()
+    else:
+        body = Path(args.body_file).read_text(encoding="utf-8")
+    print(json.dumps(extract(body), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/scaffold_checkpoint.py
+++ b/plugins/infiquetra-loop/scripts/scaffold_checkpoint.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Scaffold ignored Infiquetra loop checkpoint state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+STATE_DIR = Path(".claude/infiquetra-loop")
+CHECKPOINT_DIR = STATE_DIR / "checkpoints"
+
+DEFAULT_TEMPLATE = """# {{phase_title}}
+
+- Date: {{date}}
+- Issue: {{issue_ref}}
+- Destination: {{destination}}
+- Phase: {{phase_number}}
+- Status: {{phase_status}}
+- Plan: {{plan_path}}
+- Work session: {{work_session_path}}
+- Commit: {{last_commit_sha}}
+- Progress: {{progress_pct}}%
+- Blockers: {{blockers}}
+
+## Current Work
+
+{{current_work}}
+
+## Important Context
+
+{{important_context}}
+"""
+
+
+def render_template(template: str, context: dict[str, object]) -> str:
+    def render_var(match: re.Match[str]) -> str:
+        return str(context.get(match.group(1), ""))
+
+    return re.sub(r"\{\{(\w+)\}\}", render_var, template)
+
+
+def checkpoint_path(args: argparse.Namespace) -> Path:
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    suffix = f"-round-{args.round}" if args.round else ""
+    name = f"{args.kind}-{args.id}{suffix}-phase{args.phase}-{args.status}.md"
+    return CHECKPOINT_DIR / name
+
+
+def update_state_json(context: dict[str, object], args: argparse.Namespace) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    state_path = STATE_DIR / "state.json"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8")) if state_path.exists() else {}
+    except json.JSONDecodeError:
+        state = {}
+
+    state["last_updated"] = datetime.now(UTC).isoformat()
+    state["current_work"] = {
+        "kind": args.kind,
+        "id": args.id,
+        "round": args.round,
+        "phase": args.phase,
+        "phase_status": args.status,
+        "destination": args.destination,
+        "plan_path": args.plan_path,
+        "work_session_path": args.work_session_path,
+    }
+    if args.next_steps:
+        state["current_work"]["next_steps"] = args.next_steps.split("|")
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kind", choices=["issue", "task"], default="issue")
+    parser.add_argument("--id", required=True, help="Issue number or task slug")
+    parser.add_argument("--round", type=int)
+    parser.add_argument("--phase", type=int, required=True)
+    parser.add_argument("--status", choices=["pending", "in_progress", "complete"], default="pending")
+    parser.add_argument("--phase-title", default="")
+    parser.add_argument("--issue-ref", default="")
+    parser.add_argument("--destination", default="plan-only")
+    parser.add_argument("--progress-pct", type=int, default=0)
+    parser.add_argument("--plan-path", default="")
+    parser.add_argument("--work-session-path", default="")
+    parser.add_argument("--last-commit-sha", default="")
+    parser.add_argument("--current-work", default="")
+    parser.add_argument("--blockers", default="None")
+    parser.add_argument("--important-context", default="")
+    parser.add_argument("--next-steps", default="", help="pipe-separated list")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    context = {
+        "date": datetime.now(UTC).strftime("%Y-%m-%d %H:%M"),
+        "phase_title": args.phase_title or f"Phase {args.phase}",
+        "phase_number": args.phase,
+        "phase_status": args.status,
+        "issue_ref": args.issue_ref,
+        "destination": args.destination,
+        "progress_pct": args.progress_pct,
+        "plan_path": args.plan_path,
+        "work_session_path": args.work_session_path,
+        "last_commit_sha": args.last_commit_sha,
+        "current_work": args.current_work,
+        "blockers": args.blockers,
+        "important_context": args.important_context,
+    }
+    out_path = checkpoint_path(args)
+    out_path.write_text(render_template(DEFAULT_TEMPLATE, context), encoding="utf-8")
+    update_state_json(context, args)
+    print(
+        json.dumps(
+            {
+                "checkpoint_path": str(out_path),
+                "state_path": str(STATE_DIR / "state.json"),
+                "phase": args.phase,
+                "status": args.status,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/scaffold_checkpoint.py
+++ b/plugins/infiquetra-loop/scripts/scaffold_checkpoint.py
@@ -80,7 +80,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--id", required=True, help="Issue number or task slug")
     parser.add_argument("--round", type=int)
     parser.add_argument("--phase", type=int, required=True)
-    parser.add_argument("--status", choices=["pending", "in_progress", "complete"], default="pending")
+    parser.add_argument(
+        "--status", choices=["pending", "in_progress", "complete"], default="pending"
+    )
     parser.add_argument("--phase-title", default="")
     parser.add_argument("--issue-ref", default="")
     parser.add_argument("--destination", default="plan-only")

--- a/plugins/infiquetra-loop/skills/brainstorm/SKILL.md
+++ b/plugins/infiquetra-loop/skills/brainstorm/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: brainstorm
+description: Explore Infiquetra requirements, constraints, and implementation approaches before planning.
+---
+
+# Brainstorm
+
+Use this for collaborative requirement discovery.
+
+## Workflow
+
+1. Gather local evidence first when the answer is discoverable from the repository.
+2. Identify goals, non-goals, users, constraints, failure modes, and deployment implications.
+3. Push on hidden operational and security risk.
+4. Produce a compact decision surface rather than a giant transcript.
+5. Persist durable output under `docs/brainstorms/`.
+
+Move to `/plan` when the approach is selected. Move to `/office-hours` when the topic is still
+more personal thought-partner than concrete engineering.

--- a/plugins/infiquetra-loop/skills/code-review/SKILL.md
+++ b/plugins/infiquetra-loop/skills/code-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: code-review
+description: Structured Infiquetra code review for diffs, PRs, and pre-shipping gates.
+---
+
+# Code Review
+
+Use this for review requests or before PR and shipping gates.
+
+## Review Order
+
+1. Correctness and behavioral regressions.
+2. Security, secrets, trust boundaries, and authorization.
+3. Operational risk, migrations, deployments, and rollback.
+4. Missing tests or weak verification.
+5. Maintainability, readability, and local conventions.
+
+Findings lead. Include file and line references. If no issues are found, say so plainly and call
+out residual test or operational risk. Offer `team-execution` when the review needs multiple
+reviewer lenses or validators.

--- a/plugins/infiquetra-loop/skills/founder-review/SKILL.md
+++ b/plugins/infiquetra-loop/skills/founder-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: founder-review
+description: Founder and CEO-style review for Infiquetra strategy, scope, ambition, timing, and operator risk.
+---
+
+# Founder Review
+
+Use this for product, strategy, user-facing, roadmap, or high-scope engineering work.
+
+## Review Lens
+
+- Is the work ambitious enough for the opportunity?
+- Is the scope small enough to ship and learn?
+- Does this sharpen the product wedge or distract from it?
+- What would a founder, staff engineer, and operator each worry about?
+- What is the most likely expensive mistake?
+- What evidence would make this a clear yes or no?
+
+This is the `/ceo-review` alias target. Keep it separate from `/strategy`: review challenges the
+direction; strategy records the chosen direction.

--- a/plugins/infiquetra-loop/skills/ideate/SKILL.md
+++ b/plugins/infiquetra-loop/skills/ideate/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ideate
+description: Generate and critically evaluate grounded Infiquetra product, architecture, or workflow ideas.
+---
+
+# Ideate
+
+Use this when the user needs options, not execution yet.
+
+## Workflow
+
+1. Ground ideas in repository evidence, current SDLC context, and context-library links.
+2. Produce a small option set with clear tradeoffs.
+3. When the option set is broad, lead the user through choices one at a time.
+4. Label risks and assumptions explicitly.
+5. Persist selected ideas under `docs/ideation/` with links to issues, strategy, or plans.
+
+Graduate to `/brainstorm` when requirements need exploration, `/strategy` when the durable
+direction changed, or `/plan` when the implementation path is clear.

--- a/plugins/infiquetra-loop/skills/loop/SKILL.md
+++ b/plugins/infiquetra-loop/skills/loop/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: loop
+description: |
+  Infiquetra lifecycle router for strategy, ideation, planning, work execution, QA, issue
+  progress, engineering-journal updates, review, deployment handoff, retro, and resume.
+---
+
+# Loop
+
+Use this skill when the user wants to start, route, or continue Infiquetra work.
+
+## Start
+
+At loop start, identify the entry point and ask how far to take the work when it is not already
+clear:
+
+- `plan-only`: create durable thinking and stop before implementation.
+- `pr`: implement, verify, and prepare a PR.
+- `merge`: continue through PR readiness and merge coordination.
+- `nonprod-deploy`: continue through nonprod deployment evidence.
+
+Use `scripts/lifecycle_state.py` for destination normalization and escalation decisions.
+Use `scripts/parse_issue.py` for ADR, acceptance-criteria, round, and risk hints when an issue
+body is available.
+
+## Durable Artifacts
+
+Repository docs are the source of truth:
+
+- `STRATEGY.md`
+- `docs/ideation/`
+- `docs/brainstorms/`
+- `docs/plans/`
+- `docs/reviews/`
+- `docs/qa/`
+- `docs/work-sessions/`
+- `docs/retros/`
+- `docs/engineering-journal/`
+
+Ignored local runtime state lives under `.claude/infiquetra-loop/`. Use it only for active session
+pointers, raw checkpoint state, API caches, validator JSON, and resume scratch data.
+
+## SDLC Issue Behavior
+
+For non-trivial ad-hoc work, ask whether to file an SDLC issue first through `sdlc-manager`.
+If an issue exists, keep issue progress current:
+
+- Start comment: selected destination, plan link, and scope summary.
+- Phase comments: progress, committed `docs/work-sessions/` summary, commit SHA, checks run,
+  and blockers.
+- PR comment: PR link, review status, and remaining gates.
+- Nonprod comment: deployment status, workflow URL, and evidence link.
+- Completion comment: close or move only after acceptance criteria and destination are satisfied.
+
+Use `scripts/issue_progress.py` to render comments. Use `sdlc-manager` for issue comments and board
+movement at Infiquetra SDLC phase boundaries.
+
+## Gates
+
+- Behavior, security, infra, API, deployment, and data changes require tests.
+- Docs, config, and trivial changes may skip tests only with an explicit rationale.
+- Run an engineering review before execution on risky plans and before shipping gates.
+- Suggest founder review for strategy, scope, product, or user-facing work.
+
+## Integrations
+
+- Use `infiquetra-deploy` only when the selected destination includes deployment.
+- Offer or invoke `team-execution` for cross-repo, security, infra, large, deployment-sensitive,
+  or high-parallelism work.
+- Fall back cleanly when `infiquetra-deploy`, `team-execution`, or `sdlc-manager` is unavailable:
+  explain the missing integration and continue with manual evidence where safe.
+
+## Resume
+
+Resume from durable artifacts first: plan, issue, PR, work sessions, QA notes, retros, and
+engineering-journal entries. Use `.claude/infiquetra-loop/` only to recover raw scratch state.
+For recovery mechanics, use `scripts/find_inflight_work.py`, `scripts/load_saga_context.py`, and
+`scripts/scaffold_checkpoint.py`.

--- a/plugins/infiquetra-loop/skills/office-hours/SKILL.md
+++ b/plugins/infiquetra-loop/skills/office-hours/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: office-hours
+description: |
+  Thought-partner office-hours workflow for early Infiquetra product, architecture, founder,
+  and engineering ideas before they become plans.
+---
+
+# Office Hours
+
+Use this for exploratory thinking where the right frame is still unclear.
+
+## Workflow
+
+1. Start with the user's current intuition and restate the decision pressure.
+2. Ask one concise question at a time when more shape is needed.
+3. Offer 3 to 5 candidate frames or options when useful.
+4. Challenge weak assumptions plainly, especially around operational risk, scope, security, and
+   sequencing.
+5. End with the next useful artifact: ideation note, brainstorm note, strategy update, SDLC issue,
+   or plan.
+
+Persist worthwhile outputs under `docs/ideation/` or `docs/brainstorms/`. Keep raw scratch under
+`.claude/infiquetra-loop/`.

--- a/plugins/infiquetra-loop/skills/optimize/SKILL.md
+++ b/plugins/infiquetra-loop/skills/optimize/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: optimize
+description: Metric-driven Infiquetra optimization loop for measurable performance, cost, reliability, or workflow improvements.
+---
+
+# Optimize
+
+Use this when success is measurable and iteration should be bounded.
+
+## Workflow
+
+1. Define the metric and acceptable measurement method.
+2. Capture a baseline before changing behavior.
+3. Pick a small experiment set and expected impact.
+4. Change one meaningful variable at a time when possible.
+5. Record results, checks, and tradeoffs under `docs/qa/` or a plan-linked notes file.
+6. Stop when the target is reached, the experiment fails, or the next step needs a strategy
+   decision.
+
+Raw benchmark output and temporary profiles belong under `.claude/infiquetra-loop/`.

--- a/plugins/infiquetra-loop/skills/plan/SKILL.md
+++ b/plugins/infiquetra-loop/skills/plan/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: plan
+description: Create durable Infiquetra implementation plans with issue, review, test, and deploy gates.
+---
+
+# Plan
+
+Use this for multi-step work where chat history is not a reliable source of truth.
+
+## Workflow
+
+1. Read the issue, relevant docs, repository guidance, and local code before planning.
+2. Ask for destination if unknown: plan only, PR, merge, or nonprod deploy.
+3. Ask whether to file an SDLC issue first for non-trivial ad-hoc work.
+4. Write concise plans under `docs/plans/`.
+5. Include acceptance criteria, scope, files likely to change, checks, issue updates, review gates,
+   deploy gates when relevant, and resume notes.
+6. Offer `team-execution` when risk, size, or parallelism justify the cost.
+
+Keep the plan decision-complete but short enough to maintain during execution.

--- a/plugins/infiquetra-loop/skills/qa/SKILL.md
+++ b/plugins/infiquetra-loop/skills/qa/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: qa
+description: Run risk-based Infiquetra QA gates for code, docs, browser behavior, deployment, and acceptance evidence.
+---
+
+# QA
+
+Use this before PR readiness, merge readiness, nonprod deployment evidence, or completion.
+
+## Workflow
+
+1. Identify the risk class: behavior, security, infra, API, deployment, data, docs, config, or
+   trivial.
+2. Derive checks from repository tooling and the plan's verification section.
+3. Run narrow checks first, then broader checks when risk justifies them.
+4. Store durable QA notes under `docs/qa/` when the work is non-trivial.
+5. Update issue progress with checks run and remaining risk.
+
+Skipping tests requires a clear rationale and is only acceptable for docs, config, or trivial work.

--- a/plugins/infiquetra-loop/skills/resume/SKILL.md
+++ b/plugins/infiquetra-loop/skills/resume/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: resume
+description: Resume Infiquetra work from durable plans, work sessions, issues, PRs, and ignored local loop state.
+---
+
+# Resume
+
+Use this when a session ended, context was lost, or the user asks to continue a work loop.
+
+## Workflow
+
+1. Read committed artifacts first:
+   - `docs/plans/`
+   - `docs/work-sessions/`
+   - `docs/qa/`
+   - `docs/retros/`
+   - issue and PR comments
+2. Read `.claude/infiquetra-loop/` only for raw scratch state and active pointers.
+3. Reconstruct current phase, selected destination, blockers, checks run, and next step.
+4. Continue from the durable source of truth rather than chat memory alone.
+5. If evidence conflicts, prefer committed docs and issue state over raw local cache.

--- a/plugins/infiquetra-loop/skills/retro/SKILL.md
+++ b/plugins/infiquetra-loop/skills/retro/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: retro
+description: Capture Infiquetra work retrospectives and promote generalizable findings into the engineering journal.
+---
+
+# Retro
+
+Use this after a meaningful work loop, PR, deployment, or aborted attempt.
+
+## Workflow
+
+1. Summarize what shipped or what was learned.
+2. Capture what surprised, what slowed the work, what evidence mattered, and what should change.
+3. Write durable retros under `docs/retros/`.
+4. Promote generalizable findings into `docs/engineering-journal/LEARNINGS.md`.
+5. Promote plugin-pattern decisions into `docs/engineering-journal/DECISIONS.md`.
+6. Queue valuable deferred work in `docs/engineering-journal/QUEUED.md`.
+
+Keep retros concise and link to plans, work sessions, PRs, issues, checks, and deployment evidence.

--- a/plugins/infiquetra-loop/skills/strategy/SKILL.md
+++ b/plugins/infiquetra-loop/skills/strategy/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: strategy
+description: Maintain the repository root STRATEGY.md as the durable product and technical strategy artifact.
+---
+
+# Strategy
+
+Use this when the work changes the repository's target problem, audience, wedge, ambition,
+non-goals, sequencing, or success criteria.
+
+## Workflow
+
+1. Read the existing root `STRATEGY.md` when present.
+2. Link current Infiquetra context-library guidance instead of embedding policy text.
+3. Separate strategy from founder review:
+   - Strategy records the chosen direction.
+   - Founder review challenges whether that direction is ambitious, coherent, and worth doing.
+4. Keep changes concise and durable enough to survive a session ending.
+5. If the strategy implies implementation work, route to `/plan` or `/loop`.
+
+Do not turn `STRATEGY.md` into a changelog or meeting transcript.

--- a/plugins/infiquetra-loop/skills/work/SKILL.md
+++ b/plugins/infiquetra-loop/skills/work/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: work
+description: Execute an Infiquetra plan with phase checkpoints, issue updates, test gates, and work-session summaries.
+---
+
+# Work
+
+Use this after a plan is approved or when resuming execution from a durable plan.
+
+## Workflow
+
+1. Load the plan and active issue or PR.
+2. Record the active pointer in `.claude/infiquetra-loop/`.
+3. Execute one meaningful phase at a time.
+4. After each phase, write a concise summary under `docs/work-sessions/`.
+5. Comment issue progress through `sdlc-manager` with plan path, work-session path, commit SHA,
+   checks run, and blockers.
+6. Run hard test gates for behavior, security, infra, API, deployment, or data changes.
+7. Run `/code-review` before PR or shipping gates.
+8. If the destination includes nonprod deploy, hand off deployment mutation to `infiquetra-deploy`.
+
+Do not close or move the issue until acceptance criteria and the selected destination are satisfied.

--- a/plugins/redis-channel/scripts/integ_test.py
+++ b/plugins/redis-channel/scripts/integ_test.py
@@ -46,7 +46,9 @@ REDIS_PORT = int(os.environ.get("REDIS_CHANNEL_INTEG_PORT", "6379"))
 # HERMES_REDIS_PASSWORD for legacy compatibility. Example:
 #   REDIS_CHANNEL_INTEG_PASSWORD="$(security find-generic-password -s my-redis-password -w)" \
 #     uv run python plugins/redis-channel/scripts/integ_test.py
-REDIS_PASSWORD = os.environ.get("REDIS_CHANNEL_INTEG_PASSWORD") or os.environ["HERMES_REDIS_PASSWORD"]
+REDIS_PASSWORD = (
+    os.environ.get("REDIS_CHANNEL_INTEG_PASSWORD") or os.environ["HERMES_REDIS_PASSWORD"]
+)
 TEST_SESSION_NAME = "integ-test-headless"
 NOTIFICATION_WAIT_S = 5.0
 SHUTDOWN_WAIT_S = 5.0

--- a/plugins/redis-channel/server/channel.py
+++ b/plugins/redis-channel/server/channel.py
@@ -148,9 +148,7 @@ class ServerState:
             with self._lock:
                 if self._presence is not None:
                     return {"ok": True, "was_already_connected": True}
-                result = self._register_locked(
-                    endpoint=endpoint, session_name=None, debug=False
-                )
+                result = self._register_locked(endpoint=endpoint, session_name=None, debug=False)
                 result["consumer_attached"] = False
                 result["notifier_kind"] = None
                 return result
@@ -364,9 +362,7 @@ class ServerState:
                 }
             session_name = self._presence.session_name
             uptime = (
-                int(time.time() - self._connected_at)
-                if self._connected_at is not None
-                else None
+                int(time.time() - self._connected_at) if self._connected_at is not None else None
             )
             # Count pending inbound messages on the consumer group via XLEN-
             # like introspection. XPENDING gives unacked count for the group;
@@ -377,9 +373,7 @@ class ServerState:
             pending: int | None = None
             try:
                 if self._client is not None:
-                    pending = int(
-                        self._client.xlen(inbound_stream(session_name))
-                    )
+                    pending = int(self._client.xlen(inbound_stream(session_name)))
             except Exception:  # noqa: BLE001
                 pending = None
             return {
@@ -488,18 +482,14 @@ def _check_setup() -> dict[str, Any]:
     return {
         "plugin_root": str(_plugin_root()) if _plugin_root() else None,
         "wrapper_symlink_path": str(WRAPPER_SYMLINK),
-        "wrapper_symlink_expected_target": (
-            str(wrapper_target) if wrapper_target else None
-        ),
+        "wrapper_symlink_expected_target": (str(wrapper_target) if wrapper_target else None),
         "wrapper_symlink_status": symlink_status,
         "source_env_path": str(source_env),
         "source_env_exists": source_env.exists(),
         "registry_path": str(registry_json),
         "registry_exists": registry_json.exists(),
         "all_ready": (
-            symlink_status == "current"
-            and source_env.exists()
-            and registry_json.exists()
+            symlink_status == "current" and source_env.exists() and registry_json.exists()
         ),
     }
 
@@ -678,10 +668,7 @@ def _do_setup(*, link_wrapper: bool, scaffold_configs: bool) -> dict[str, Any]:
                     {
                         "target": str(dest),
                         "status": "skipped",
-                        "reason": (
-                            f"example not found at {example} — is the plugin "
-                            f"installed?"
-                        ),
+                        "reason": (f"example not found at {example} — is the plugin installed?"),
                     }
                 )
                 continue
@@ -896,9 +883,7 @@ def build_app() -> FastMCP:
     async def redis_channel_setup(
         link_wrapper: bool = True, scaffold_configs: bool = True
     ) -> dict[str, Any]:
-        return _do_setup(
-            link_wrapper=link_wrapper, scaffold_configs=scaffold_configs
-        )
+        return _do_setup(link_wrapper=link_wrapper, scaffold_configs=scaffold_configs)
 
     @app.tool(
         name="redis_channel_configure",
@@ -1106,8 +1091,7 @@ def _maybe_auto_connect() -> None:
         )
     else:
         log.warning(
-            "auto-connect failed: %s. Server continuing; use "
-            "/redis-channel-connect manually.",
+            "auto-connect failed: %s. Server continuing; use /redis-channel-connect manually.",
             result,
         )
 
@@ -1205,8 +1189,7 @@ def _log_setup_nag() -> None:
         issues.append(f"missing: {state.get('registry_path')}")
     if issues:
         log.warning(
-            "redis-channel setup is incomplete — run /redis-channel-setup. "
-            "Issues: %s",
+            "redis-channel setup is incomplete — run /redis-channel-setup. Issues: %s",
             "; ".join(issues),
         )
 

--- a/tests/test_infiquetra_deploy_plugin.py
+++ b/tests/test_infiquetra_deploy_plugin.py
@@ -1,0 +1,110 @@
+"""Contract tests for the infiquetra-deploy plugin package."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PLUGIN_ROOT = ROOT / "plugins" / "infiquetra-deploy"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_module(script_name: str):
+    path = PLUGIN_ROOT / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(script_name.removesuffix(".py"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter_name(path: Path) -> str:
+    lines = _read(path).splitlines()
+    assert lines[0] == "---"
+    for line in lines[1:]:
+        if line.startswith("name: "):
+            return line.removeprefix("name: ").strip()
+    raise AssertionError(f"{path} has no frontmatter name")
+
+
+def test_infiquetra_deploy_metadata_and_marketplace_entry_match() -> None:
+    plugin_json = json.loads(_read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+    marketplace = json.loads(_read(ROOT / ".claude-plugin" / "marketplace.json"))
+    entry = next(p for p in marketplace["plugins"] if p["name"] == "infiquetra-deploy")
+
+    assert plugin_json["name"] == "infiquetra-deploy"
+    assert plugin_json["version"] == "0.1.0"
+    assert entry["version"] == plugin_json["version"]
+    assert entry["source"] == "./plugins/infiquetra-deploy"
+    assert "tag-promotion" in plugin_json["description"]
+    assert {"deploy", "tag-promotion", "rollback", "hotfix"} <= set(plugin_json["keywords"])
+
+
+def test_infiquetra_deploy_commands_skills_agents_and_scripts_are_packaged() -> None:
+    for command in ("deploy", "deploy-status", "deploy-notes", "deploy-hotfix"):
+        assert (PLUGIN_ROOT / "commands" / f"{command}.md").exists()
+
+    skill_path = PLUGIN_ROOT / "skills" / "deploy-state" / "SKILL.md"
+    assert _frontmatter_name(skill_path) == "deploy-state"
+    assert "ADR-0004" in _read(skill_path)
+
+    agent_path = PLUGIN_ROOT / "agents" / "release-orchestrator.md"
+    assert _frontmatter_name(agent_path) == "release-orchestrator"
+
+    for script in ("mint_tag.py", "query_deployments.py", "preview_release_notes.py"):
+        assert (PLUGIN_ROOT / "scripts" / script).exists()
+
+
+def test_mint_tag_uses_infiquetra_environments_and_tag_prefixes() -> None:
+    mint_tag = _load_module("mint_tag.py")
+
+    assert mint_tag.ENV_TO_PREFIX == {
+        "nonprod": "nonprod",
+        "staging": "staging",
+        "production": "production",
+    }
+    assert mint_tag.build_tag_name("staging", "1.2.3", rollback=False) == "staging-v1.2.3"
+    assert (
+        mint_tag.build_tag_name("production", "1.2.3", rollback=True)
+        == "rollback-production-v1.2.3"
+    )
+    assert (
+        mint_tag.build_tag_name("production", "1.2.3.1", rollback=False)
+        == "production-v1.2.3.1"
+    )
+
+
+def test_mint_tag_resolves_and_rejects_repository_owners(monkeypatch) -> None:
+    mint_tag = _load_module("mint_tag.py")
+
+    assert mint_tag.resolve_repo("campps-service") == "infiquetra/campps-service"
+    assert mint_tag.resolve_repo("infiquetra/campps-service") == "infiquetra/campps-service"
+
+    def fake_run(cmd: list[str], *, check: bool = True, capture: bool = True) -> str:
+        assert cmd == ["git", "remote", "get-url", "origin"]
+        return "git@github.com:other-org/service.git"
+
+    monkeypatch.setattr(mint_tag, "run", fake_run)
+
+    try:
+        mint_tag.resolve_repo(None)
+    except SystemExit as exc:
+        assert "expected github.com/infiquetra/*" in str(exc)
+    else:
+        raise AssertionError("non-Infiquetra remote should be rejected")
+
+
+def test_query_deployments_strips_infiquetra_tag_prefixes() -> None:
+    query_deployments = _load_module("query_deployments.py")
+
+    assert query_deployments.strip_prefix("v1.2.3") == "1.2.3"
+    assert query_deployments.strip_prefix("nonprod-v1.2.3") == "1.2.3"
+    assert query_deployments.strip_prefix("staging-v1.2.3") == "1.2.3"
+    assert query_deployments.strip_prefix("production-v1.2.3") == "1.2.3"
+    assert query_deployments.strip_prefix("rollback-production-v1.2.3") == "1.2.3"

--- a/tests/test_infiquetra_deploy_plugin.py
+++ b/tests/test_infiquetra_deploy_plugin.py
@@ -74,10 +74,7 @@ def test_mint_tag_uses_infiquetra_environments_and_tag_prefixes() -> None:
         mint_tag.build_tag_name("production", "1.2.3", rollback=True)
         == "rollback-production-v1.2.3"
     )
-    assert (
-        mint_tag.build_tag_name("production", "1.2.3.1", rollback=False)
-        == "production-v1.2.3.1"
-    )
+    assert mint_tag.build_tag_name("production", "1.2.3.1", rollback=False) == "production-v1.2.3.1"
 
 
 def test_mint_tag_resolves_and_rejects_repository_owners(monkeypatch) -> None:

--- a/tests/test_infiquetra_loop_plugin.py
+++ b/tests/test_infiquetra_loop_plugin.py
@@ -1,0 +1,189 @@
+"""Contract tests for the infiquetra-loop plugin package."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+PLUGIN_ROOT = ROOT / "plugins" / "infiquetra-loop"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_module(script_name: str):
+    path = PLUGIN_ROOT / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(script_name.removesuffix(".py"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter_name(path: Path) -> str:
+    lines = _read(path).splitlines()
+    assert lines[0] == "---"
+    for line in lines[1:]:
+        if line.startswith("name: "):
+            return line.removeprefix("name: ").strip()
+    raise AssertionError(f"{path} has no frontmatter name")
+
+
+def test_infiquetra_loop_metadata_and_marketplace_entry_match() -> None:
+    plugin_json = json.loads(_read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+    marketplace = json.loads(_read(ROOT / ".claude-plugin" / "marketplace.json"))
+    entry = next(p for p in marketplace["plugins"] if p["name"] == "infiquetra-loop")
+
+    assert plugin_json["name"] == "infiquetra-loop"
+    assert plugin_json["version"] == "0.1.0"
+    assert entry["version"] == plugin_json["version"]
+    assert entry["source"] == "./plugins/infiquetra-loop"
+    assert "lifecycle" in plugin_json["description"]
+    assert {"loop", "lifecycle", "strategy", "code-review", "optimize"} <= set(
+        plugin_json["keywords"]
+    )
+
+
+def test_infiquetra_loop_commands_are_packaged() -> None:
+    for command in (
+        "loop",
+        "office-hours",
+        "strategy",
+        "ideate",
+        "brainstorm",
+        "plan",
+        "work",
+        "qa",
+        "retro",
+        "resume",
+        "founder-review",
+        "ceo-review",
+        "code-review",
+        "optimize",
+    ):
+        assert (PLUGIN_ROOT / "commands" / f"{command}.md").exists()
+
+
+def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
+    expected_skills = {
+        "loop",
+        "office-hours",
+        "strategy",
+        "ideate",
+        "brainstorm",
+        "plan",
+        "work",
+        "qa",
+        "retro",
+        "resume",
+        "founder-review",
+        "code-review",
+        "optimize",
+    }
+    for skill in expected_skills:
+        skill_path = PLUGIN_ROOT / "skills" / skill / "SKILL.md"
+        assert _frontmatter_name(skill_path) == skill
+
+    loop_doc = _read(PLUGIN_ROOT / "skills" / "loop" / "SKILL.md")
+    for required in (
+        "STRATEGY.md",
+        "docs/work-sessions/",
+        ".claude/infiquetra-loop/",
+        "team-execution",
+        "infiquetra-deploy",
+        "sdlc-manager",
+        "issue progress",
+        "engineering-journal",
+    ):
+        assert required in loop_doc
+
+    for script in (
+        "parse_issue.py",
+        "scaffold_checkpoint.py",
+        "find_inflight_work.py",
+        "load_saga_context.py",
+        "discover_subissues.py",
+    ):
+        assert (PLUGIN_ROOT / "scripts" / script).exists()
+
+
+def test_destination_selector_and_escalation_helpers() -> None:
+    lifecycle = _load_module("lifecycle_state.py")
+
+    assert lifecycle.normalize_destination("plan") == "plan-only"
+    assert lifecycle.normalize_destination("nonprod deploy") == "nonprod-deploy"
+    assert lifecycle.destination_includes_deploy("nonprod-deploy")
+    assert not lifecycle.destination_includes_deploy("pr")
+
+    assert lifecycle.should_offer_team_execution(
+        file_count=2,
+        phase_count=2,
+        has_security=False,
+        has_infra=False,
+        cross_repo=False,
+        deployment_sensitive=False,
+    ) is False
+    assert lifecycle.should_offer_team_execution(
+        file_count=1,
+        phase_count=1,
+        has_security=True,
+        has_infra=False,
+        cross_repo=False,
+        deployment_sensitive=False,
+    ) is True
+
+
+def test_issue_progress_comments_include_required_evidence() -> None:
+    issue_progress = _load_module("issue_progress.py")
+
+    start = issue_progress.render_issue_comment(
+        event="start",
+        issue_ref="infiquetra/campps-service#42",
+        destination="nonprod-deploy",
+        plan_path="docs/plans/2026-05-29-campps-service.md",
+        summary="Add deployment status endpoint.",
+    )
+    assert "selected destination: nonprod-deploy" in start
+    assert "docs/plans/2026-05-29-campps-service.md" in start
+
+    phase = issue_progress.render_issue_comment(
+        event="phase",
+        issue_ref="infiquetra/campps-service#42",
+        destination="nonprod-deploy",
+        work_session_path="docs/work-sessions/2026-05-29-phase-1.md",
+        commit_sha="abc1234",
+        checks_run=["uv run pytest tests/test_service.py -q"],
+        blockers="None",
+    )
+    assert "docs/work-sessions/2026-05-29-phase-1.md" in phase
+    assert "abc1234" in phase
+    assert "uv run pytest tests/test_service.py -q" in phase
+
+
+def test_deploy_strategy_detection_matches_infiquetra_policy() -> None:
+    deploy_strategy = _load_module("detect_deploy_strategy.py")
+
+    assert deploy_strategy.classify(
+        ["deploy-nonprod.yml", "deploy-staging.yml", "deploy-production.yml"]
+    )["strategy"] == "tag-promotion"
+    partial = deploy_strategy.classify(["post-merge.yml", "deploy-staging.yml"])
+    assert partial["strategy"] == "tag-promotion-partial"
+    assert partial["envs_available"] == ["staging"]
+
+
+def test_issue_parser_extracts_infiquetra_context_and_risk_flags() -> None:
+    parse_issue = _load_module("parse_issue.py")
+
+    extracted = parse_issue.extract(
+        "ADR-0004 Round 2\n\nAC-1 Add OpenAPI endpoint with IAM auth."
+    )
+
+    assert extracted["adr_refs"] == ["ADR-0004"]
+    assert extracted["ac_refs"] == ["AC-1"]
+    assert extracted["round_refs"] == [2]
+    assert extracted["flags"]["has_api"] is True
+    assert extracted["flags"]["has_security"] is True

--- a/tests/test_infiquetra_loop_plugin.py
+++ b/tests/test_infiquetra_loop_plugin.py
@@ -119,22 +119,28 @@ def test_destination_selector_and_escalation_helpers() -> None:
     assert lifecycle.destination_includes_deploy("nonprod-deploy")
     assert not lifecycle.destination_includes_deploy("pr")
 
-    assert lifecycle.should_offer_team_execution(
-        file_count=2,
-        phase_count=2,
-        has_security=False,
-        has_infra=False,
-        cross_repo=False,
-        deployment_sensitive=False,
-    ) is False
-    assert lifecycle.should_offer_team_execution(
-        file_count=1,
-        phase_count=1,
-        has_security=True,
-        has_infra=False,
-        cross_repo=False,
-        deployment_sensitive=False,
-    ) is True
+    assert (
+        lifecycle.should_offer_team_execution(
+            file_count=2,
+            phase_count=2,
+            has_security=False,
+            has_infra=False,
+            cross_repo=False,
+            deployment_sensitive=False,
+        )
+        is False
+    )
+    assert (
+        lifecycle.should_offer_team_execution(
+            file_count=1,
+            phase_count=1,
+            has_security=True,
+            has_infra=False,
+            cross_repo=False,
+            deployment_sensitive=False,
+        )
+        is True
+    )
 
 
 def test_issue_progress_comments_include_required_evidence() -> None:
@@ -167,9 +173,12 @@ def test_issue_progress_comments_include_required_evidence() -> None:
 def test_deploy_strategy_detection_matches_infiquetra_policy() -> None:
     deploy_strategy = _load_module("detect_deploy_strategy.py")
 
-    assert deploy_strategy.classify(
-        ["deploy-nonprod.yml", "deploy-staging.yml", "deploy-production.yml"]
-    )["strategy"] == "tag-promotion"
+    assert (
+        deploy_strategy.classify(
+            ["deploy-nonprod.yml", "deploy-staging.yml", "deploy-production.yml"]
+        )["strategy"]
+        == "tag-promotion"
+    )
     partial = deploy_strategy.classify(["post-merge.yml", "deploy-staging.yml"])
     assert partial["strategy"] == "tag-promotion-partial"
     assert partial["envs_available"] == ["staging"]
@@ -178,9 +187,7 @@ def test_deploy_strategy_detection_matches_infiquetra_policy() -> None:
 def test_issue_parser_extracts_infiquetra_context_and_risk_flags() -> None:
     parse_issue = _load_module("parse_issue.py")
 
-    extracted = parse_issue.extract(
-        "ADR-0004 Round 2\n\nAC-1 Add OpenAPI endpoint with IAM auth."
-    )
+    extracted = parse_issue.extract("ADR-0004 Round 2\n\nAC-1 Add OpenAPI endpoint with IAM auth.")
 
     assert extracted["adr_refs"] == ["ADR-0004"]
     assert extracted["ac_refs"] == ["AC-1"]

--- a/tests/test_redis_channel_channel.py
+++ b/tests/test_redis_channel_channel.py
@@ -526,9 +526,7 @@ def test_reply_validates_empty_chat_id(patched_state: channel.ServerState, fr: A
 # ─── Phase 2.5: auto-connect at MCP startup ─────────────────────────────────
 
 
-def test_startup_register_eager_no_consumer(
-    patched_state: channel.ServerState, fr: Any
-) -> None:
+def test_startup_register_eager_no_consumer(patched_state: channel.ServerState, fr: Any) -> None:
     """startup_register publishes presence + creates consumer group but
     does NOT start consumer thread (no MCP ctx yet at startup time)."""
     out = patched_state.startup_register(endpoint="mimir")
@@ -773,12 +771,8 @@ def fake_plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     wrapper = plugin / "scripts" / "claude-channel.sh"
     wrapper.write_text("#!/bin/sh\necho fake\n")
     wrapper.chmod(0o755)
-    (plugin / "docs" / "source-env.example.sh").write_text(
-        "#!/bin/sh\nexport FOO=bar\n"
-    )
-    (plugin / "docs" / "registry.example.json").write_text(
-        '{"endpoints":{}}\n'
-    )
+    (plugin / "docs" / "source-env.example.sh").write_text("#!/bin/sh\nexport FOO=bar\n")
+    (plugin / "docs" / "registry.example.json").write_text('{"endpoints":{}}\n')
     monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin))
     return plugin
 
@@ -797,9 +791,7 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
-def test_setup_fresh_creates_symlink_and_configs(
-    fake_plugin_root: Path, fake_home: Path
-) -> None:
+def test_setup_fresh_creates_symlink_and_configs(fake_plugin_root: Path, fake_home: Path) -> None:
     """First-time setup: symlink absent, configs absent → both created."""
     result = channel._do_setup(link_wrapper=True, scaffold_configs=True)
     assert result["ok"] is True
@@ -820,9 +812,7 @@ def test_setup_fresh_creates_symlink_and_configs(
     assert statuses.count("created_from_example") == 2
 
 
-def test_setup_preserves_existing_user_config(
-    fake_plugin_root: Path, fake_home: Path
-) -> None:
+def test_setup_preserves_existing_user_config(fake_plugin_root: Path, fake_home: Path) -> None:
     """Re-running setup must NOT overwrite an existing source-env.sh / registry."""
     cfg = fake_home / ".claude" / "channels" / "redis-channel"
     cfg.mkdir(parents=True)
@@ -841,8 +831,9 @@ def test_setup_preserves_existing_user_config(
 
     # Reported as exists (not overwritten)
     config_actions = [
-        a for a in result["actions"] if "source-env" in a.get("target", "")
-        or "registry" in a.get("target", "")
+        a
+        for a in result["actions"]
+        if "source-env" in a.get("target", "") or "registry" in a.get("target", "")
     ]
     for a in config_actions:
         assert a["status"] == "exists"
@@ -901,9 +892,7 @@ def test_setup_skips_link_when_wrapper_not_in_plugin_root(
     monkeypatch.setattr(channel, "WRAPPER_SYMLINK", bin_dir / "claude-channel")
 
     result = channel._do_setup(link_wrapper=True, scaffold_configs=False)
-    link_actions = [
-        a for a in result["actions"] if "claude-channel" in a.get("target", "")
-    ]
+    link_actions = [a for a in result["actions"] if "claude-channel" in a.get("target", "")]
     assert len(link_actions) == 1
     assert link_actions[0]["status"] == "skipped"
     assert (bin_dir / "claude-channel").is_symlink() is False
@@ -918,7 +907,9 @@ def test_setup_nag_logs_when_state_incomplete(
     # No plugin root, no symlink, no configs
     monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
     monkeypatch.setattr(
-        channel, "_check_setup", lambda: {
+        channel,
+        "_check_setup",
+        lambda: {
             "all_ready": False,
             "wrapper_symlink_status": "missing",
             "wrapper_symlink_expected_target": "/x",
@@ -926,27 +917,21 @@ def test_setup_nag_logs_when_state_incomplete(
             "source_env_exists": False,
             "registry_path": "/z",
             "registry_exists": False,
-        }
+        },
     )
     with caplog.at_level("WARNING", logger="redis_channel.channel"):
         channel._log_setup_nag()
-    assert any(
-        "/redis-channel-setup" in r.message for r in caplog.records
-    )
+    assert any("/redis-channel-setup" in r.message for r in caplog.records)
 
 
 def test_setup_nag_silent_when_state_ready(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """_log_setup_nag stays quiet when everything is in order."""
-    monkeypatch.setattr(
-        channel, "_check_setup", lambda: {"all_ready": True}
-    )
+    monkeypatch.setattr(channel, "_check_setup", lambda: {"all_ready": True})
     with caplog.at_level("WARNING", logger="redis_channel.channel"):
         channel._log_setup_nag()
-    assert not any(
-        "/redis-channel-setup" in r.message for r in caplog.records
-    )
+    assert not any("/redis-channel-setup" in r.message for r in caplog.records)
 
 
 # ─── Phase 6: auto-refresh stale symlink (extends v0.4.14 startup nag) ────
@@ -962,9 +947,7 @@ def test_auto_refresh_skips_when_no_symlink(
     assert result is None
 
 
-def test_auto_refresh_skips_when_symlink_current(
-    fake_plugin_root: Path, fake_home: Path
-) -> None:
+def test_auto_refresh_skips_when_symlink_current(fake_plugin_root: Path, fake_home: Path) -> None:
     """If symlink already points at the running version's wrapper → no-op."""
     channel._do_setup(link_wrapper=True, scaffold_configs=False)
     symlink = fake_home / "bin" / "claude-channel"
@@ -1088,9 +1071,7 @@ def test_log_setup_nag_auto_refreshes_and_logs_info(
     # Auto-refresh fired
     assert any("auto-refreshed" in r.message for r in caplog.records)
     # No "setup is incomplete" warning (state was fixed in-place)
-    assert not any(
-        "setup is incomplete" in r.message for r in caplog.records
-    )
+    assert not any("setup is incomplete" in r.message for r in caplog.records)
 
 
 # ─── Phase 6: /redis-channel-configure ─────────────────────────────────────

--- a/tests/test_redis_channel_registry.py
+++ b/tests/test_redis_channel_registry.py
@@ -218,9 +218,7 @@ def test_resolve_default_endpoint_raises_when_multi_and_unresolvable(
         },
     )
     r = registry.load_registry(cfg)
-    with pytest.raises(
-        registry.EndpointNotFoundError, match="no default endpoint resolvable"
-    ):
+    with pytest.raises(registry.EndpointNotFoundError, match="no default endpoint resolvable"):
         r.resolve_default_endpoint()
 
 


### PR DESCRIPTION
## Summary
- Add infiquetra-deploy for Infiquetra tag-promotion deployment, rollback, hotfix, status, and release-note workflows.
- Add infiquetra-loop for lifecycle routing, office-hours, strategy, ideation, planning, work, QA, review, optimization, retro, and resume workflows.
- Register both plugins in the marketplace and document the lifecycle/deploy boundary in the engineering journal.

## Validation
- uv run ruff check .
- uv run mypy plugins/
- uv run bandit -r plugins/infiquetra-deploy plugins/infiquetra-loop
- git diff --check
- uv run pytest -q