### PR TITLE
feat(sdlc-manager): consume SDLC board schema

### DIFF
--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Changed
+- Added vendored `config/sdlc-schema.json` and taught board/metric helpers to consume schema-backed boards, workflows, WIP limits, and terminal statuses.
+- Added live Jeff Intent (#3) and Asgard (#2) project mappings plus explicit `--project` targeting for board add/move.
+- Refreshed board, metrics, milestones, labels, rollout, and operator guidance around Jeff Intent, Asgard, Olympus, direct project fields, and deployment-state separation.
+- Preserved read compatibility for live/legacy Olympus statuses such as `In Progress`, `In Development`, and `Deployed` while guiding new movement to the current schema.
 - Synced `sdlc-issues` template guidance with canonical issue forms in `infiquetra-sdlc`, including current Hermes actionable labels and required card sections.
 - Added a deterministic template documentation generator plus drift guard tests for `templates-reference.md`.
 

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -1,12 +1,12 @@
 # sdlc-manager
 
-SDLC management for the Infiquetra Mount Olympus agent team. This plugin provides a complete interface for managing the development lifecycle — from issue creation to flow metrics — reading all configuration dynamically from the local `infiquetra-sdlc` repository.
+SDLC management for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. This plugin provides a complete interface for managing the development lifecycle — from issue creation to flow metrics — reading board and workflow configuration from `infiquetra-sdlc` and vendored fallbacks.
 
 ## Overview
 
 All operations run locally via the `gh` CLI, providing:
 
-- **Project board operations** — view, move, add, archive, WIP analysis, standup prep
+- **Project board operations** — view, move, add, archive, WIP analysis, standup prep across Jeff Intent, Asgard, and Olympus
 - **Issue creation** — guided workflow with templates, auto-labeling, and project board integration
 - **Label management** — deploy, audit, sync initiative/objective fields, auto-label rules
 - **Flow metrics** — cycle time, throughput, WIP age using GitHub timeline events
@@ -67,7 +67,7 @@ The `sdlc-operator` agent orchestrates complex multi-step operations:
 - New initiative/objective setup (labels + field options + milestone)
 - Objective progress tracking across repos
 - Batch triage of untriaged issues
-- Project field assignment via `flow set-field` (Initiative, Objective, Status — single-select fields on the Olympus board per the 2026-05-03 DECISION)
+- Project field assignment via `flow set-field` (Initiative, Objective, Status, Target Team, Mode, and other live single-select fields)
 - Native sub-issue linking via `flow link-sub-issue` (cross-repo, idempotent)
 - Card body pre-flight validation via `flow validate-card`
 
@@ -83,21 +83,24 @@ sdlc-manager uses a single shared CLI (`scripts/sdlc_manager.py`) at the plugin 
 # View board by column
 python3 $SCRIPT board view --project mount-olympus
 
-# Add issue to project board
+# Add issue to its default repo-mapped board
 python3 $SCRIPT board add --repo athena-service --number 42
 
-# Move item to different column
-python3 $SCRIPT board move --repo athena-service --number 42 --status "E2E Testing"
+# Add or move issue on a specific board
+python3 $SCRIPT board add --project asgard --repo infiquetra-sdlc --number 42
+python3 $SCRIPT board move --project asgard --repo infiquetra-sdlc --number 42 --status "Active"
+python3 $SCRIPT board move --repo athena-service --number 42 --status "Assigned"
 
-# Archive deployed items (use --dry-run first)
+# Archive terminal workflow items (use --dry-run first)
 python3 $SCRIPT board archive --project mount-olympus --dry-run
-python3 $SCRIPT board archive --project mount-olympus
+python3 $SCRIPT board archive --project asgard --dry-run
 
 # Check WIP counts vs limits
 python3 $SCRIPT board wip --project mount-olympus
 
 # Standup prep (right-to-left board review)
 python3 $SCRIPT board standup --project mount-olympus
+python3 $SCRIPT board standup --project jeff-intent
 
 # Discover all project fields and options
 python3 $SCRIPT board discover-fields --project mount-olympus
@@ -106,8 +109,10 @@ python3 $SCRIPT board discover-fields --project mount-olympus
 ### Label Operations
 
 ```bash
-# Sync initiative/objective labels to project fields
-python3 $SCRIPT labels sync-fields --repo athena-service --number 42
+# Set initiative/objective project fields directly
+python3 $SCRIPT flow set-field --project mount-olympus \
+  --repo athena-service --number 42 \
+  --field Objective --option "platform-launch"
 
 # Audit repo labels
 python3 $SCRIPT labels audit --repo athena-service
@@ -226,6 +231,7 @@ python3 $SCRIPT flow validate-card --repo campps-mvp --number 42
 | File | Purpose |
 |------|---------|
 | `config/project-mappings.json` | Project IDs, field IDs, repo-to-project mapping |
+| `config/sdlc-schema.json` | Canonical board/team/workflow/WIP/deployment-state schema |
 | `config/labels.json` | Label definitions and auto-label rules |
 | `config/beads-config.json` | (legacy — file removed from infiquetra-sdlc on 2026-04-26; reads degrade gracefully to `{}`. The `legacy_rollout_config` key in `load_config` documents the migration.) |
 
@@ -233,17 +239,21 @@ python3 $SCRIPT flow validate-card --repo campps-mvp --number 42
 
 | Project | Team | Purpose |
 |---------|------|---------|
-| Strategic Direction | Mount Olympus | High-level objectives and roadmap |
-| Mount Olympus Operations | Mount Olympus | Day-to-day kanban board |
+| Jeff Intent | Jeff | Raw intent, approvals, personal/operator work, and shaping before team execution |
+| Asgard | Asgard | Rapid action, incubation, and mission-mode work close to Jeff |
+| Olympus | Mount Olympus | Primary engineering execution pipeline |
 
 ## WIP Limits
 
-| Column | Limit |
+| Board / Column | Limit |
 |--------|-------|
-| Ready | 10 |
-| In Development | 3 per agent |
-| E2E Testing | 3 |
-| Deployment Ready | 5 |
+| Jeff Intent / Shaping | 10 |
+| Jeff Intent / Active | 5 |
+| Asgard / Active | 5 |
+| Olympus / Ready | 10 |
+| Olympus / Planning | 3 |
+| Olympus / Assigned | 3 per assigned agent |
+| Olympus / In Review | 5 |
 
 ## Metric Targets
 

--- a/plugins/sdlc-manager/agents/sdlc-operator.md
+++ b/plugins/sdlc-manager/agents/sdlc-operator.md
@@ -3,7 +3,7 @@ name: sdlc-operator
 description: |
   Orchestrator for complex multi-step SDLC operations spanning multiple skills.
   Use this agent for operations that require judgment, multiple sequential steps, or
-  interpreting results in context — like full issue lifecycle management, board grooming,
+  interpreting results in context - like full issue lifecycle management, board grooming,
   objective tracking, blueprint-driven issue creation, or setting up a new initiative end-to-end.
 
   <example>
@@ -17,10 +17,10 @@ description: |
 
   <example>
   Context: User wants board grooming and weekly prep.
-  user: "Let's groom the board and get ready for the week. Archive deployed items and check WIP."
+  user: "Let's groom the board and get ready for the week. Archive terminal items and check WIP."
   assistant: "I'll use the sdlc-operator agent to do a comprehensive board review and cleanup."
   <commentary>
-  Multi-step: archive deployed -> check WIP -> review aging -> standup prep requires coordination.
+  Multi-step: archive terminal items -> check WIP -> review aging -> standup prep requires coordination.
   </commentary>
   </example>
 
@@ -54,8 +54,8 @@ color: orange
 
 # SDLC Operator
 
-You are the SDLC Operator for the Mount Olympus team — an expert orchestrator of the
-Infiquetra SDLC. You coordinate complex multi-step SDLC operations using the shared
+You are the SDLC Operator for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards.
+You coordinate complex multi-step SDLC operations using the shared
 `sdlc_manager.py` script and `gh` CLI tools.
 
 ## Identity
@@ -63,9 +63,10 @@ Infiquetra SDLC. You coordinate complex multi-step SDLC operations using the sha
 You are deeply familiar with the Infiquetra SDLC process as documented in the
 `infiquetra-sdlc` repo:
 
-- **Team shape**: 1 human (Jeff, operator) + 8 Mount Olympus dev agents + Hermes (orchestrator)
-  + Themis (PR reviewer). NOT all-agent, NOT AI-augmented-human. See
-  `infiquetra-sdlc/docs/philosophy/team-shape.md`.
+- **Team shape**: 1 human (Jeff, operator) + agent teams + Hermes (orchestrator).
+  Mount Olympus is the primary engineering pipeline; Asgard is the Jeff-proximal rapid-action
+  and incubation team. Themis is retired historical context, not an active PR-review path.
+  See `infiquetra-sdlc/docs/philosophy/team-shape.md` and `config/sdlc-schema.json`.
 - **Work hierarchy**: Initiative → Objective → Capability (3 tiers). Initiative + Objective
   are **single-select project FIELDS on the Olympus board** (decided 2026-05-03 — see
   `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md`), NOT labels.
@@ -74,18 +75,17 @@ You are deeply familiar with the Infiquetra SDLC process as documented in the
   non-actionable** (`hermes-not-actionable`: objective, exploration, context-update). Verified
   2026-05-04 against `infiquetra-sdlc/.github/ISSUE_TEMPLATE/*.yml`.
 
-  **Today's reality (2026-05-04)**: only `Status` is a single-select field on the Olympus
-  board. Initiative, Objective, Capability Size, Business Value, Technical Risk, Target Quarter
-  are all "decided, not yet created" per Phase A carry-over #2. The `flow` helpers correctly
-  silently skip prompts for missing fields.
-- **1 project board**: Mount Olympus (project #1; only board). Strategic Direction was
-  proposed but never created; the concept was dropped in PR #16.
+  Field availability is live-discovered; prompts skip fields that do not exist on the target
+  board yet.
+- **3 project boards**: Mount Olympus (project #1), Asgard (project #2), and Jeff Intent
+  (project #3). Strategic Direction was dropped; it is not a current project.
 - **Sub-issues are the default grouping mechanism**: every new card has a parent by
   default (native GitHub sub-issue API; cross-repo supported).
 - **Coordination layer**: Redis pub/sub (`olympus:*` channels) + GitHub Projects v2 +
   per-card Discord threads. Beads/Dolt was removed 2026-04-26.
 - **Organization**: `infiquetra` on github.com (NOT GitHub Enterprise).
-- **Config source**: `~/workspace/infiquetra/infiquetra-sdlc/`
+- **Config source**: `~/workspace/infiquetra/infiquetra-sdlc/`; vendored fallbacks live in
+  `plugins/sdlc-manager/config/`.
 
 ## Tools Available
 
@@ -128,10 +128,10 @@ The plugin's `issue create` subcommand encodes the interactive version:
 
 ```bash
 # Sub-issue-first interactive flow (Phase C)
-python "$SCRIPT" issue create --repo <repo> --type <capability|enhancement|defect|exploration|context-update|objective>
+python3 "$SCRIPT" issue create --repo <repo> --type <capability|enhancement|defect|exploration|context-update|objective>
 
 # With pre-supplied parent (skips the sub-issue prompt):
-python "$SCRIPT" issue create --repo <repo> --type capability \
+python3 "$SCRIPT" issue create --repo <repo> --type capability \
     --parent-ref campps-context-library#1
 ```
 
@@ -148,12 +148,10 @@ This is a 10-step flow (full details in `issue_create` docstring):
 9. Apply post-create metadata (labels, board add, fields, sub-issue link)
 10. Paired-card prompt (opt-in)
 
-**Today's reality (2026-05-04)**: only `Status` is a single-select field on the Olympus board.
-Initiative, Objective, Capability Size, etc. are "decided, not yet created" per Phase A
-carry-over #2. The flow's per-project schema discovery silently skips prompts for missing
-fields — operators see only the prompts the project actually exposes. When fields get created
-via the runbook in `infiquetra-sdlc/docs/operations/operational-reference.md`, the additional
-prompts light up automatically.
+The flow's per-project schema discovery silently skips prompts for missing fields - operators
+see only the prompts the selected board actually exposes. When fields get created via the
+runbook in `infiquetra-sdlc/docs/operations/operational-reference.md`, the additional prompts
+light up automatically.
 
 For batch issue creation from a blueprint, prefer the manual lifecycle below over the
 interactive flow:
@@ -165,53 +163,53 @@ gh issue create --repo infiquetra/<repo> --template <type>.yml --title "..." --b
 # 2. Apply hermes-task / hermes-not-actionable label
 gh issue edit <N> --repo infiquetra/<repo> --add-label hermes-task
 
-# 3. Add to Mount Olympus board
-python "$SCRIPT" board add --repo <repo> --number <N>
+# 3. Add to the default repo-mapped board, or pass --project for Jeff Intent / Asgard
+python3 "$SCRIPT" board add --repo <repo> --number <N>
+python3 "$SCRIPT" board add --project asgard --repo <repo> --number <N>
 
 # 4. Set Initiative + Objective + Status project fields (Phase C foundation):
-python "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
+python3 "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
     --field Initiative --option <name>
-python "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
+python3 "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
     --field Objective --option <name>
-python "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
+python3 "$SCRIPT" flow set-field --project mount-olympus --repo <repo> --number <N> \
     --field Status --option Backlog
 
 # 5. Link as native sub-issue (cross-repo, idempotent)
-python "$SCRIPT" flow link-sub-issue \
+python3 "$SCRIPT" flow link-sub-issue \
     --parent-repo campps-context-library --parent-number <P> \
     --child-repo <repo> --child-number <N>
 
 # 6. (Optional) Link to milestone if the parent Objective has one
-python "$SCRIPT" milestones link --repo <repo> --issue <N> --milestone <M>
+python3 "$SCRIPT" milestones link --repo <repo> --issue <N> --milestone <M>
 
 # 7. Pre-flight validate the card body
-python "$SCRIPT" flow validate-card --repo <repo> --number <N>
+python3 "$SCRIPT" flow validate-card --repo <repo> --number <N>
 ```
 
 ### Board Grooming
 
 ```bash
-# 1. Archive deployed items (always dry-run first)
-python "$SCRIPT" board archive --project mount-olympus --dry-run
-python "$SCRIPT" board archive --project mount-olympus  # after operator confirms
+# 1. Archive terminal items (always dry-run first)
+python3 "$SCRIPT" board archive --project mount-olympus --dry-run
+python3 "$SCRIPT" board archive --project mount-olympus  # after operator confirms
 
 # 2. Check WIP per agent
-python "$SCRIPT" board wip --project mount-olympus
+python3 "$SCRIPT" board wip --project mount-olympus
 
 # 3. Review aging cards
-python "$SCRIPT" metrics wip-age --project mount-olympus
+python3 "$SCRIPT" metrics wip-age --project mount-olympus
 
 # 4. Standup prep (right-to-left review)
-python "$SCRIPT" board standup --project mount-olympus
+python3 "$SCRIPT" board standup --project mount-olympus
 
 # 5. Summarize findings + recommend actions
 ```
 
 ### New Initiative + Objective Setup (end-to-end)
 
-Sets up the project-field options for an Initiative + creates the Objective issue + links
-its milestone. Note: as of 2026-05-04, the Initiative + Objective fields don't yet exist on
-the Olympus board; create them first per
+Sets up the project-field options for an Initiative, creates the Objective issue, and links
+its milestone when useful. Live-discover fields first; create missing fields per
 `infiquetra-sdlc/docs/operations/operational-reference.md`.
 
 ```bash
@@ -225,11 +223,11 @@ gh project field-create 1 --owner infiquetra \
     --name "Objective" --data-type SINGLE_SELECT
 
 # 3. List current options (live discovery)
-python "$SCRIPT" flow field-options --project mount-olympus --field Initiative
-python "$SCRIPT" flow field-options --project mount-olympus --field Objective
+python3 "$SCRIPT" flow field-options --project mount-olympus --field Initiative
+python3 "$SCRIPT" flow field-options --project mount-olympus --field Objective
 
 # 4. Add a new option to the Initiative field if needed
-python "$SCRIPT" fields create-option --project mount-olympus \
+python3 "$SCRIPT" fields create-option --project mount-olympus \
     --field Initiative --option <new-name>
 
 # 5. Create the Objective issue in the appropriate blueprint repo
@@ -237,15 +235,15 @@ gh issue create --repo infiquetra/<blueprint-repo> --template objective.yml \
     --title "<Objective name>" --body "..."
 
 # 6. (Optional) Create a per-repo Milestone for PR-rollup view
-python "$SCRIPT" milestones create --repo <consumer-repo> \
+python3 "$SCRIPT" milestones create --repo <consumer-repo> \
     --title "<Objective>" --due-date <YYYY-MM-DD>
 
 # 7. Add the Objective issue as a new option on the Objective project field
-python "$SCRIPT" fields create-option --project mount-olympus \
+python3 "$SCRIPT" fields create-option --project mount-olympus \
     --field Objective --option "<Objective name>"
 
 # 8. Set the Objective field on the Objective issue itself (self-referential)
-python "$SCRIPT" flow set-field --project mount-olympus \
+python3 "$SCRIPT" flow set-field --project mount-olympus \
     --repo <blueprint-repo> --number <N> \
     --field Objective --option "<Objective name>"
 ```
@@ -255,10 +253,8 @@ python "$SCRIPT" flow set-field --project mount-olympus \
 Per the 2026-05-03 DECISION, Objectives are tracked via the project's Objective field, not
 labels or milestones-only.
 
-**Today (2026-05-04) the Objective project field doesn't exist yet** — this section's
-filter approach starts working once the operator runs the field-creation runbook in
-`infiquetra-sdlc/docs/operations/operational-reference.md`. For now, fall back to the
-parent-Objective-issue's sub-issue tree (`gh sub-issue list <parent>`).
+If the Objective project field is absent, fall back to the parent Objective issue's
+sub-issue tree (`gh sub-issue list <parent>`).
 
 ```bash
 # 0. Discovery first — `gh project item-list` flattens project-field values into top-level
@@ -288,7 +284,7 @@ python "$SCRIPT" milestones progress --repo <repo> --milestone <N>
 4. For each item:
    a. Create the issue with the right template + sub-issue parent
    b. Apply hermes-task label
-   c. Add to Mount Olympus board
+   c. Add to the target board
    d. Set Initiative + Objective + Status fields
    e. Link as sub-issue of the Objective
 5. Report the batch with issue URLs + parent linkages
@@ -320,10 +316,10 @@ gh issue edit <N> --repo infiquetra/<repo> \
     --add-label "high-priority" --remove-label "needs-triage"
 
 # 3. Add to project board if not already
-python "$SCRIPT" board add --repo <repo> --number <N>
+python3 "$SCRIPT" board add --repo <repo> --number <N>
 
-# 4. Move to Ready if context complete; else keep in Backlog
-python "$SCRIPT" board move --repo <repo> --number <N> --status Ready
+# 4. Move to Ready if context complete; else keep in Backlog or Shaping
+python3 "$SCRIPT" board move --repo <repo> --number <N> --status Ready
 ```
 
 ## Key Configuration
@@ -336,7 +332,7 @@ SCRIPT_INSTALLED="$HOME/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/<v
 SCRIPT_DEV="$HOME/workspace/infiquetra/infiquetra-claude-plugins/plugins/sdlc-manager/scripts/sdlc_manager.py"
 
 # Per-user defaults (Phase C foundation)
-# First-run setup: python "$SCRIPT" config init-defaults
+# First-run setup: python3 "$SCRIPT" config init-defaults
 # Persists at ~/.claude/sdlc-defaults.json:
 #   - assignee (gh login from `gh api user --jq .login`)
 #   - default_project, default_status, default_priority
@@ -347,8 +343,10 @@ SCRIPT_DEV="$HOME/workspace/infiquetra/infiquetra-claude-plugins/plugins/sdlc-ma
 ## Decision Rules
 
 ### Which project to use?
-There's only one (Mount Olympus, project #1). The vendored project-mappings.json
-(`plugins/sdlc-manager/config/project-mappings.json`) lists the canonical repos.
+Use Jeff Intent for raw operator intent and shaping, Asgard for Jeff-proximal rapid action
+or incubation, and Mount Olympus for the primary engineering pipeline. The vendored
+`project-mappings.json` lists default repo routing; pass `--project` when deliberately
+targeting Jeff Intent or Asgard.
 - `python "$SCRIPT" flow discover-project --repo <repo>` resolves the mapping for a repo
 - Unmapped repo: warn the operator; don't auto-add
 

--- a/plugins/sdlc-manager/commands/sdlc-board.md
+++ b/plugins/sdlc-manager/commands/sdlc-board.md
@@ -3,60 +3,58 @@ name: sdlc-board
 description: Quick board status view with WIP check for Infiquetra project boards
 ---
 
-Show the current status of an Infiquetra project board (mount-olympus or strategic) including WIP counts, aging items, and blockers.
+Show current status for an Infiquetra project board, including WIP counts, aging items,
+and blockers.
 
 ## Usage
 
 ```
-/sdlc-board [mount-olympus|strategic]
+/sdlc-board [jeff-intent|asgard|mount-olympus]
 ```
 
 ## Arguments
 
-- `mount-olympus` — Show Mount Olympus Operations board (default)
-- `strategic` — Show Strategic Direction board
+- `mount-olympus` - Show Olympus engineering execution board (default)
+- `asgard` - Show Asgard rapid-action/incubation board
+- `jeff-intent` - Show Jeff's intent and shaping board
 
 ## What This Does
 
-1. Fetches all items from the specified project board
-2. Groups items by status column (Ready, In Development, E2E Testing, Deployment Ready, Deployed)
-3. Shows WIP counts vs. limits with violation warnings
-4. Flags aging items (>3 days in development, >1 day in E2E)
-5. Highlights blocked items
+1. Fetches items from the selected GitHub Project.
+2. Groups items by schema-backed Status.
+3. Shows WIP counts and violations where configured.
+4. Flags aging and blocked items.
+5. Keeps deployment state separate from workflow Status.
 
 ## Examples
 
 ```
 /sdlc-board
 /sdlc-board mount-olympus
-/sdlc-board strategic
+/sdlc-board asgard
+/sdlc-board jeff-intent
 ```
 
-## Script Command
+## Script Commands
 
 ```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py \
-  board view --project mount-olympus
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py
+
+python3 $SCRIPT board view --project mount-olympus
+python3 $SCRIPT board wip --project mount-olympus
 ```
 
-For WIP check only:
-```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py \
-  board wip --project mount-olympus
-```
+Replace `mount-olympus` with `asgard` or `jeff-intent` for those boards.
 
 ## Instructions
 
 When the user invokes `/sdlc-board [project]`:
 
-1. Determine target project (default: mount-olympus)
-2. Run the board view command
-3. Run the WIP check command
-4. Present a clean summary with:
-   - Items by column with age
-   - WIP violations (if any)
-   - Blocked items highlighted
-   - Aging items flagged
-5. Offer follow-up actions: standup prep, move items, archive deployed
+1. Determine target project, defaulting to `mount-olympus`.
+2. Run `board view --project <project>`.
+3. Run `board wip --project <project>`.
+4. Summarize items by status, WIP violations, blockers, and aging work.
+5. Suggest concrete follow-up actions when useful: standup prep, move cards, or dry-run archive.
 
-Use the `sdlc-board` skill for detailed board operations or the `sdlc-operator` agent for multi-step workflows.
+Use the `sdlc-board` skill for detailed board operations or the `sdlc-operator` agent for
+multi-step workflows.

--- a/plugins/sdlc-manager/commands/sdlc-metrics.md
+++ b/plugins/sdlc-manager/commands/sdlc-metrics.md
@@ -1,37 +1,37 @@
 ---
 name: sdlc-metrics
-description: Show flow metrics dashboard for Infiquetra project boards — cycle time, throughput, WIP age, and flow health
+description: Show flow metrics for Infiquetra project boards
 ---
 
-Display a comprehensive flow metrics dashboard for an Infiquetra project board, showing cycle times, throughput, WIP age, and comparisons against targets.
+Display a flow metrics dashboard for an Infiquetra project board: cycle time,
+throughput, WIP age, and bottleneck hints.
 
 ## Usage
 
 ```
-/sdlc-metrics [project] [--type metric-type]
+/sdlc-metrics [jeff-intent|asgard|mount-olympus] [--type metric-type]
 ```
 
 ## Arguments
 
-- `project` — Project name: `mount-olympus` (default) or `strategic`
-- `--type` — Optional metric type: `cycle-time`, `throughput`, `wip-age`, or `all` (default)
+- `project` - Project name: `mount-olympus` (default), `asgard`, or `jeff-intent`
+- `--type` - Optional metric type: `cycle-time`, `throughput`, `wip-age`, or `all` (default)
 
 ## What This Does
 
-1. Shows cycle time percentiles (P50/P85/P95) vs. targets
-2. Shows throughput by issue type for last 4 weeks
-3. Shows WIP age for all in-progress items
-4. Flags metrics that are over target
-5. Provides interpretation and recommendations
+1. Shows cycle time percentiles against targets.
+2. Shows terminal-status throughput.
+3. Shows WIP age for current active items.
+4. Flags metrics that are over target.
+5. Separates workflow Status from deployment environment state.
 
 ## Examples
 
 ```
 /sdlc-metrics
 /sdlc-metrics mount-olympus
-/sdlc-metrics strategic --type cycle-time
-/sdlc-metrics mount-olympus --type throughput
-/sdlc-metrics mount-olympus --type wip-age
+/sdlc-metrics asgard --type throughput
+/sdlc-metrics jeff-intent --type wip-age
 ```
 
 ## Script Commands
@@ -39,58 +39,19 @@ Display a comprehensive flow metrics dashboard for an Infiquetra project board, 
 ```bash
 SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py
 
-# Cycle time (uses timeline events — may take a moment)
 python3 $SCRIPT metrics cycle-time --project mount-olympus --days 30
-
-# Throughput by week
-python3 $SCRIPT metrics throughput --project mount-olympus --weeks 4
-
-# WIP age (fast — no timeline events needed)
-python3 $SCRIPT metrics wip-age --project mount-olympus
+python3 $SCRIPT metrics throughput --project asgard --weeks 4
+python3 $SCRIPT metrics wip-age --project jeff-intent
 ```
-
-## Metric Targets
-
-| Issue Type | Cycle Time P85 | SLA |
-|------------|---------------|-----|
-| Capability | < 5 days | -- |
-| Enhancement | < 2 days | -- |
-| Defect (Critical) | -- | 4 hours |
-| Defect (High) | -- | 1 day |
-| Defect (Medium) | -- | 3 days |
-
-Throughput targets: 2-4 capabilities/week, 5-10 enhancements/week
 
 ## Instructions
 
 When the user invokes `/sdlc-metrics [project] [--type metric-type]`:
 
-1. Determine project (default: mount-olympus)
-2. Determine which metrics to show (default: all)
-3. Run appropriate commands:
-   - Cycle time: Note this requires fetching timeline events and may take 30-60s
-   - Throughput: Fast, just looks at deployed items
-   - WIP age: Fast, just looks at current board state
-4. Present results with:
-   - Clear comparison vs. targets (pass/fail markers)
-   - Interpretation of what's over/under target
-   - Specific recommendations when metrics are over target
-5. Offer follow-up: "Want me to investigate the aging items in E2E Testing?"
+1. Determine project, defaulting to `mount-olympus`.
+2. Determine which metrics to show, defaulting to all.
+3. Run the matching metric commands.
+4. Summarize pass/fail signals, bottlenecks, and concrete next actions.
 
-### Interpreting Metrics
-
-**Cycle time over target**:
-- Check WIP age for bottlenecks
-- Look for items stuck in E2E Testing or Deployment Ready
-- Consider if WIP limits are being respected
-
-**Throughput too low**:
-- Check if too many items are in In Development simultaneously
-- Look for blocked items
-- Check if WIP limits are being exceeded
-
-**WIP age high**:
-- Items stuck >3 days: blockers or WIP violations
-- Recommend flagging in standup and considering swarming
-
-Use the `sdlc-metrics` skill for detailed metric analysis or the `sdlc-operator` agent for comprehensive SDLC health reports.
+Use the `sdlc-metrics` skill for detailed interpretation or the `sdlc-operator` agent for
+multi-step SDLC health reports.

--- a/plugins/sdlc-manager/commands/sdlc-triage.md
+++ b/plugins/sdlc-manager/commands/sdlc-triage.md
@@ -23,8 +23,8 @@ Triage an existing issue by analyzing its content, recommending appropriate labe
 4. Recommends initiative/objective labels based on context
 5. Applies auto-label rules
 6. Adds to project board if not already there
-7. Syncs project field values from labels
-8. Recommends initial board status (Ready if context complete, stays in analysis if missing context)
+7. Sets project fields when the target board exposes them
+8. Recommends initial board status (Ready if context complete, Backlog or Shaping if missing context)
 
 ## Examples
 
@@ -45,8 +45,10 @@ python3 $SCRIPT labels auto-label --repo athena-service --number 42
 # Add to project
 python3 $SCRIPT board add --repo athena-service --number 42
 
-# Sync fields after labeling
-python3 $SCRIPT labels sync-fields --repo athena-service --number 42
+# Set project fields directly when needed
+python3 $SCRIPT flow set-field --project mount-olympus \
+  --repo athena-service --number 42 \
+  --field Status --option Ready
 ```
 
 ## Instructions
@@ -58,21 +60,22 @@ When the user invokes `/sdlc-triage repo#number`:
 3. Analyze content:
    - Is there already a type label? If not, recommend one using the decision tree
    - Is it a defect without a priority? Ask user for priority (critical/high/medium/low)
-   - Does title/body mention an initiative or objective? Suggest those labels
+   - Does title/body mention an initiative or objective? Suggest project field values
 4. Apply auto-label rules:
    - `python3 $SCRIPT labels auto-label --repo <repo> --number <N>`
 5. Manually apply recommended labels:
    - `gh issue edit <N> --repo infiquetra/<repo> --add-label "capability,needs-analysis"`
 6. Add to project board:
    - `python3 $SCRIPT board add --repo <repo> --number <N>`
-7. Sync initiative/objective fields:
-   - `python3 $SCRIPT labels sync-fields --repo <repo> --number <N>`
+7. Set initiative/objective fields when applicable:
+   - `python3 $SCRIPT flow set-field --project mount-olympus --repo <repo> --number <N> --field Initiative --option <name>`
+   - `python3 $SCRIPT flow set-field --project mount-olympus --repo <repo> --number <N> --field Objective --option <name>`
 8. Recommend status:
-   - Defect (critical/high): Move directly to In Development
+   - Defect (critical/high): Move directly to Assigned on Olympus, or Active on Asgard
    - Has complete context: Ready
-   - Needs more context: Add `needs-analysis` label, leave in backlog
+   - Needs more context: Add `needs-analysis` label, leave in Backlog or Shaping
 9. Show summary of all actions taken
 
-If the issue is a defect with `critical` label, flag urgency: "This is a critical defect with a 4-hour SLA. Moving to In Development now."
+If the issue is a defect with `critical` label, flag urgency: "This is a critical defect with a 4-hour SLA. Moving to active ownership now."
 
 Use the `sdlc-operator` agent for batch triage of multiple issues.

--- a/plugins/sdlc-manager/config/project-mappings.json
+++ b/plugins/sdlc-manager/config/project-mappings.json
@@ -1,12 +1,14 @@
 {
   "_comment": "Vendored canonical project mapping for the Infiquetra org. Plugin reads this by default. Override at $INFIQUETRA_SDLC_PATH/config/project-mappings.json (per the resolution order in load_config). Project node IDs and field/option IDs are NOT cached here — they rotate on rename/recreate; fetched live via _resolve_project_field and discover_project_field_options.",
-  "_provenance": "Verified 2026-05-04: `gh project list --owner infiquetra` (Olympus is the only project, #1); `gh repo list infiquetra --json name --jq '.[].name'` (the 9 repos listed below are the canonical org-wide set as of this date). The id field is captured for board_add convenience; if it rotates, re-run `gh project view 1 --owner infiquetra --format json -q .id` and update.",
+  "_provenance": "Verified 2026-05-29: `gh project list --owner infiquetra` shows Olympus #1, Asgard #2, and Jeff Intent #3. `gh repo list infiquetra --json name --jq '.[].name'` repo list below remains the canonical Olympus repo set for default board_add routing. The id field is captured for board_add convenience; if it rotates, re-run `gh project view N --owner infiquetra --format json -q .id` and update.",
   "organization": "infiquetra",
   "projects": {
     "mount-olympus": {
       "number": 1,
       "id": "PVT_kwDODdfJoc4BVHOl",
       "name": "Olympus",
+      "board_key": "olympus",
+      "workflow": "olympus_execution",
       "_id_note": "Project node id captured 2026-05-04. If it rotates (project rename/recreate), re-fetch via: gh project view 1 --owner infiquetra --format json -q .id",
       "repositories": [
         "campps-context-library",
@@ -19,6 +21,24 @@
         "mimir",
         "mimir-context-library"
       ]
+    },
+    "asgard": {
+      "number": 2,
+      "id": "PVT_kwDODdfJoc4BZLMH",
+      "name": "Asgard",
+      "board_key": "asgard",
+      "workflow": "intent_flow",
+      "_id_note": "Project node id captured 2026-05-29. If it rotates, re-fetch via: gh project view 2 --owner infiquetra --format json -q .id",
+      "repositories": []
+    },
+    "jeff-intent": {
+      "number": 3,
+      "id": "PVT_kwDODdfJoc4BZLMK",
+      "name": "Jeff Intent",
+      "board_key": "jeff_intent",
+      "workflow": "intent_flow",
+      "_id_note": "Project node id captured 2026-05-29. If it rotates, re-fetch via: gh project view 3 --owner infiquetra --format json -q .id",
+      "repositories": []
     }
   },
   "excluded_repositories": []

--- a/plugins/sdlc-manager/config/sdlc-schema.json
+++ b/plugins/sdlc-manager/config/sdlc-schema.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": "2026-05-29",
+  "status": "active",
+  "description": "Canonical Infiquetra SDLC board, team, routing, review, approval, and deployment-state schema. This file intentionally contains no live GitHub Projects field option IDs; tooling must resolve those from GitHub at runtime.",
+  "teams": {
+    "jeff": {
+      "kind": "human_operator",
+      "status": "active",
+      "role": "Sole human operator, intent source, approval gate, escalation arbitrator, and occasional direct implementer with local AI tools",
+      "board": "jeff_intent",
+      "review_model": "operator_judgment"
+    },
+    "asgard": {
+      "kind": "agent_team",
+      "status": "active_defining",
+      "role": "Jeff-proximal rapid-action team biased toward reversible work, shaping, incubation, and mission-mode execution",
+      "board": "asgard",
+      "modes": ["Rapid Action", "Incubator", "Mission"],
+      "review_model": "team_owned_review"
+    },
+    "olympus": {
+      "kind": "agent_team",
+      "status": "active",
+      "role": "Primary autonomous engineering execution pipeline",
+      "board": "olympus",
+      "agents": ["Zeus", "Athena", "Apollo", "Artemis", "Hephaestus", "Perseus", "Prometheus", "Ares"],
+      "review_model": "team_owned_review"
+    },
+    "hermes": {
+      "kind": "system_role",
+      "status": "active",
+      "role": "Single Python orchestrator process that ingests GitHub webhooks, dispatches work, coordinates plan review, and manages Discord threads",
+      "board": null,
+      "review_model": "not_a_reviewer"
+    },
+    "themis": {
+      "kind": "system_role",
+      "status": "retired_historical",
+      "role": "Former PR-review state machine. Preserved for migration history only; not an active routing path.",
+      "board": null,
+      "review_model": "retired"
+    }
+  },
+  "boards": {
+    "jeff_intent": {
+      "name": "Jeff Intent",
+      "status": "active",
+      "purpose": "Raw operator intent, approvals, questions, personal/operator work, and shaping before team execution",
+      "owner": "jeff",
+      "workflow": "intent_flow",
+      "routing_required_at": "Ready",
+      "live_creation": "created_2026-05-29_project_3"
+    },
+    "asgard": {
+      "name": "Asgard",
+      "status": "active",
+      "purpose": "Rapid action, incubation, and mission-mode work close to Jeff",
+      "owner": "asgard",
+      "workflow": "intent_flow",
+      "live_creation": "created_2026-05-29_project_2"
+    },
+    "olympus": {
+      "name": "Mount Olympus Operations",
+      "status": "active",
+      "purpose": "Primary engineering execution pipeline",
+      "owner": "olympus",
+      "workflow": "olympus_execution",
+      "live_creation": "already_exists"
+    }
+  },
+  "workflows": {
+    "intent_flow": {
+      "statuses": ["Idea", "Shaping", "Ready", "Active", "Verify", "Done"],
+      "terminal_statuses": ["Done"],
+      "canonical_for": ["jeff_intent", "asgard"]
+    },
+    "olympus_execution": {
+      "statuses": ["Backlog", "Ready", "Planning", "Assigned", "In Review", "Done", "Closed"],
+      "pause_states": ["Plan-Approved", "Needs Review", "Needs Question", "Blocked", "Cancelled"],
+      "terminal_statuses": ["Done", "Closed", "Cancelled"],
+      "noncanonical_statuses": {
+        "In Progress": "Treat as historical, legacy, migration, or live-evidence exception text only. Do not include in the canonical Olympus workflow unless later authoritative runtime evidence forces a schema revision.",
+        "In Development": "Legacy pre-modernization status; map to Assigned when interpreting old references.",
+        "E2E Testing": "Legacy pre-modernization status; map to In Review or Verify depending on board context.",
+        "Deployment Ready": "Legacy pre-modernization status; represent with deployment_state fields.",
+        "Deployed": "Legacy pre-modernization status; represent with GitHub Deployments/Environments plus Done or Closed work status."
+      },
+      "canonical_for": ["olympus"]
+    }
+  },
+  "fields": {
+    "common": ["Status", "Owner", "Priority", "Risk", "Initiative", "Objective"],
+    "jeff_intent": ["Status", "Target Team", "Jeff Needed", "Context Pack", "Decision Needed"],
+    "asgard": ["Status", "Mode", "Jeff Needed", "Target Repository", "Risk", "Promotion Target"],
+    "olympus": ["Status", "Assigned Agent", "Initiative", "Objective", "Capability Size", "Risk", "Deploy Target", "Deploy State", "Snapshot Version", "Promotion Pending", "Release Risk", "Last Deployment"]
+  },
+  "pause_states": {
+    "Plan-Approved": "Plan accepted but operator intentionally paused dispatch.",
+    "Needs Review": "Operator or team review needed before work can continue.",
+    "Needs Question": "Author or operator input needed; currently treated as a human-input state.",
+    "Blocked": "Known external blocker prevents progress.",
+    "Cancelled": "Work intentionally stopped before completion."
+  },
+  "wip_limits": {
+    "jeff_intent": {
+      "Idea": null,
+      "Shaping": 10,
+      "Ready": 10,
+      "Active": 5,
+      "Verify": 5,
+      "Done": null
+    },
+    "asgard": {
+      "Idea": null,
+      "Shaping": 8,
+      "Ready": 8,
+      "Active": 5,
+      "Verify": 5,
+      "Done": null
+    },
+    "olympus": {
+      "Backlog": null,
+      "Ready": 10,
+      "Planning": 3,
+      "Assigned": "3 per assigned agent",
+      "In Review": 5,
+      "Done": null,
+      "Closed": null,
+      "pause_states": null
+    }
+  },
+  "dispatch_gates": {
+    "jeff_intent": {
+      "Ready": ["Target Team must be set before promotion out of Jeff Intent"]
+    },
+    "asgard": {
+      "Active": ["Mode must be set", "Jeff Needed must be set when work crosses an approval boundary"]
+    },
+    "olympus": {
+      "Ready": ["Hermes-actionable issue schema passes", "Work is labeled for Olympus dispatch", "Acceptance criteria and verification are present"],
+      "Assigned": ["Selected agent has available WIP capacity"],
+      "In Review": ["Team-owned review is active for the PR or work artifact"]
+    }
+  },
+  "team_routing": {
+    "target_team_values": ["Asgard", "Olympus", "Jeff", "External/Deferred"],
+    "jeff_intent_ready_rule": "A Ready Jeff Intent card must name one target team before moving to another board or workflow.",
+    "asgard_to_olympus_rule": "Asgard may seed Olympus when work is repeatable, engineering-pipeline-shaped, and has acceptance criteria clear enough for autonomous execution.",
+    "default_pressure_valve": "Prefer project views over new boards unless scale, automation, or reporting needs justify a separate board."
+  },
+  "review_model": {
+    "current": "team_owned_review",
+    "team_owned_review": "The team that owns the work owns PR review, evidence, and merge readiness. Hermes may coordinate events, but does not route active PR review to Themis.",
+    "plan_review": "Hermes can coordinate plan review before dispatch.",
+    "retired": {
+      "Themis": "Historical PR-review state machine. Do not route active PR review to Themis from current SDLC docs."
+    }
+  },
+  "human_approval_state": {
+    "active_pattern": "Per-agent direct message or per-card thread request to Jeff, depending on the work context.",
+    "retired_patterns": ["olympus-input-orchestrator", "olympus:agent:input-request", "#agent-handoffs as canonical HITL channel"],
+    "approval_required_for": [
+      "production changes",
+      "destructive operations",
+      "secrets or credential changes",
+      "IAM or permission changes",
+      "billing or cost-impacting actions",
+      "external commitments",
+      "major team or process authority changes"
+    ]
+  },
+  "deployment_state": {
+    "source_of_truth": "GitHub Deployments/Environments plus tag-promotion records",
+    "not_workflow_statuses": ["nonprod", "staging", "production", "Deployment Ready", "Deployed"],
+    "fields": {
+      "Deploy Target": "Environment or promotion target requested by the work item",
+      "Deploy State": "Current deployment or promotion state derived from deployment records",
+      "Snapshot Version": "Immutable version or tag promoted across environments",
+      "Promotion Pending": "Whether a promotion approval or gate is waiting",
+      "Release Risk": "Operational risk classification for the release or promotion",
+      "Last Deployment": "Most recent deployment evidence link or timestamp"
+    },
+    "mutation_owner": "infiquetra-deploy",
+    "display_owner": "sdlc-manager may display or link deployment state in a later pass"
+  }
+}

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -10,7 +10,7 @@ All GitHub operations use the `gh` CLI for zero-token-management auth.
 Usage:
     sdlc_manager.py board view --project mount-olympus
     sdlc_manager.py board add --repo athena-service --number 42
-    sdlc_manager.py board move --repo athena-service --number 42 --status "E2E Testing"
+    sdlc_manager.py board move --repo athena-service --number 42 --status "Assigned"
     sdlc_manager.py board archive --project mount-olympus [--dry-run]
     sdlc_manager.py board wip --project mount-olympus
     sdlc_manager.py board standup --project mount-olympus
@@ -211,8 +211,9 @@ def load_config() -> dict[str, Any]:
             except Exception:
                 config[key] = {}
 
-    # Project mappings — three-step resolution
+    # Project mappings and SDLC schema — three-step resolution
     config["project_mappings"] = _resolve_project_mappings(sdlc_path)
+    config["sdlc_schema"] = _resolve_sdlc_schema(sdlc_path)
 
     config["sdlc_path"] = str(sdlc_path)
     return config
@@ -226,6 +227,17 @@ def load_config() -> dict[str, Any]:
 _VENDORED_PROJECT_MAPPINGS_PATH = (
     Path(__file__).resolve().parent.parent / "config" / "project-mappings.json"
 )
+_VENDORED_SDLC_SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "sdlc-schema.json"
+)
+PROJECT_CHOICES = ("mount-olympus", "asgard", "jeff-intent")
+LIVE_LEGACY_STATUS_ALIASES = {
+    "In Progress": "Assigned",
+    "In Development": "Assigned",
+    "E2E Testing": "In Review",
+    "Deployment Ready": "Deploy State",
+    "Deployed": "Done",
+}
 
 
 def _resolve_project_mappings(sdlc_path: Path) -> dict[str, Any]:
@@ -263,6 +275,37 @@ def _resolve_project_mappings(sdlc_path: Path) -> dict[str, Any]:
     return {}
 
 
+def _resolve_sdlc_schema(sdlc_path: Path) -> dict[str, Any]:
+    """Resolve sdlc-schema.json via external checkout → vendored → remote fallback."""
+    override = sdlc_path / "config" / "sdlc-schema.json"
+    if override.exists():
+        with open(override) as f:
+            return cast(dict[str, Any], json.load(f))
+
+    if _VENDORED_SDLC_SCHEMA_PATH.exists():
+        with open(_VENDORED_SDLC_SCHEMA_PATH) as f:
+            return cast(dict[str, Any], json.load(f))
+
+    try:
+        result = _gh(
+            [
+                "api",
+                f"repos/{ORG}/infiquetra-sdlc/contents/config/sdlc-schema.json",
+                "--jq",
+                ".content",
+            ]
+        )
+        if result:
+            import base64
+
+            content = base64.b64decode(result.strip()).decode()
+            return cast(dict[str, Any], json.loads(content))
+    except (GhApiError, RuntimeError):
+        pass
+
+    return {}
+
+
 def get_project_config(config: dict, project_name: str) -> dict:
     """Get config for a specific project."""
     projects = config.get("project_mappings", {}).get("projects", {})
@@ -270,6 +313,110 @@ def get_project_config(config: dict, project_name: str) -> dict:
         _error(f"Unknown project: {project_name}. Known projects: {', '.join(projects.keys())}")
         sys.exit(1)
     return cast(dict, projects[project_name])
+
+
+def _project_board_key(project_name: str, proj: dict) -> str:
+    """Return the SDLC schema board key for a project mapping."""
+    if proj.get("board_key"):
+        return cast(str, proj["board_key"])
+    if project_name == "mount-olympus":
+        return "olympus"
+    return project_name.replace("-", "_")
+
+
+def _project_workflow_name(schema: dict, project_name: str, proj: dict) -> str:
+    """Return the workflow name for a project mapping."""
+    if proj.get("workflow"):
+        return cast(str, proj["workflow"])
+    board_key = _project_board_key(project_name, proj)
+    board = schema.get("boards", {}).get(board_key, {})
+    workflow = board.get("workflow")
+    if workflow:
+        return cast(str, workflow)
+    return "olympus_execution" if project_name == "mount-olympus" else "intent_flow"
+
+
+def _project_workflow(config: dict, project_name: str, proj: dict) -> dict:
+    """Return the workflow config for a project, or an empty fallback."""
+    schema = config.get("sdlc_schema", {})
+    workflow_name = _project_workflow_name(schema, project_name, proj)
+    return cast(dict, schema.get("workflows", {}).get(workflow_name, {}))
+
+
+def _status_order(
+    config: dict, project_name: str, proj: dict, columns: dict | None = None
+) -> list[str]:
+    """Return schema-backed display order with live/legacy statuses appended."""
+    workflow = _project_workflow(config, project_name, proj)
+    ordered = list(workflow.get("statuses", []))
+
+    if project_name == "mount-olympus" and "In Progress" not in ordered:
+        # Live Olympus still exposes this option. Keep it visible without
+        # making it canonical in the SDLC schema.
+        insert_at = ordered.index("In Review") if "In Review" in ordered else len(ordered)
+        ordered.insert(insert_at, "In Progress")
+
+    for status in workflow.get("pause_states", []):
+        if status not in ordered:
+            ordered.append(status)
+
+    if columns:
+        for status in columns:
+            if status not in ordered:
+                ordered.append(status)
+
+    if "No Status" not in ordered:
+        ordered.append("No Status")
+    return ordered
+
+
+def _wip_limits(config: dict, project_name: str, proj: dict) -> dict[str, Any]:
+    """Return schema-backed WIP limits for the project."""
+    schema = config.get("sdlc_schema", {})
+    board_key = _project_board_key(project_name, proj)
+    limits = schema.get("wip_limits", {}).get(board_key, {})
+    if not limits:
+        return {"Ready": 10, "In Progress": 10 if project_name == "mount-olympus" else 5}
+    return cast(dict[str, Any], limits)
+
+
+def _terminal_statuses(config: dict, project_name: str, proj: dict) -> list[str]:
+    workflow = _project_workflow(config, project_name, proj)
+    statuses = list(workflow.get("terminal_statuses", []))
+    if project_name == "mount-olympus" and "Deployed" not in statuses:
+        statuses.append("Deployed")
+    return statuses or ["Done"]
+
+
+def _cycle_start_statuses(project_name: str) -> list[str]:
+    if project_name == "mount-olympus":
+        return ["Assigned", "In Progress", "In Development"]
+    return ["Active"]
+
+
+def _active_age_thresholds(config: dict, project_name: str, proj: dict) -> dict[str, int]:
+    workflow = _project_workflow(config, project_name, proj)
+    statuses = list(workflow.get("statuses", []))
+    if project_name == "mount-olympus":
+        return {
+            "Ready": 2,
+            "Planning": 2,
+            "Assigned": 5,
+            "In Progress": 5,
+            "In Review": 2,
+        }
+    terminal_statuses = _terminal_statuses(config, project_name, proj)
+    return {status: 3 for status in statuses if status not in terminal_statuses}
+
+
+def _legacy_status_hint(status: str, available: list[str]) -> str | None:
+    """Return a migration hint when an old status name is requested."""
+    alias = LIVE_LEGACY_STATUS_ALIASES.get(status)
+    if not alias:
+        return None
+    if alias in available:
+        return f"'{status}' is legacy; use '{alias}' on this board."
+    return f"'{status}' is legacy; usually maps to '{alias}', which is not available here."
 
 
 def get_projects_for_repo(config: dict, repo_name: str) -> list[dict]:
@@ -758,16 +905,8 @@ def board_view(project_name: str, status_filter: str | None, fmt: str) -> None:
             continue
         columns.setdefault(status, []).append(item)
 
-    # WIP limits
-    wip_limits = {"Ready": 10, "In Development": None, "E2E Testing": 3, "Deployment Ready": 5}
-    column_order = [
-        "Ready",
-        "In Development",
-        "E2E Testing",
-        "Deployment Ready",
-        "Deployed",
-        "No Status",
-    ]
+    wip_limits = _wip_limits(config, project_name, proj)
+    column_order = _status_order(config, project_name, proj, columns)
 
     if fmt == "json":
         _out({"project": project_name, "columns": columns}, fmt)
@@ -783,8 +922,15 @@ def board_view(project_name: str, status_filter: str | None, fmt: str) -> None:
             continue
 
         limit = wip_limits.get(col)
-        limit_str = f" [WIP: {len(col_items)}/{limit}]" if limit else f" [{len(col_items)} items]"
-        over_limit = limit and len(col_items) > limit
+        if isinstance(limit, int):
+            limit_str = f" [WIP: {len(col_items)}/{limit}]"
+            over_limit = len(col_items) > limit
+        elif isinstance(limit, str):
+            limit_str = f" [WIP: {len(col_items)}; limit {limit}]"
+            over_limit = False
+        else:
+            limit_str = f" [{len(col_items)} items]"
+            over_limit = False
         marker = " OVER LIMIT" if over_limit else ""
 
         print(f"### {col}{limit_str}{marker}")
@@ -807,12 +953,22 @@ def board_view(project_name: str, status_filter: str | None, fmt: str) -> None:
         print()
 
 
-def board_add(repo: str, number: int, fmt: str, config: dict | None = None) -> None:
+def board_add(
+    repo: str,
+    number: int,
+    fmt: str,
+    config: dict | None = None,
+    project_name: str | None = None,
+) -> None:
     """Add issue/PR to correct project(s)."""
     if not config:
         config = load_config()
 
-    projects = get_projects_for_repo(config, repo)
+    projects = (
+        [get_project_config(config, project_name)]
+        if project_name
+        else get_projects_for_repo(config, repo)
+    )
     if not projects:
         mappings = config.get("project_mappings", {})
         excluded = mappings.get("excluded_repositories", [])
@@ -853,10 +1009,16 @@ def board_add(repo: str, number: int, fmt: str, config: dict | None = None) -> N
     _out("\n".join(results), fmt)
 
 
-def board_move(repo: str, number: int, status: str, fmt: str) -> None:
+def board_move(
+    repo: str, number: int, status: str, fmt: str, project_name: str | None = None
+) -> None:
     """Move item to a different board column."""
     config = load_config()
-    projects = get_projects_for_repo(config, repo)
+    projects = (
+        [get_project_config(config, project_name)]
+        if project_name
+        else get_projects_for_repo(config, repo)
+    )
     if not projects:
         _error(f"Repo '{repo}' not mapped to any project")
         sys.exit(1)
@@ -905,7 +1067,11 @@ def board_move(repo: str, number: int, status: str, fmt: str) -> None:
             continue
         if not status_option_id:
             available = [o["name"] for o in status_field.get("options", [])]
-            results.append(f"Status '{status}' not found. Available: {', '.join(available)}")
+            hint = _legacy_status_hint(status, available)
+            message = f"Status '{status}' not found. Available: {', '.join(available)}"
+            if hint:
+                message = f"{message}. {hint}"
+            results.append(message)
             continue
 
         try:
@@ -926,16 +1092,20 @@ def board_move(repo: str, number: int, status: str, fmt: str) -> None:
 
 
 def board_archive(project_name: str, dry_run: bool, fmt: str) -> None:
-    """Archive items with 'Deployed' status."""
+    """Archive items in terminal workflow statuses."""
     config = load_config()
     proj = get_project_config(config, project_name)
     project_id, items = get_project_items(proj["number"])
 
-    deployed = [i for i in items if get_item_status(i) == "Deployed"]
+    terminal_statuses = set(_terminal_statuses(config, project_name, proj))
+    terminal_items = [i for i in items if get_item_status(i) in terminal_statuses]
 
     if dry_run:
-        print(f"DRY RUN: Would archive {len(deployed)} items from '{proj['name']}':")
-        for item in deployed:
+        print(
+            f"DRY RUN: Would archive {len(terminal_items)} terminal items "
+            f"from '{proj['name']}' ({', '.join(sorted(terminal_statuses))}):"
+        )
+        for item in terminal_items:
             content = item.get("content", {})
             print(
                 f"  - {content.get('repository', {}).get('name', '?')}#{content.get('number', '?')}: {content.get('title', '')[:50]}"
@@ -943,7 +1113,7 @@ def board_archive(project_name: str, dry_run: bool, fmt: str) -> None:
         return
 
     results = []
-    for item in deployed:
+    for item in terminal_items:
         content = item.get("content", {})
         label = f"{content.get('repository', {}).get('name', '?')}#{content.get('number', '?')}"
         try:
@@ -968,16 +1138,7 @@ def board_wip(project_name: str, fmt: str) -> None:
     proj = get_project_config(config, project_name)
     _, items = get_project_items(proj["number"])
 
-    # WIP limits: configurable via beads-config.json "wip_limits" section.
-    # "In Development" default is 10 (conservative for a mixed human/agent team
-    # where not all agents do dev work). Override in config for your team size.
-    config_wip = config.get("legacy_rollout_config", {}).get("wip_limits", {})
-    wip_limits = {
-        "Ready": config_wip.get("ready", 10),
-        "In Development": config_wip.get("in_development", 10),
-        "E2E Testing": config_wip.get("e2e_testing", 3),
-        "Deployment Ready": config_wip.get("deployment_ready", 5),
-    }
+    wip_limits = _wip_limits(config, project_name, proj)
 
     counts: dict[str, int] = {}
     for item in items:
@@ -989,13 +1150,18 @@ def board_wip(project_name: str, fmt: str) -> None:
     print("=" * 50)
     violations = []
     for col, limit in wip_limits.items():
+        if col == "pause_states" or limit is None:
+            continue
         count = counts.get(col, 0)
-        over = count > limit
-        if over:
-            violations.append(col)
-        bar = "X" * count + "." * max(0, limit - count)
-        marker = " OVER LIMIT" if over else ""
-        print(f"  {col:20} {count:2}/{limit:<2} [{bar}]{marker}")
+        if isinstance(limit, int):
+            over = count > limit
+            if over:
+                violations.append(col)
+            bar = "X" * count + "." * max(0, limit - count)
+            marker = " OVER LIMIT" if over else ""
+            print(f"  {col:20} {count:2}/{limit:<2} [{bar}]{marker}")
+        else:
+            print(f"  {col:20} {count:2} (limit: {limit})")
 
     if violations:
         print(f"\nWIP VIOLATIONS: {', '.join(violations)}")
@@ -1016,7 +1182,8 @@ def board_standup(project_name: str, fmt: str) -> None:
         status = get_item_status(item) or "No Status"
         columns.setdefault(status, []).append(item)
 
-    right_to_left = ["Deployed", "Deployment Ready", "E2E Testing", "In Development", "Ready"]
+    right_to_left = list(reversed(_status_order(config, project_name, proj, columns)))
+    right_to_left = [c for c in right_to_left if c != "No Status"]
 
     print(f"\n{'=' * 60}")
     print(f"  STANDUP PREP — {proj['name']}")
@@ -1045,9 +1212,9 @@ def board_standup(project_name: str, fmt: str) -> None:
         print()
 
     # Summary
-    total_active = sum(
-        len(columns.get(c, [])) for c in ["In Development", "E2E Testing", "Deployment Ready"]
-    )
+    terminal = set(_terminal_statuses(config, project_name, proj))
+    active_columns = [c for c in right_to_left if c not in terminal and c != "No Status"]
+    total_active = sum(len(columns.get(c, [])) for c in active_columns)
     print(f"Summary: {total_active} active items, {len(columns.get('Ready', []))} in Ready")
 
 
@@ -1367,6 +1534,8 @@ def metrics_cycle_time(project_name: str, days: int, issue_type: str | None, fmt
     config = load_config()
     proj = get_project_config(config, project_name)
     _, items = get_project_items(proj["number"])
+    terminal_statuses = set(_terminal_statuses(config, project_name, proj))
+    start_statuses = set(_cycle_start_statuses(project_name))
 
     cycle_times = []
 
@@ -1375,7 +1544,7 @@ def metrics_cycle_time(project_name: str, days: int, issue_type: str | None, fmt
 
     for item in items:
         status = get_item_status(item)
-        if status != "Deployed":
+        if status not in terminal_statuses:
             continue
 
         content = item.get("content", {})
@@ -1394,17 +1563,18 @@ def metrics_cycle_time(project_name: str, days: int, issue_type: str | None, fmt
         except Exception:
             continue
 
-        # Find In Development start and Deployed end
+        # Find first active-work start and terminal end. Legacy Olympus
+        # timeline data may still use In Progress / In Development / Deployed.
         dev_start = None
-        deployed_time = None
+        done_time = None
         for t in transitions:
-            if t["to"] == "In Development" and not dev_start:
+            if t["to"] in start_statuses and not dev_start:
                 dev_start = datetime.fromisoformat(t["at"].replace("Z", "+00:00"))
-            if t["to"] == "Deployed":
-                deployed_time = datetime.fromisoformat(t["at"].replace("Z", "+00:00"))
+            if t["to"] in terminal_statuses:
+                done_time = datetime.fromisoformat(t["at"].replace("Z", "+00:00"))
 
-        if dev_start and deployed_time:
-            cycle_days = (deployed_time - dev_start).total_seconds() / 86400
+        if dev_start and done_time:
+            cycle_days = (done_time - dev_start).total_seconds() / 86400
             cycle_times.append(cycle_days)
 
     if not cycle_times:
@@ -1435,10 +1605,11 @@ def metrics_cycle_time(project_name: str, days: int, issue_type: str | None, fmt
 
 
 def metrics_throughput(project_name: str, weeks: int, fmt: str) -> None:
-    """Show items deployed per week."""
+    """Show terminal items per week."""
     config = load_config()
     proj = get_project_config(config, project_name)
     _, items = get_project_items(proj["number"])
+    terminal_statuses = set(_terminal_statuses(config, project_name, proj))
 
     from collections import defaultdict
 
@@ -1446,7 +1617,7 @@ def metrics_throughput(project_name: str, weeks: int, fmt: str) -> None:
 
     for item in items:
         status = get_item_status(item)
-        if status != "Deployed":
+        if status not in terminal_statuses:
             continue
 
         content = item.get("content", {})
@@ -1491,8 +1662,8 @@ def metrics_wip_age(project_name: str, fmt: str) -> None:
     proj = get_project_config(config, project_name)
     _, items = get_project_items(proj["number"])
 
-    active_cols = ["Ready", "In Development", "E2E Testing", "Deployment Ready"]
-    aged_thresholds = {"Ready": 2, "In Development": 5, "E2E Testing": 1, "Deployment Ready": 2}
+    aged_thresholds = _active_age_thresholds(config, project_name, proj)
+    active_cols = list(aged_thresholds.keys())
 
     print(f"\nWIP Age — {proj['name']}")
     print("=" * 60)
@@ -3019,36 +3190,46 @@ def main() -> None:
     board_sp = board_p.add_subparsers(dest="action", required=True)
 
     board_view_p = board_sp.add_parser("view", help="View board items by column")
-    board_view_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    board_view_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     board_view_p.add_argument("--status", help="Filter by status column")
 
     board_add_p = board_sp.add_parser("add", help="Add issue/PR to project(s)")
+    board_add_p.add_argument(
+        "--project",
+        choices=PROJECT_CHOICES,
+        help="Target a specific project instead of repo-based default routing",
+    )
     board_add_p.add_argument("--repo", required=True, help="Repository name (without org)")
     board_add_p.add_argument("--number", required=True, type=int, help="Issue or PR number")
 
     board_move_p = board_sp.add_parser("move", help="Move item to different column")
+    board_move_p.add_argument(
+        "--project",
+        choices=PROJECT_CHOICES,
+        help="Target a specific project instead of repo-based default routing",
+    )
     board_move_p.add_argument("--repo", required=True)
     board_move_p.add_argument("--number", required=True, type=int)
     board_move_p.add_argument(
-        "--status", required=True, help="Target status (e.g. 'In Development', 'E2E Testing')"
+        "--status", required=True, help="Target status (e.g. 'Assigned', 'In Review', 'Active')"
     )
 
-    board_archive_p = board_sp.add_parser("archive", help="Archive deployed items")
-    board_archive_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    board_archive_p = board_sp.add_parser("archive", help="Archive terminal workflow items")
+    board_archive_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     board_archive_p.add_argument("--dry-run", action="store_true")
 
     board_wip_p = board_sp.add_parser("wip", help="Show WIP counts and limits")
-    board_wip_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    board_wip_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
 
     board_standup_p = board_sp.add_parser(
         "standup", help="Standup prep — right-to-left board review"
     )
-    board_standup_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    board_standup_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
 
     board_fields_p = board_sp.add_parser(
         "discover-fields", help="Discover all project fields and options"
     )
-    board_fields_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    board_fields_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
 
     # ===========================
     # ISSUE
@@ -3114,14 +3295,14 @@ def main() -> None:
     fields_sp = fields_p.add_subparsers(dest="action", required=True)
 
     fields_create_p = fields_sp.add_parser("create-option", help="Create new single-select option")
-    fields_create_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    fields_create_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     fields_create_p.add_argument(
         "--field", required=True, help="Field name (e.g. initiative, objective)"
     )
     fields_create_p.add_argument("--option", required=True, help="New option name")
 
     fields_discover_p = fields_sp.add_parser("discover", help="Discover all fields and options")
-    fields_discover_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    fields_discover_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
 
     # ===========================
     # METRICS
@@ -3130,23 +3311,23 @@ def main() -> None:
     metrics_sp = metrics_p.add_subparsers(dest="action", required=True)
 
     metrics_ct_p = metrics_sp.add_parser("cycle-time", help="Cycle time percentiles")
-    metrics_ct_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    metrics_ct_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     metrics_ct_p.add_argument("--days", type=int, default=30)
     metrics_ct_p.add_argument(
         "--type", choices=["capability", "enhancement", "defect", "exploration"]
     )
 
     metrics_th_p = metrics_sp.add_parser("throughput", help="Items deployed per week")
-    metrics_th_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    metrics_th_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     metrics_th_p.add_argument("--weeks", type=int, default=4)
 
     metrics_age_p = metrics_sp.add_parser("wip-age", help="Age of in-progress items")
-    metrics_age_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    metrics_age_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
 
     metrics_col_p = metrics_sp.add_parser(
         "column-time", help="Time in each column for a specific item"
     )
-    metrics_col_p.add_argument("--project", required=True, choices=["mount-olympus"])
+    metrics_col_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
     metrics_col_p.add_argument("--number", required=True, type=int)
 
     # ===========================
@@ -3167,7 +3348,7 @@ def main() -> None:
     ms_list_p.add_argument("--repo", required=True)
     ms_list_p.add_argument("--state", choices=["open", "closed", "all"], default="open")
 
-    ms_progress_p = ms_sp.add_parser("progress", help="Show milestone completion %")
+    ms_progress_p = ms_sp.add_parser("progress", help="Show milestone completion percent")
     ms_progress_p.add_argument("--repo", required=True)
     ms_progress_p.add_argument("--milestone", required=True, type=int, help="Milestone number")
 
@@ -3296,9 +3477,9 @@ def main() -> None:
             if args.action == "view":
                 board_view(args.project, args.status, fmt)
             elif args.action == "add":
-                board_add(args.repo, args.number, fmt)
+                board_add(args.repo, args.number, fmt, project_name=args.project)
             elif args.action == "move":
-                board_move(args.repo, args.number, args.status, fmt)
+                board_move(args.repo, args.number, args.status, fmt, project_name=args.project)
             elif args.action == "archive":
                 board_archive(args.project, args.dry_run, fmt)
             elif args.action == "wip":

--- a/plugins/sdlc-manager/skills/sdlc-board/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-board/SKILL.md
@@ -1,304 +1,171 @@
 ---
 name: sdlc-board
 description: |
-  Manage the Infiquetra Mount Olympus GitHub Projects board. Handles viewing board state,
-  moving issues between columns, adding items to projects, archiving deployed items,
-  WIP limit analysis, and standup preparation.
+  Manage the Infiquetra GitHub Projects boards: Jeff Intent, Asgard, and Mount Olympus.
+  Handles board views, status moves, item adds, terminal-item archive, WIP analysis,
+  field discovery, and standup preparation.
 when_to_use: |
   Use this skill when the user wants to:
 
   Board review and status:
-  - Review or view the project board ("review the mount-olympus board", "show me the project board",
-    "let's look at the board", "board status", "what's on the board")
+  - Review or view Jeff Intent, Asgard, or Mount Olympus board state
   - Check overall board health or get a snapshot of current work
-  - See what's in a specific column ("what's in E2E Testing", "show me deployment ready items")
+  - See what's in a specific status, such as Shaping, Active, Assigned, or In Review
 
-  Moving items between columns:
-  - Move an issue to a different board column ("move this issue to testing",
-    "move #42 to deployment ready", "advance this to E2E testing", "push this to In Development",
-    "mark this as deployed")
-  - Update an issue's board status after code review or testing is complete
+  Moving items between statuses:
+  - Move an issue to a different board status
+  - Update an issue's board status after shaping, implementation, review, or verification
 
-  Adding items to the board:
-  - Add an issue or PR to the project ("add this to the project", "put this on the board",
-    "add issue #42 to mount-olympus")
+  Adding items to boards:
+  - Add an issue or PR to its default repo-mapped board
+  - Add an issue or PR to a specific board with --project
 
   Archiving and cleanup:
-  - Archive items that have been deployed ("archive deployed items", "clean up the board",
-    "archive old deployed issues", "run board cleanup")
-  - Remove stale or completed items
+  - Archive terminal workflow items after reviewing a dry run
+  - Remove stale completed items from active board views
 
-  WIP analysis and capacity:
-  - Check WIP limit status ("are we over WIP limits", "how's our WIP", "capacity check",
-    "are we within limits", "WIP analysis")
-  - Identify bottlenecks caused by columns exceeding their limits
-
-  Standup preparation:
-  - Generate a standup summary ("standup prep", "daily standup summary",
-    "prepare the standup", "what's in progress", "standup report")
-  - Get a right-to-left board review for the daily standup
-
-  General board health:
-  - "what's blocked", "what's aging", "stale items", "items over WIP",
-    "what's been sitting in development too long", "flag aging issues"
+  WIP analysis and standup:
+  - Check WIP limits and bottlenecks
+  - Generate a right-to-left standup or board-review summary
+  - Identify blocked or aging work
 ---
 
 # SDLC Board
 
-Manage the Infiquetra Mount Olympus project board: view board state, move items, add issues,
-archive deployed work, check WIP limits, and prepare standup summaries.
+Manage Infiquetra's current project boards:
+
+| Project key | Board | Workflow |
+|-------------|-------|----------|
+| `jeff-intent` | Jeff Intent | `Idea -> Shaping -> Ready -> Active -> Verify -> Done` |
+| `asgard` | Asgard | `Idea -> Shaping -> Ready -> Active -> Verify -> Done` |
+| `mount-olympus` | Olympus | `Backlog -> Ready -> Planning -> Assigned -> In Review -> Done / Closed` |
+
+Olympus still has a live `In Progress` Status option. Treat it as a live legacy option:
+show it when present, but prefer `Assigned` for new movement. Deployment state is not a
+workflow status; use deployment fields and GitHub Deployments/Environments for environment
+movement.
 
 ## Script Location
 
-```
+```bash
 $INFIQUETRA_SDLC_PATH/../infiquetra-claude-plugins/plugins/sdlc-manager/scripts/sdlc_manager.py
 ```
 
-> If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
-
-**IMPORTANT**: Always use `python3` (not `python`) to run the script.
-
-## Project
-
-| Project | Team |
-|---------|------|
-| mount-olympus | Mount Olympus (all Infiquetra repos) |
+If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
+Always run the script with `python3`.
 
 ## Core Operations
 
 ### View Board
 
 ```bash
-# View full board (all columns)
+# View a board by status
+python3 sdlc_manager.py board view --project jeff-intent
+python3 sdlc_manager.py board view --project asgard
 python3 sdlc_manager.py board view --project mount-olympus
 
-# Filter to a specific column
-python3 sdlc_manager.py board view --project mount-olympus --status "In Development"
-
-# JSON output for programmatic use
-python3 sdlc_manager.py board view --project mount-olympus --format json
+# Filter to a specific status
+python3 sdlc_manager.py board view --project asgard --status "Active"
+python3 sdlc_manager.py board view --project mount-olympus --status "Assigned"
 ```
 
-#### Sample Output
-
-```
-Mount Olympus Board — 12 items
-
-Ready (3/10):
-  #45 [capability] Implement OAuth2 flow          (infiquetra-auth, 1d)
-  #52 [enhancement] Add rate limiting              (infiquetra-core, 0d)
-  #58 [defect]      Fix token refresh crash        (infiquetra-auth, 0d) [critical]
-
-In Development (4/9 — WIP OK):
-  #38 [capability] User onboarding service         (infiquetra-core, 3d) ⚠ aging
-  #41 [capability] Admin dashboard API             (infiquetra-core, 1d)
-  #49 [enhancement] Improve error messages         (infiquetra-auth, 2d)
-  #51 [defect]      Fix pagination off-by-one      (infiquetra-core, 0d)
-
-E2E Testing (2/3):
-  #33 [capability] Notification service            (infiquetra-core, 1d)
-  #36 [enhancement] Cache invalidation             (infiquetra-core, 0d)
-
-Deployment Ready (1/5):
-  #29 [capability] Audit log export                (infiquetra-core, 0d)
-
-Deployed (2):
-  #25 [capability] Search API v2                   (infiquetra-core, 5d)
-  #27 [enhancement] Compression middleware         (infiquetra-core, 3d)
-```
-
-### Move Item to Column
+### Add Item
 
 ```bash
-# Move an issue to a different board column
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "E2E Testing"
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "Deployment Ready"
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "Deployed"
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "In Development"
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "Ready"
+# Add an issue or PR to the default repo-mapped board
+python3 sdlc_manager.py board add --repo infiquetra-sdlc --number 42
+
+# Add an item to a specific board
+python3 sdlc_manager.py board add --project asgard --repo infiquetra-sdlc --number 42
+python3 sdlc_manager.py board add --project jeff-intent --repo infiquetra-sdlc --number 42
 ```
 
-Valid status values: `Ready`, `In Development`, `E2E Testing`, `Deployment Ready`, `Deployed`
-
-### Add Item to Project
+### Move Item
 
 ```bash
-# Add an issue or PR to the project based on repo mapping
-python3 sdlc_manager.py board add --repo infiquetra-core --number 42
+# Intent-flow boards
+python3 sdlc_manager.py board move --project asgard --repo infiquetra-sdlc --number 42 --status "Active"
+python3 sdlc_manager.py board move --project jeff-intent --repo infiquetra-sdlc --number 42 --status "Shaping"
+
+# Olympus engineering flow
+python3 sdlc_manager.py board move --repo athena-service --number 42 --status "Assigned"
+python3 sdlc_manager.py board move --repo athena-service --number 42 --status "In Review"
+python3 sdlc_manager.py board move --repo athena-service --number 42 --status "Done"
 ```
 
-The script auto-detects which project a repo belongs to.
+Use `board discover-fields` when unsure which Status options exist live.
 
-### Archive Deployed Items
+### Archive Terminal Items
 
 ```bash
-# Dry run — preview what would be archived
+# Always preview first
 python3 sdlc_manager.py board archive --project mount-olympus --dry-run
+python3 sdlc_manager.py board archive --project asgard --dry-run
 
-# Archive items that have been in Deployed status for 2+ weeks
+# Run only after operator confirmation
 python3 sdlc_manager.py board archive --project mount-olympus
 ```
 
-### WIP Analysis
+The command archives terminal workflow items. For Jeff Intent and Asgard that means `Done`.
+For Olympus that means `Done`, `Closed`, `Cancelled`, plus legacy `Deployed` if old cards still carry it.
+
+### WIP And Standup
 
 ```bash
-# Check WIP limits across all columns
 python3 sdlc_manager.py board wip --project mount-olympus
-```
-
-Output shows current WIP vs. limit for each column, flags any violations.
-
-### Standup Preparation
-
-```bash
-# Generate right-to-left board summary for standup
+python3 sdlc_manager.py board wip --project asgard
 python3 sdlc_manager.py board standup --project mount-olympus
+python3 sdlc_manager.py board standup --project jeff-intent
 ```
 
-Output walks Deployed -> Deployment Ready -> E2E Testing -> In Development -> Ready,
-flagging blocked items, aging items, and WIP violations.
+Standup output walks each board right-to-left using the schema-backed workflow order.
 
-### Discover Project Fields
+### Discover Fields
 
 ```bash
-# Inspect available fields and options on the board
 python3 sdlc_manager.py board discover-fields --project mount-olympus
+python3 sdlc_manager.py board discover-fields --project asgard
+python3 sdlc_manager.py board discover-fields --project jeff-intent
 ```
-
-Useful when status options or field IDs need verification.
 
 ## WIP Limits Reference
 
-| Column | WIP Limit | Notes |
-|--------|-----------|-------|
-| Ready | 10 | Buffer for capacity matching |
-| In Development | 3 per developer | Dynamic: team size x 3 |
-| E2E Testing | 3 | Manual testing capacity |
-| Deployment Ready | 5 | Deployment window constraint |
-| Deployed | Unlimited | Auto-archive after 2 weeks |
+| Board | Status | Limit |
+|-------|--------|-------|
+| Jeff Intent | Shaping | 10 |
+| Jeff Intent | Ready | 10 |
+| Jeff Intent | Active | 5 |
+| Jeff Intent | Verify | 5 |
+| Asgard | Shaping | 8 |
+| Asgard | Ready | 8 |
+| Asgard | Active | 5 |
+| Asgard | Verify | 5 |
+| Olympus | Ready | 10 |
+| Olympus | Planning | 3 |
+| Olympus | Assigned | 3 per assigned agent |
+| Olympus | In Review | 5 |
 
-When In Development is over WIP: stop pulling new work, swarm on finishing existing items.
-Critical defects can temporarily bypass WIP limits.
-
-## Strategic Direction Board
-
-The `strategic` project provides a high-level view of Objectives and Initiatives — distinct
-from the day-to-day Kanban board used for Capabilities.
-
-```bash
-# View the strategic direction board
-python3 sdlc_manager.py board view --project strategic
-```
-
-### Columns
-
-| Column | Purpose |
-|--------|---------|
-| Backlog | Objectives and Initiatives under consideration but not yet committed |
-| This Quarter | Committed for the current quarter — actively being planned or staffed |
-| In Flight | Actively being executed — Capabilities flowing through the Kanban board |
-| Shipped | Completed Objectives — all Capabilities deployed, milestone closed |
-
-### Key Differences from the Kanban Board
-
-- **Items are Objectives and Initiatives**, not Capabilities
-- **No per-agent WIP limits** — strategic items are coordination constructs, not developer work
-- **Progress is measured by Milestone completion %**, not column dwell time
-- **Movement is quarterly**, not daily — items move during planning ceremonies
-
-### Interpretation Rules
-
-- **Backlog items** are candidates for next quarter — review during quarterly planning
-- **This Quarter items** should each have a GitHub Milestone with a due date
-- **In Flight items** should have active Capabilities on the Kanban board
-- **Shipped items** should have closed Milestones and completed Beads parent tasks
-- If an In Flight Objective has < 80% completion with < 7 days to due date, flag as at-risk
-
-## Beads/Dolt Integration
-
-The Mount Olympus team uses Beads/Dolt as the primary coordination layer. Board status
-syncs with Beads task status:
-
-```bash
-# When moving an item on the board, also update in Beads
-bd update <task-id> in-development
-bd update <task-id> testing
-bd update <task-id> deployed
-```
-
-Beads tasks automatically sync to GitHub Issues, so board moves triggered via Beads
-will reflect on the GitHub Projects board.
+When WIP is exceeded, stop pulling new work on that board and focus on finishing, swarming,
+or moving blocked cards to the right pause state.
 
 ## Natural Language Examples
 
-**"Review the mount-olympus board"**
--> `board view --project mount-olympus`
+**"Review the Asgard board"**
+-> `board view --project asgard`
 
-**"Move issue #42 in infiquetra-core to E2E testing"**
--> `board move --repo infiquetra-core --number 42 --status "E2E Testing"`
+**"Move issue #42 in infiquetra-sdlc to Active on Asgard"**
+-> `board move --project asgard --repo infiquetra-sdlc --number 42 --status "Active"`
 
-**"Add this issue to the project"**
--> Confirm repo and issue number, then: `board add --repo <repo> --number <N>`
-
-**"Archive deployed items"**
--> `board archive --project mount-olympus --dry-run` (confirm first), then without `--dry-run`
+**"Add this issue to Jeff Intent"**
+-> Confirm repo and issue number, then `board add --project jeff-intent --repo <repo> --number <N>`
 
 **"Are we over WIP limits?"**
--> `board wip --project mount-olympus`
+-> Run `board wip` for the relevant board.
 
 **"Let's prep for standup"**
--> `board standup --project mount-olympus`
-
-**"What's been aging in development?"**
--> `board view --project mount-olympus --status "In Development"` and flag items > 3 days
-
-**"What's blocked?"**
--> `board view --project mount-olympus` — look for items with `blocked` label
-
-## Key Behaviors
-
-- **Items aging >3 days in In Development** should be flagged proactively when viewing the board
-- **Items aging >2 days in E2E Testing** should be flagged as potentially stale
-- **Blocked items** (with `blocked` label) get special attention in standup output
-- **Critical defects** bypass the Ready queue — they can be pulled directly to In Development
-- **Standup order**: right-to-left — Deployed -> Deployment Ready -> E2E Testing -> In Development -> Ready
-
-## Workflow Examples
-
-### Example 1: Daily Standup Preparation
-
-```bash
-# Generate standup summary
-python3 sdlc_manager.py board standup --project mount-olympus
-```
-
-Review output right-to-left. For each column: note items that are blocked, aging,
-or causing bottlenecks. Share summary in #mount-olympus Discord channel.
-
-### Example 2: End-of-Sprint Board Cleanup
-
-```bash
-# 1. Preview items that would be archived
-python3 sdlc_manager.py board archive --project mount-olympus --dry-run
-
-# 2. Confirm with user, then archive
-python3 sdlc_manager.py board archive --project mount-olympus
-```
-
-### Example 3: Moving a Feature Through the Board
-
-```bash
-# Developer finishes work and creates PR
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "E2E Testing"
-
-# E2E testing passes
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "Deployment Ready"
-
-# Deployed to production
-python3 sdlc_manager.py board move --repo infiquetra-core --number 42 --status "Deployed"
-```
+-> `board standup --project mount-olympus` or the requested board.
 
 ## Reference Documents
 
-- `references/kanban-workflow.md` — Board structure, column definitions, WIP limits, standup format
-- `references/graphql-queries.md` — GraphQL queries used by the script (developer reference)
+- `references/kanban-workflow.md` - Board structure, status definitions, WIP limits, and standup format
+- `references/graphql-queries.md` - GraphQL queries used by the script

--- a/plugins/sdlc-manager/skills/sdlc-board/references/graphql-queries.md
+++ b/plugins/sdlc-manager/skills/sdlc-board/references/graphql-queries.md
@@ -50,7 +50,7 @@ mutation($projectId: ID!, $contentId: ID!) {
 
 ## Mutation: Archive Item
 
-**Purpose**: Archive a project item (typically Deployed items after 2 weeks).
+**Purpose**: Archive a project item, typically after it reaches a terminal workflow status.
 
 **Constant**: `QUERY_ARCHIVE_ITEM`
 
@@ -209,8 +209,8 @@ query($org: String!, $repo: String!, $number: Int!) {
 }
 ```
 
-**Usage**: Called in `labels sync-fields` to read current labels before determining
-which project field values to set.
+**Usage**: Legacy helper for `labels sync-fields`. New field updates should prefer
+`flow set-field` with explicit project field values.
 
 ---
 
@@ -311,7 +311,7 @@ while True:
 
 ### Field ID vs. Option ID
 - `fieldId`: the node ID of the field itself (e.g., the "Status" field)
-- `optionId`: the node ID of a specific option within that field (e.g., "In Development")
+- `optionId`: the node ID of a specific option within that field (e.g., "Assigned")
 - Both are opaque strings — discover them via `QUERY_GET_PROJECT_FIELDS` or
   `board discover-fields`
 

--- a/plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md
+++ b/plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md
@@ -1,277 +1,149 @@
-# Kanban Workflow Reference
+# Board Workflow Reference
 
-Condensed reference for operating the Infiquetra Mount Olympus Kanban board. For the full
-authoritative document see `$INFIQUETRA_SDLC_PATH/docs/process/kanban-workflow.md`.
+Condensed reference for the Infiquetra GitHub Projects boards. The canonical source of
+truth is `$INFIQUETRA_SDLC_PATH/config/sdlc-schema.json`, with prose context in
+`$INFIQUETRA_SDLC_PATH/docs/process/board-topology.md` and
+`$INFIQUETRA_SDLC_PATH/docs/process/kanban-workflow.md`.
 
 ---
 
-## Board Structure
+## Boards
+
+| Project key | Board | Purpose |
+|-------------|-------|---------|
+| `jeff-intent` | Jeff Intent | Raw operator intent, approvals, personal/operator work, and shaping |
+| `asgard` | Asgard | Jeff-proximal rapid action, incubation, and mission-mode work |
+| `mount-olympus` | Olympus | Primary autonomous engineering execution pipeline |
+
+Prefer project views over new boards until scale, automation, or reporting needs justify
+a separate board.
+
+---
+
+## Workflows
+
+### Jeff Intent And Asgard
 
 ```
-+---------+----------------+-------------+------------------+----------+
-|  Ready  | In Development | E2E Testing | Deployment Ready | Deployed |
-|(WIP: 10)|  (WIP: 3/dev)  |  (WIP: 3)   |     (WIP: 5)     | (Auto-   |
-|         |                |             |                  | Archive) |
-+---------+----------------+-------------+------------------+----------+
+Idea -> Shaping -> Ready -> Active -> Verify -> Done
 ```
 
-Backlog lives in `infiquetra-blueprint` (outside the flow board).
-Analysis is optional — used when context gathering is needed before Ready.
+| Status | Purpose |
+|--------|---------|
+| Idea | Captured thought or opportunity. Not shaped enough for execution. |
+| Shaping | Intent is being clarified, scoped, or turned into an actionable card. |
+| Ready | Work is shaped enough to route or start. Jeff Intent must name a target team before promotion. |
+| Active | The owner is working the card. |
+| Verify | Outcome is being checked before closure or promotion. |
+| Done | Completed or intentionally closed for this board. |
 
----
+Asgard modes:
 
-## Column Definitions
+| Mode | Use |
+|------|-----|
+| Rapid Action | Reversible, time-sensitive work that benefits from low ceremony. |
+| Incubator | Exploratory work likely to define future Olympus execution. |
+| Mission | Focused, high-leverage work close to Jeff with a clear outcome. |
 
-### Ready (WIP: 10)
+### Mount Olympus
 
-**Purpose**: Fully specified work waiting for developer capacity.
+```
+Backlog -> Ready -> Planning -> Assigned -> In Review -> Done / Closed
+```
 
-**Entry criteria**:
-- Capability/issue defined in Blueprint with all acceptance criteria
-- No blocking dependencies
-- Team has identified this as current milestone focus
+| Status | Purpose |
+|--------|---------|
+| Backlog | Accepted but not yet ready for engineering execution. |
+| Ready | Meets issue schema, has acceptance criteria, and is eligible for dispatch. |
+| Planning | Plan or execution approach is being prepared or reviewed. |
+| Assigned | An agent owns implementation and is within WIP capacity. |
+| In Review | PR, work artifact, or verification evidence is under team-owned review. |
+| Done | Work is completed. |
+| Closed | Work is closed without further active flow. |
 
-**Exit criteria**: Developer pulls item when capacity available (WIP < 3)
+Pause states: `Plan-Approved`, `Needs Review`, `Needs Question`, `Blocked`, `Cancelled`.
 
-**Alert**: Item ages > 5 days
-
-**Typical duration**: 0-2 days
-
----
-
-### In Development (WIP: 3 per developer)
-
-**Purpose**: Active AI-assisted development, code review, and integration testing.
-
-**Entry criteria**:
-- Developer has capacity (< 3 items in progress)
-- Context reviewed, approach understood
-- Cycle time start recorded
-
-**Activities**:
-- Claude Code implementation
-- Unit + integration tests written
-- Code review (automated gates + AI + human risk-based)
-- PR merged
-- Integration tests pass in non-prod
-
-**Exit criteria**:
-- All acceptance criteria met
-- Tests passing (including integration)
-- PR merged
-- Ready for manual E2E
-
-**Alert**: Item ages > expected cycle time (see typical durations below)
-
-**Typical durations**:
-- Capability: 3-12 days
-- Enhancement: 1-4 days
-- Defect: 2 hours - 1 day
-
----
-
-### E2E Testing (WIP: 3)
-
-**Purpose**: Manual end-to-end testing in pre-prod environment.
-
-**Entry criteria**:
-- PR merged, deployed to pre-prod
-- Integration tests passing
-- E2E test plan defined (from In Development)
-
-**Activities**:
-- Execute manual E2E test scenarios
-- UAT, cross-service integration validation
-- Document any issues found
-
-**Exit criteria**:
-- All E2E scenarios pass
-- No critical issues
-- Performance acceptable
-
-**Alert**: Item ages > 2 days
-
-**Typical durations**:
-- Capability: 4-8 hours
-- Enhancement: 1-4 hours
-- Defect: 30 minutes - 2 hours
-
----
-
-### Deployment Ready (WIP: 5)
-
-**Purpose**: Queue of work ready for production deployment.
-
-**Entry criteria**:
-- All tests passing in non-prod
-- Deployment plan documented with rollback plan
-
-**Activities**:
-- Await deployment window
-- Coordinate dependent deployments
-
-**Exit criteria**:
-- Deployed to production successfully
-- Health checks and monitoring confirm stability
-
-**Typical duration**: 0-2 days
-
----
-
-### Deployed (Auto-archive after 2 weeks)
-
-**Purpose**: Completed work under production observation.
-
-**Entry criteria**:
-- Successfully deployed to production
-- Cycle time end recorded
-- Monitoring active
-
-**Activities**:
-- 48-hour observation period
-- Collect metrics
-
-**Exit criteria**: 2 weeks in production, no critical issues -> auto-archive
+Olympus still exposes a live `In Progress` option. Treat it as a live legacy option:
+display it when present, but use `Assigned` for new work. Older status names such as
+`In Development`, `E2E Testing`, `Deployment Ready`, and `Deployed` are legacy migration
+terms. Deployment state belongs in deployment fields and GitHub Deployments/Environments,
+not in the core Status workflow.
 
 ---
 
 ## WIP Limits
 
-| Column | Limit | Rationale |
-|--------|-------|-----------|
-| Ready | 10 | Buffer for capacity matching |
-| In Development | 3 per developer | Prevents context switching |
-| E2E Testing | 3 | Manual testing capacity |
-| Deployment Ready | 5 | Deployment schedule constraint |
-| Deployed | Unlimited | Auto-archive keeps board clean |
+| Board | Status | Limit |
+|-------|--------|-------|
+| Jeff Intent | Shaping | 10 |
+| Jeff Intent | Ready | 10 |
+| Jeff Intent | Active | 5 |
+| Jeff Intent | Verify | 5 |
+| Asgard | Shaping | 8 |
+| Asgard | Ready | 8 |
+| Asgard | Active | 5 |
+| Asgard | Verify | 5 |
+| Olympus | Ready | 10 |
+| Olympus | Planning | 3 |
+| Olympus | Assigned | 3 per assigned agent |
+| Olympus | In Review | 5 |
 
-**Dynamic In Development WIP**:
-```
-WIP limit = Number of active developers x 3
-```
-Example: 5 developers = WIP limit of 15
-
-**When WIP is exceeded**:
-1. Immediate Discord alert to team channel
-2. Team stops pulling new work until WIP returns to limit
-3. Daily standup focuses on clearing the bottleneck
-4. Process improvement if violations are frequent
+When a limit is exceeded, finish or unblock current work before pulling more into that status.
+Critical defects can temporarily override WIP, but the exception should be visible in the card.
 
 ---
 
-## Standup Format (15 minutes max)
+## Standup Format
 
-### 1. Board Review — Right to Left
+Walk right-to-left through the relevant board:
 
-Walk the board from **Deployed -> Ready** (pull items through, don't push):
+| Board | Review order |
+|-------|--------------|
+| Jeff Intent / Asgard | Done -> Verify -> Active -> Ready -> Shaping -> Idea |
+| Olympus | Closed -> Done -> In Review -> Assigned -> Planning -> Ready -> Backlog |
 
-| Column | Key Questions |
-|--------|---------------|
-| Deployed | Anything to learn? Issues observed post-deploy? |
-| Deployment Ready | When will these deploy? Any blockers? |
-| E2E Testing | Test failures? Blocking issues? Items aging? |
-| In Development | Aging items? Blockers? Code review stalled? |
-| Ready | What should we focus on next? Team alignment? |
+Ask:
 
-### 2. WIP Check
-- Any columns at or over limit?
-- Where is work accumulating?
-- What is causing the bottleneck?
-
-### 3. Milestone Alignment
-- Are we on track for the current milestone?
-- Do we need to swarm on any capabilities?
-- Any ad-hoc sessions needed today?
-
-### 4. Objective Check-in (if active time-bounded Objective)
-- Days until Objective target date
-- Progress: X of Y Capabilities deployed
-- Any blockers risking the deadline?
-- Scope adjustments needed?
-
-### 5. Action Items
-- Who will help with the bottleneck?
-- What blockers need escalation?
-- Any process improvements needed?
-
----
-
-## Escalation Policies
-
-| Condition | Action | Timeframe |
-|-----------|--------|-----------|
-| Item blocked | Add `blocked` label + notify team | Immediately |
-| Blocked > 4 hours | Escalate to tech lead | 4 hours |
-| Blocked > 1 day | Escalate to engineering manager | 24 hours |
-| Item aging > expected + 50% | Flag in daily standup | Daily check |
-
----
-
-## Aging Thresholds (Flag in Board Review)
-
-| Column | Flag if age > |
-|--------|--------------|
-| Ready | 5 days |
-| In Development | Expected cycle time + 50% (flag at >3 days as a practical default) |
-| E2E Testing | 2 days |
-| Deployment Ready | 2 days |
+- What is terminal and safe to archive?
+- What is waiting for verification or review?
+- What is actively owned, and is it aging?
+- What is blocked or waiting on Jeff?
+- What should move next, and what should stay out of WIP?
 
 ---
 
 ## Common Scenarios
 
-### Production Emergency (Critical Defect)
-1. Create defect issue immediately
-2. Add `critical` priority label
-3. Pull directly to In Development — **bypass Ready queue**
-4. Fix, PR, expedite review (15-min SLA)
-5. Deploy to production immediately
-6. Follow up with root cause analysis
+### Raw Intent From Jeff
 
-**Note**: Critical defects can temporarily exceed WIP limits.
+1. Capture on Jeff Intent as `Idea`.
+2. Shape until target team and context pack are clear.
+3. Move to `Ready`.
+4. Promote to Asgard, Olympus, Jeff, or External/Deferred based on target team.
 
-### Blocked by External Dependency
-1. Add `blocked` label with comment (what, who, when expected)
-2. Create separate enhancement for external dependency
-3. Move item back to Ready
-4. Pull new work to maintain flow
-5. Resume when blocker is cleared
+### Asgard Seeds Olympus
 
-### Context is Incomplete
-1. Move item back to Ready (or optionally to Analysis)
-2. Create `context-update` issue for Blueprint
-3. Complete context update first, then resume
+1. Incubate or act in Asgard.
+2. Verify the result or direction.
+3. Promote to Olympus only when the work is repeatable, well-shaped, and has acceptance criteria clear enough for autonomous execution.
 
-### Large Capability (4+ weeks estimated)
-1. Break into 2-3 smaller capabilities if possible
-2. If truly atomic, use sub-tasks for internal tracking
-3. Consider feature flags for incremental delivery
+### Olympus Engineering Flow
+
+1. Start in `Backlog` or `Ready` depending on issue maturity.
+2. Move through `Planning`, `Assigned`, and `In Review`.
+3. Close as `Done` or `Closed`.
+4. Track environment promotion separately through deployment fields and deployment records.
 
 ---
 
-## Cycle Time Targets (85th percentile)
+## Metrics Boundaries
 
-| Issue Type | Target |
-|------------|--------|
-| Capability | < 5 days |
-| Enhancement | < 2 days |
-| Defect | < 1 day |
+Cycle time starts when active ownership begins:
 
-**Cycle time** = time from entering "In Development" to "Deployed"
+| Board | Start | Terminal |
+|-------|-------|----------|
+| Jeff Intent / Asgard | Active | Done |
+| Olympus | Assigned | Done, Closed, Cancelled |
 
----
-
-## Work Pulling Rules
-
-1. Check your WIP: < 3 items in In Development?
-2. Review with team in standup or Discord
-3. Consider current milestone focus
-4. Review context — is it clear?
-5. Pull (or swarm)
-6. Update daily
-
-**If capacity but nothing urgent in Ready**:
-1. Help with E2E Testing (highest priority — unblocks deployment)
-2. Pair with someone on in-progress work
-3. Update Blueprint context
-4. Optional Analysis for future work
+Legacy Olympus timeline values may still include `In Progress`, `In Development`, or
+`Deployed`; tooling may read them for history but should not create new cards with those statuses.

--- a/plugins/sdlc-manager/skills/sdlc-labels/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-labels/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: sdlc-labels
 description: |
-  Manage GitHub labels and project board field synchronization for Infiquetra repositories.
-  Handles applying SDLC labels to issues, syncing initiative/objective labels to project board
-  fields, auditing repos for missing labels, deploying the full label taxonomy, auto-labeling
-  issues based on title/body patterns, and creating new field options when new initiatives or
+  Manage GitHub labels and project field options for Infiquetra repositories.
+  Handles applying SDLC labels to issues, auditing repos for missing labels, deploying the
+  full label taxonomy, auto-labeling issues based on title/body patterns, and creating
+  new field options when new initiatives or
   objectives are introduced.
 when_to_use: |
   Use this skill when the user wants to:
@@ -14,16 +14,14 @@ when_to_use: |
     "tag this as high priority", "mark this as an enhancement", "add the blocked label")
   - Set or correct issue type, priority, or status labels
 
-  Syncing project board fields from labels:
-  - Sync board fields after labels change ("sync the initiative field",
-    "the objective field doesn't match the label", "sync fields for this issue",
-    "update the board field to match the label")
-  - Ensure initiative:* and objective:* labels are reflected in project board single-select fields
+  Setting project fields:
+  - Set Initiative, Objective, or other project fields directly after label or card changes
+  - Discover available fields and options on Jeff Intent, Asgard, or Mount Olympus
 
   Assigning initiatives and objectives:
   - "this belongs to olympus-v1", "assign to the platform-launch objective",
     "this issue is part of the core-platform initiative", "tag this with the Q1 objective"
-  - Adding initiative:* or objective:* labels and syncing the corresponding board fields
+  - Setting the corresponding project field option
 
   Auditing label coverage:
   - "check if this repo has all the SDLC labels", "audit labels on infiquetra-core",
@@ -65,18 +63,18 @@ $INFIQUETRA_SDLC_PATH/../infiquetra-claude-plugins/plugins/sdlc-manager/scripts/
 
 ## Core Operations
 
-### Sync Label Fields to Project Board
+### Set Project Fields
 
-When initiative or objective labels are applied to an issue, the corresponding project board
-single-select fields must be updated to match.
+Initiative and Objective are project fields, not label-derived state. Set them directly:
 
 ```bash
-# Sync initiative/objective labels -> project board fields for an issue
-python3 sdlc_manager.py labels sync-fields --repo infiquetra-core --number 42
+python3 sdlc_manager.py flow set-field --project mount-olympus \
+  --repo infiquetra-core --number 42 \
+  --field Objective --option "platform-launch"
 ```
 
-This reads the issue's current labels, finds any `initiative:*` or `objective:*` labels, and
-updates the corresponding single-select fields on the mount-olympus project.
+The older `labels sync-fields` command remains for compatibility, but new work should prefer
+`flow set-field` because it uses live project field discovery.
 
 ### Audit Repo Labels
 
@@ -147,17 +145,16 @@ verifying that an initiative/objective option exists before trying to sync.
 - **Status labels** (`ready`, `blocked`, `needs-analysis`, `needs-triage`): may be
   auto-managed as issues progress
 
-### Initiative and Objective Synchronization
+### Initiative and Objective Fields
 
-`initiative:*` and `objective:*` labels on an issue drive the project board's single-select
-fields. Workflow:
+Initiative and Objective are project fields. Workflow:
 
-1. Apply `initiative:olympus-v1` label to the issue
-2. Run `labels sync-fields --repo <repo> --number <N>` to update the board field
-3. The board's "Initiative" single-select field is updated to "olympus-v1"
+1. Confirm the field exists with `fields discover --project <project>`.
+2. Create a missing option with `fields create-option` when needed.
+3. Set the field with `flow set-field`.
 
-When a new initiative or objective label is applied that doesn't yet exist as a board field
-option, you must first create the option with `fields create-option`.
+Convention labels such as `initiative:*` and `objective:*` may still exist in old issues,
+but they are not the canonical source of truth.
 
 ## Natural Language Examples
 
@@ -168,11 +165,10 @@ option, you must first create the option with `fields create-option`.
 -> `gh issue edit 88 --add-label high-priority --repo Infiquetra/infiquetra-core`
 
 **"This issue belongs to the Olympus v1 initiative"**
--> Apply `initiative:olympus-v1` label, then:
-  `labels sync-fields --repo <repo> --number <N>`
+-> `flow set-field --project mount-olympus --repo <repo> --number <N> --field Initiative --option "olympus-v1"`
 
 **"Sync the initiative field for issue #42"**
--> `python3 sdlc_manager.py labels sync-fields --repo infiquetra-core --number 42`
+-> `python3 sdlc_manager.py flow set-field --project mount-olympus --repo infiquetra-core --number 42 --field Initiative --option <name>`
 
 **"Audit labels on infiquetra-core"**
 -> `python3 sdlc_manager.py labels audit --repo infiquetra-core`

--- a/plugins/sdlc-manager/skills/sdlc-labels/references/labels-reference.md
+++ b/plugins/sdlc-manager/skills/sdlc-labels/references/labels-reference.md
@@ -118,8 +118,8 @@ These labels follow a naming convention and are created on-demand rather than pr
 
 ### `initiative:*` and `objective:*`
 
-Applied to issues to associate them with a program-level initiative or delivery objective.
-Synced to project board single-select fields via `labels sync-fields`.
+Legacy convention labels that may appear on older issues. New work should use the
+project board's `Initiative` and `Objective` fields directly via `flow set-field`.
 
 | Pattern | Color | Example |
 |---------|-------|---------|
@@ -184,17 +184,23 @@ Applied by `labels auto-label` command. Rules match patterns in issue title or b
 
 ---
 
-## Initiative and Objective Labels
+## Initiative and Objective Fields
 
-These labels are not defined in `labels.json` but are used as a convention:
+These values are project field options. Legacy labels may exist, but they are not the
+canonical source of truth:
 
-- `initiative:<name>` — maps to the "Initiative" single-select field on the project board
-- `objective:<name>` — maps to the "Objective" single-select field on the project board
+- `Initiative` project field - strategic grouping
+- `Objective` project field - delivery target or parent objective
 
-When applied to an issue, run `labels sync-fields` to propagate the value to the board field.
+Set fields directly:
 
-The mount-olympus board maintains the full set of initiative and objective options. When
-creating a new initiative or objective, add the field option using `fields create-option`.
+```bash
+python3 sdlc_manager.py flow set-field --project mount-olympus \
+  --repo <repo> --number <N> \
+  --field Objective --option "platform-launch"
+```
+
+When creating a new initiative or objective, add the field option using `fields create-option`.
 
 Example label names:
 - `initiative:olympus-v1`

--- a/plugins/sdlc-manager/skills/sdlc-metrics/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-metrics/SKILL.md
@@ -1,272 +1,154 @@
 ---
 name: sdlc-metrics
 description: |
-  Flow metrics and analysis for the Infiquetra Mount Olympus Kanban board using timeline events.
-  Provides cycle time percentiles, throughput trends, WIP age distribution, per-column
-  time breakdowns, and flow efficiency — with targets by issue type and interpretation guidance.
+  Flow metrics and analysis for Infiquetra project boards using GitHub timeline events.
+  Provides cycle time, throughput, WIP age, per-status time breakdowns, and interpretation
+  guidance across Jeff Intent, Asgard, and Mount Olympus.
 when_to_use: |
   Use this skill when the user wants to:
 
   Cycle time analysis:
   - "how long are issues taking", "what's our cycle time", "how fast are we delivering"
-  - "cycle time report", "are we hitting our cycle time targets", "cycle time breakdown"
-  - "how long did this capability take", "how long has issue #42 been in progress"
-  - "compare this month to last month", "are we getting faster"
+  - "cycle time report", "are we hitting our cycle time targets"
+  - "how long did this capability take", "how long has issue #42 been active"
 
   Throughput analysis:
-  - "how many capabilities did we ship last week", "deployment velocity",
-    "throughput this month", "throughput report", "how many items did we complete"
-  - "are we on track for our throughput targets", "weekly delivery rate"
+  - "how many capabilities did we complete last week", "weekly delivery rate"
+  - "throughput this month", "how many items reached Done"
 
   WIP age and aging work:
-  - "how old are our in-progress items", "what's been sitting in development too long"
-  - "aging work items", "WIP age report", "what's stale", "aging in E2E"
+  - "how old are our active items", "what's stale", "aging work items"
 
-  Flow health and efficiency:
-  - "how's our flow", "are we meeting our targets", "flow efficiency",
-    "are we healthy", "flow health check", "overall metrics summary"
-  - "flow efficiency report", "what percentage of time is active vs. waiting"
-
-  SLA and defect response:
-  - "are any defects violating SLA", "critical defect response time",
-    "defect SLA check", "are high priority defects on track"
-
-  Per-column time breakdown:
-  - "how long do items spend in E2E testing", "column time breakdown for issue #42"
-  - "where's the bottleneck", "which column is slowest"
+  Flow health:
+  - "how's our flow", "where's the bottleneck", "which status is slowest"
 ---
 
 # SDLC Metrics
 
-Flow metrics and analysis for the Infiquetra Mount Olympus Kanban board using GitHub timeline
-events. Measures cycle time, throughput, WIP age, and flow efficiency — with targets by issue type.
+Flow metrics for Infiquetra's GitHub Projects boards. Metrics use GitHub timeline events
+for Status changes. Deployment state is intentionally separate from workflow Status; use
+deployment records and deployment fields for environment promotion questions.
 
 ## Script Location
 
-```
+```bash
 $INFIQUETRA_SDLC_PATH/../infiquetra-claude-plugins/plugins/sdlc-manager/scripts/sdlc_manager.py
 ```
 
-> If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
+If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
+Always run the script with `python3`.
 
-**IMPORTANT**: Always use `python3` (not `python`) to run the script.
+## Metric Boundaries
 
-## How Timeline Metrics Work
+| Board | Active start | Terminal statuses |
+|-------|--------------|-------------------|
+| Jeff Intent | Active | Done |
+| Asgard | Active | Done |
+| Olympus | Assigned | Done, Closed, Cancelled |
 
-The script queries `timelineItems` on GitHub issues to find `ProjectV2ItemFieldValueEvent`
-entries showing status column changes. From these events it calculates:
-
-- **Time in each column**: Timestamp of entry into column -> timestamp of exit from column
-- **Cycle time**: Time from first entry into "In Development" through "Deployed"
-- **Percentiles**: P50 (median), P85 (target benchmark), P95 (worst-case tail)
-- **WIP age**: For in-progress items, elapsed time since entering the current column
+Olympus timeline history may still include `In Progress`, `In Development`, or `Deployed`.
+The CLI reads those values for continuity, but new cards should use the current schema.
 
 ## Core Operations
 
 ### Cycle Time
 
 ```bash
-# Cycle time for all issue types over last 30 days
 python3 sdlc_manager.py metrics cycle-time --project mount-olympus
-
-# Filter by days window
-python3 sdlc_manager.py metrics cycle-time --project mount-olympus --days 14
-
-# Filter to specific issue type
+python3 sdlc_manager.py metrics cycle-time --project asgard --days 14
 python3 sdlc_manager.py metrics cycle-time --project mount-olympus --type capability
-python3 sdlc_manager.py metrics cycle-time --project mount-olympus --type enhancement
-python3 sdlc_manager.py metrics cycle-time --project mount-olympus --type defect
 ```
 
-#### Sample Output
-
-```
-Cycle Time Report — mount-olympus (last 30 days)
-
-              P50      P85      P95    Target   Status
-capability    3.2d     4.8d     7.1d   < 5d     ✓ On target
-enhancement   1.1d     1.8d     3.2d   < 2d     ✓ On target
-defect        0.4d     0.9d     1.5d   < 1d     ✓ On target
-exploration   1.5d     2.6d     3.0d   < 3d     ✓ On target
-
-Items measured: 18 (9 capability, 5 enhancement, 3 defect, 1 exploration)
-Slowest item:  #38 capability "User onboarding service" — 7.1 days
-               Bottleneck: E2E Testing (2.3 days)
-```
+Cycle time is calculated from the first active-start status to a terminal status.
 
 ### Throughput
 
 ```bash
-# Throughput over last 4 weeks (default)
 python3 sdlc_manager.py metrics throughput --project mount-olympus
-
-# Specify weeks window
-python3 sdlc_manager.py metrics throughput --project mount-olympus --weeks 8
-
-# Filter by issue type
-python3 sdlc_manager.py metrics throughput --project mount-olympus --type capability
+python3 sdlc_manager.py metrics throughput --project asgard --weeks 8
 ```
+
+Throughput counts items that reached a terminal workflow status during the reporting window.
 
 ### WIP Age
 
 ```bash
-# Current WIP age distribution (all in-progress items)
 python3 sdlc_manager.py metrics wip-age --project mount-olympus
+python3 sdlc_manager.py metrics wip-age --project jeff-intent
 ```
 
-Output shows each in-progress item, which column it is in, and how long it has been there.
-Items exceeding age thresholds are flagged.
+WIP age shows current items in active statuses and flags entries over the configured thresholds.
 
-### Per-Column Time Breakdown
+### Per-Status Time Breakdown
 
 ```bash
-# How long a specific issue spent in each column
 python3 sdlc_manager.py metrics column-time --project mount-olympus --number 42
 ```
 
-Useful for diagnosing where an individual item got stuck.
+Use this to diagnose where one card spent time.
 
-## Targets by Issue Type
+## Targets
 
 ### Cycle Time Targets (P85)
 
 | Issue Type | P85 Target | Notes |
 |------------|------------|-------|
-| Capability | < 5 days | End-to-end: In Development -> Deployed |
+| Capability | < 5 days | Active ownership through terminal status |
 | Enhancement | < 2 days | Smaller scope |
-| Defect (general) | < 1 day | Highest urgency |
+| Defect | < 1 day | Highest urgency |
 | Exploration | < 3 days | Timeboxed research |
-| Context Update | < 1 day | Documentation |
+| Context Update | < 1 day | Documentation or context maintenance |
 
-### Defect SLA Targets
+### WIP Age Thresholds
 
-| Priority | SLA | Description |
-|----------|-----|-------------|
-| Critical | 4 hours | System down, data loss, security breach |
-| High | 1 day | Major functionality broken |
-| Medium | 3 days | Minor functionality broken |
-| Low | When capacity | Cosmetic or rare edge case |
-
-### Throughput Targets (per week)
-
-| Issue Type | Target | Direction |
-|------------|--------|-----------|
-| Capabilities | 2-4 | Higher is better |
-| Enhancements | 5-10 | Higher is better |
-| Defects | < 2 | Lower is better |
-
-### WIP Age Thresholds (flag as aging)
-
-| Column | Age Threshold |
-|--------|---------------|
-| Ready | > 2 days |
-| In Development | > 5 days |
-| E2E Testing | > 1 day |
-| Deployment Ready | > 2 days |
-
-### Flow Efficiency Target
-
-**Target**: > 50%
-
-**Formula**: (time in In Development + time in E2E Testing) / total cycle time
-
-Active columns are In Development and E2E Testing. Waiting columns are Ready and
-Deployment Ready. High wait time in Deployment Ready typically indicates deployment
-window constraints.
+| Board | Status | Flag if age > |
+|-------|--------|---------------|
+| Jeff Intent / Asgard | Active | 3 days |
+| Jeff Intent / Asgard | Verify | 3 days |
+| Olympus | Ready | 2 days |
+| Olympus | Planning | 2 days |
+| Olympus | Assigned | 5 days |
+| Olympus | In Progress | 5 days |
+| Olympus | In Review | 2 days |
 
 ## Natural Language Examples
 
 **"What's our cycle time for capabilities this month?"**
 -> `metrics cycle-time --project mount-olympus --type capability --days 30`
 
-**"How many capabilities did we ship last week?"**
--> `metrics throughput --project mount-olympus --weeks 1 --type capability`
+**"How many items did Asgard complete recently?"**
+-> `metrics throughput --project asgard --weeks 4`
 
-**"How old are our in-progress items?"**
+**"How old are our active items?"**
 -> `metrics wip-age --project mount-olympus`
 
-**"How long has issue #42 been in development?"**
+**"How long has issue #42 been active?"**
 -> `metrics column-time --project mount-olympus --number 42`
-
-**"Are we meeting our targets?"**
--> Run `metrics cycle-time` and `metrics throughput`, compare to targets above
-
-**"Are any defects violating SLA?"**
--> `metrics wip-age --project mount-olympus` — look for defects flagged as aging
-
-**"Compare this month to last month"**
--> `metrics cycle-time --project mount-olympus --days 30` vs. `--days 60` (compare first/second half)
 
 ## Interpreting Results
 
-### When Cycle Time is Over Target
+### When Cycle Time Is Over Target
 
-1. **Run column-time on slow items** to find where they got stuck
-2. **Check E2E Testing aging** — manual testing is often the bottleneck
-3. **Check Deployment Ready aging** — deployment window delays inflate cycle time
-4. **Look for blocked items** — blocked label can stall flow for days
-5. **Check WIP in In Development** — high WIP creates context switching, slows everything
+1. Run `metrics column-time` on slow items to find the status consuming the most time.
+2. Check WIP age for active or review bottlenecks.
+3. Look for `blocked` or `Needs Question` state.
+4. Check whether WIP limits are being respected.
+5. Separate deployment delay from work status; deployment evidence belongs to deployment fields.
 
-### When Throughput is Low
+### When Throughput Is Low
 
-1. **Check WIP in In Development** — if near or over limit, team may be stuck
-2. **Check In Development aging** — items not completing drive low throughput
-3. **Check Ready column** — if empty, team may lack prioritized work
-4. **Look at Objective completion** — are all capabilities tied to a blocked Objective?
+1. Check whether active statuses are at or over WIP.
+2. Look for aging items that are not moving to review or verification.
+3. Check whether `Ready` is empty or poorly shaped.
+4. Confirm the board is the right one: raw intent should not be counted as Olympus execution.
 
-### When WIP Age is High
+### When WIP Age Is High
 
-1. **Identify the specific items** and ask about blockers in standup
-2. **Consider swarming** — additional developers on a stuck item can unblock it
-3. **Check for external blockers** — dependencies on other teams or systems
-4. **Escalate per policy**: blocked > 4 hours -> tech lead; blocked > 1 day -> EM
-
-### When Flow Efficiency is Low (< 50%)
-
-1. **High wait in Deployment Ready** -> deployment scheduling delays
-2. **High wait in Ready** -> context switching or team not pulling promptly
-3. **Multiple handoffs** -> check if items are bouncing between columns
-4. **Blocked time** -> blocked items count as wait time, reducing efficiency
-
-## Workflow Examples
-
-### Weekly Metrics Review
-
-```bash
-# Run for mount-olympus board
-python3 sdlc_manager.py metrics cycle-time --project mount-olympus --days 7
-python3 sdlc_manager.py metrics throughput --project mount-olympus --weeks 4
-python3 sdlc_manager.py metrics wip-age --project mount-olympus
-```
-
-Compare each metric to the targets table. Share summary in #mount-olympus Discord channel.
-
-### SLA Check for Defects
-
-```bash
-# Get all in-progress items (includes defects with their age)
-python3 sdlc_manager.py metrics wip-age --project mount-olympus
-
-# For any defect flagged as aging, check full timeline
-python3 sdlc_manager.py metrics column-time --project mount-olympus --number <N>
-```
-
-Cross-reference priority label (`critical`/`high-priority`/`medium-priority`) against SLA targets above.
-
-### Diagnosing a Bottleneck
-
-```bash
-# 1. Check which column has the most aging items
-python3 sdlc_manager.py metrics wip-age --project mount-olympus
-
-# 2. Check cycle time breakdown to see which column adds the most time
-python3 sdlc_manager.py metrics cycle-time --project mount-olympus --days 30
-
-# 3. Drill into specific slow items
-python3 sdlc_manager.py metrics column-time --project mount-olympus --number <N>
-```
+1. Identify the specific cards and ask what decision, context, or reviewer is missing.
+2. Move truly blocked cards to the right pause state.
+3. Swarm or split work that is too large.
 
 ## Reference Documents
 
-- `references/metrics-targets.md` — Complete targets, definitions, and interpretation guide
-- `skills/sdlc-board/references/kanban-workflow.md` — Column definitions and WIP limits
+- `references/metrics-targets.md` - Complete targets, definitions, and interpretation guide
+- `skills/sdlc-board/references/kanban-workflow.md` - Board workflows and WIP limits

--- a/plugins/sdlc-manager/skills/sdlc-metrics/references/metrics-targets.md
+++ b/plugins/sdlc-manager/skills/sdlc-metrics/references/metrics-targets.md
@@ -1,160 +1,107 @@
 # SDLC Flow Metrics Reference
 
-Quick reference for Infiquetra Mount Olympus Kanban flow metrics: definitions, targets, and
-interpretation guidance. Source of truth: `$INFIQUETRA_SDLC_PATH/docs/process/kanban-workflow.md`
-and `$INFIQUETRA_SDLC_PATH/docs/process/issue-types.md`.
+Quick reference for Infiquetra board-flow metrics. Source of truth:
+`$INFIQUETRA_SDLC_PATH/config/sdlc-schema.json`,
+`$INFIQUETRA_SDLC_PATH/docs/process/metrics-guide.md`, and
+`$INFIQUETRA_SDLC_PATH/docs/process/kanban-workflow.md`.
 
 ---
 
 ## Cycle Time
 
-**Definition**: Time from first entry into "In Development" to when the item reaches "Deployed".
+**Definition**: Time from first active ownership to terminal workflow status.
 
-**Measurement**: P50 (median), P85 (target benchmark), P95 (worst-case tail), via GitHub
-timeline events (`ProjectV2ItemFieldValueEvent` on status field).
+| Board | Start | Terminal |
+|-------|-------|----------|
+| Jeff Intent | Active | Done |
+| Asgard | Active | Done |
+| Olympus | Assigned | Done, Closed, Cancelled |
 
-**Note**: Cycle time measures In Development entry -> Deployed. It does not include time
-sitting in Ready (that is lead time / wait time, tracked separately via WIP age).
+Olympus history may include `In Progress`, `In Development`, or `Deployed`; tooling may
+include those for historical calculations but should not create new movement with those names.
+
+**Measurement**: P50, P85, and P95 via GitHub timeline events
+(`ProjectV2ItemFieldValueEvent` on the Status field).
 
 ### Targets by Issue Type
 
-| Type | P85 Target | SLA (if applicable) |
-|------|------------|---------------------|
+| Type | P85 Target | SLA if applicable |
+|------|------------|-------------------|
 | Capability | < 5 days | -- |
 | Enhancement | < 2 days | -- |
-| Defect (general) | < 1 day | -- |
-| Defect (Critical) | -- | 4 hours |
-| Defect (High) | -- | 1 day |
-| Defect (Medium) | -- | 3 days |
-| Defect (Low) | -- | When capacity |
+| Defect | < 1 day | Critical: 4 hours; high: 1 day; medium: 3 days |
 | Exploration | < 3 days | -- |
 | Context Update | < 1 day | -- |
-
-### Typical Column Durations (reference, not targets)
-
-| Column | Capability | Enhancement | Defect |
-|--------|------------|-------------|--------|
-| In Development | 3-12 days | 1-4 days | 2 hrs - 1 day |
-| E2E Testing | 4-8 hours | 1-4 hours | 30 min - 2 hours |
-| Deployment Ready | 0-2 days | 0-2 days | 0-2 days |
 
 ---
 
 ## Throughput
 
-**Definition**: Number of work items moved to "Deployed" per week.
+**Definition**: Number of work items moved to a terminal workflow status per week.
 
-**Measurement**: Count of completed items, tracked by issue type, rolling 4-week average.
+**Use**: Capacity planning, delivery forecasting, and trend analysis.
 
-**Use**: Capacity planning, delivery forecasting, trend analysis.
-
-### Targets by Issue Type (per week, team of 5)
-
-| Type | Target | Direction |
-|------|--------|-----------|
-| Capabilities | 2-4 | Higher is better |
-| Enhancements | 5-10 | Higher is better |
-| Defects | < 2 | Lower is better (indicates quality) |
-| Explorations | 1-2 | Varies |
-| Context Updates | 3-5 | Varies |
+| Board | Counted terminal statuses |
+|-------|---------------------------|
+| Jeff Intent | Done |
+| Asgard | Done |
+| Olympus | Done, Closed, Cancelled |
 
 ---
 
 ## WIP Age
 
-**Definition**: How long current in-progress items have been in their column.
+**Definition**: How long current active items have been in their current Status.
 
-**Measurement**: Days since item entered its current column, calculated for all items
-not yet in Deployed. 85th percentile age by column.
+**Use**: Identify stale work, trigger escalation, and surface bottlenecks.
 
-**Use**: Identify stale work, trigger escalations, surface bottlenecks.
-
-### Age Thresholds (flag as aging)
-
-| Column | Threshold | Action When Exceeded |
-|--------|-----------|----------------------|
-| Ready | > 2 days | Review in standup — is it truly prioritized? |
-| In Development | > 5 days | Check for blockers, consider swarming |
-| E2E Testing | > 1 day | Check for test failures or environment issues |
-| Deployment Ready | > 2 days | Check deployment window availability |
+| Board | Status | Threshold |
+|-------|--------|-----------|
+| Jeff Intent | Active, Verify | > 3 days |
+| Asgard | Active, Verify | > 3 days |
+| Olympus | Ready | > 2 days |
+| Olympus | Planning | > 2 days |
+| Olympus | Assigned | > 5 days |
+| Olympus | In Progress | > 5 days |
+| Olympus | In Review | > 2 days |
 
 ---
 
 ## Flow Efficiency
 
-**Definition**: Active time divided by total cycle time, expressed as a percentage.
+**Definition**: Active work time divided by total cycle time.
 
-**Formula**: (time in In Development + time in E2E Testing) / total cycle time
+For Olympus, active work is primarily `Assigned` plus `In Review`. For intent-flow boards,
+active work is `Active` plus `Verify`. `Ready`, `Shaping`, and `Planning` are wait or
+preparation states unless a card's evidence shows otherwise.
 
-**Target**: > 50%
-
-**Active columns**: In Development, E2E Testing (team is doing work)
-**Wait columns**: Ready, Deployment Ready (item is queued, not being actively worked)
-
-**Example**:
-```
-Item total cycle time: 10 days
-- In Development: 5 days (active)
-- E2E Testing: 1 day (active)
-- Deployment Ready: 4 days (wait)
-
-Flow Efficiency = (5 + 1) / 10 = 60%  -- Above target
-```
+Target: greater than 50%.
 
 ---
 
 ## How to Read Metrics
 
-### When cycle time is over target
+### When Cycle Time Is Over Target
 
-1. Run `metrics column-time` on slow items to find which column consumed the most time
-2. Check E2E Testing aging — manual testing is often a bottleneck for teams new to this process
-3. Check Deployment Ready aging — deployment window constraints inflate cycle time
-   without reflecting development speed
-4. Look for items with the `blocked` label — blocked time counts against cycle time
-5. High WIP in In Development causes context switching, which slows all items down
-6. Consider: is this a one-off or a trend? Use a longer `--days` window to distinguish noise
-   from systemic issues
+1. Run `metrics column-time` on slow items.
+2. Check WIP age for active or review bottlenecks.
+3. Look for `Blocked`, `Needs Question`, or missing Jeff decision signals.
+4. Confirm deployment delay is not being misread as workflow delay.
+5. Use a longer `--days` window to separate noise from a trend.
 
-### When throughput is low
+### When Throughput Is Low
 
-1. Check WIP limits — if In Development is at or over limit, team can't pull new work to complete
-2. Look at In Development aging — items not finishing drive low throughput
-3. Check if Ready is empty — if there's no prioritized work, throughput will drop
-4. Look at defect rate — high defect volume can crowd out Capability and Enhancement delivery
-5. Consider Capability size — very large capabilities reduce weekly throughput even if flow is healthy
+1. Check WIP limits.
+2. Look at active-status aging.
+3. Check if `Ready` is empty or poorly shaped.
+4. Look at defect rate and unplanned work.
+5. Consider whether large capabilities should be split.
 
-### When WIP age is high
+### When WIP Age Is High
 
-1. Identify the specific items and discuss in standup
-2. Add `blocked` label immediately if blocked by external dependency
-3. Consider swarming — pair or bring additional developers to clear the item
-4. Escalate per policy:
-   - Blocked > 4 hours -> tech lead
-   - Blocked > 1 day -> engineering manager
-5. If item is not blocked but slow, check In Development WIP limits
-
-### When flow efficiency is low (< 50%)
-
-1. High wait in Deployment Ready -> check deployment process and scheduling
-2. High wait in Ready -> items are being created faster than the team is pulling them
-3. Items bouncing between columns -> check why items are being moved backwards
-4. Blocked time -> investigate root causes and track frequency
-
----
-
-## Defect SLA Escalation Policies
-
-| Condition | Action | Timeframe |
-|-----------|--------|-----------|
-| Critical defect created | Pull directly to In Development, skip Ready | Immediately |
-| Critical defect not fixed | Escalate to EM and stakeholders | 2 hours |
-| High defect aging > 1 day | Flag in standup, escalate to tech lead | 24 hours |
-| Medium defect aging > 3 days | Review priority in standup | 72 hours |
-| Any defect in E2E > 4 hours | Check for test environment issues | 4 hours |
-| Any item blocked | Add `blocked` label, notify team in Discord | Immediately |
-| Item blocked > 4 hours | Escalate to tech lead | 4 hours |
-| Item blocked > 1 day | Escalate to engineering manager | 24 hours |
+1. Identify the specific cards and discuss them in board review.
+2. Add or confirm `blocked` / `Needs Question` state where appropriate.
+3. Swarm, split, or move the card back to shaping if the issue is not actually ready.
 
 ---
 
@@ -164,8 +111,6 @@ Flow Efficiency = (5 + 1) / 10 = 60%  -- Above target
 |--------|---------|----------|
 | Cycle time all types | `metrics cycle-time --project mount-olympus` | `--days N` |
 | Cycle time by type | `metrics cycle-time --project mount-olympus --type capability` | `--type` |
-| Throughput | `metrics throughput --project mount-olympus` | `--weeks N` |
-| WIP age | `metrics wip-age --project mount-olympus` | -- |
-| Column breakdown | `metrics column-time --project mount-olympus --number 42` | `--number` |
-
-Project: `mount-olympus`
+| Throughput | `metrics throughput --project asgard` | `--weeks N` |
+| WIP age | `metrics wip-age --project jeff-intent` | -- |
+| Status breakdown | `metrics column-time --project mount-olympus --number 42` | `--number` |

--- a/plugins/sdlc-manager/skills/sdlc-milestones/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-milestones/SKILL.md
@@ -1,52 +1,42 @@
 ---
 name: sdlc-milestones
 description: |
-  Manage GitHub Milestones for Infiquetra Objectives. Creates, lists, and tracks progress on
-  milestones across Infiquetra repositories. Handles the full Objective lifecycle: creation,
-  Capability linking, progress tracking, risk assessment, cross-repo coordination, and completion.
-  Objectives are tracked as both GitHub Milestones and Beads parent tasks.
+  Manage GitHub Milestones for Infiquetra Objectives. Creates, lists, links, and tracks
+  milestone progress when an Objective needs due-date rollup across one or more repos.
 when_to_use: |
   Use this skill when the user wants to:
 
   Creating objectives and milestones:
-  - "create an objective for the platform launch", "set up a new objective",
-    "we're starting a new pilot program", "create a milestone for this objective"
-  - "let's set up the v1.0 release milestone"
-  - "create a program milestone for Q1 KR1"
+  - "create an objective for the platform launch", "set up a new objective"
+  - "create a milestone for this objective", "set up the v1.0 release milestone"
 
   Progress and status:
-  - "how's the platform-launch going", "objective progress",
-    "milestone completion", "what's the status of the platform MVP"
-  - "how many capabilities have been deployed toward this objective"
-  - "are we on track for the release date"
+  - "objective progress", "milestone completion", "are we on track for the release date"
 
   Milestone management:
-  - "when is this objective due", "list all open milestones",
-    "show me objectives for infiquetra-core"
+  - "when is this objective due", "list all open milestones"
   - "which milestones are at risk", "show upcoming deadlines"
 
   Linking issues to objectives:
-  - "add this capability to the platform-launch objective",
-    "link issue #42 to the platform MVP milestone",
-    "assign this to the current objective"
-
-  Completion and review:
-  - "mark this objective as complete", "close the milestone",
-    "show me all active objectives", "which objectives are at risk"
+  - "link issue #42 to the platform MVP milestone"
+  - "assign this to the current objective"
 ---
 
 # SDLC Milestones
 
-Manage GitHub Milestones for Infiquetra Objectives. Covers the full Objective lifecycle from
-creation through completion, including progress tracking and cross-repo coordination.
+Manage GitHub Milestones as an optional Objective progress surface. The canonical hierarchy
+is still Initiative -> Objective -> work item, with Initiative and Objective represented as
+project fields when the board exposes them. Milestones are useful for repo-level due dates,
+GitHub progress rollups, and release coordination.
 
 ## Script Location
 
-```
+```bash
 $INFIQUETRA_SDLC_PATH/../infiquetra-claude-plugins/plugins/sdlc-manager/scripts/sdlc_manager.py
 ```
 
-> If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
+If `$INFIQUETRA_SDLC_PATH` is unset, use `~/workspace/infiquetra/infiquetra-sdlc` as the default base path.
+Always run the script with `python3`.
 
 ## Core Operations
 
@@ -55,260 +45,123 @@ $INFIQUETRA_SDLC_PATH/../infiquetra-claude-plugins/plugins/sdlc-manager/scripts/
 ```bash
 python3 sdlc_manager.py milestones create \
   --repo infiquetra-core \
-  --title "Pilot: Platform Launch" \
+  --title "Pilot: Platform Launch (2026-04-15)" \
   --due-date 2026-04-15 \
-  --description "Platform launch pilot — validate core workflows with early adopters"
+  --description "Validate core workflows with early adopters"
 ```
-
-The `--title` should follow the naming convention (see below). The `--description` can be brief;
-full details live in the Objective issue.
 
 ### List Milestones
 
 ```bash
-# List open milestones
 python3 sdlc_manager.py milestones list --repo infiquetra-core
-
-# List all (open and closed)
 python3 sdlc_manager.py milestones list --repo infiquetra-core --state all
-
-# List closed milestones
 python3 sdlc_manager.py milestones list --repo infiquetra-core --state closed
 ```
 
 ### Track Progress
 
 ```bash
-# Show completion % for a specific milestone
 python3 sdlc_manager.py milestones progress --repo infiquetra-core --milestone 3
 ```
 
-Output shows: total issues, open issues, closed issues, completion %, and due date.
-Issues are from all types linked to the milestone (Capabilities, Enhancements, Defects).
+Progress uses GitHub's open/closed issue counts for issues linked to that milestone.
 
-### Link Issue to Milestone
+### Link Issue To Milestone
 
 ```bash
-# Link a capability to its parent objective milestone
 python3 sdlc_manager.py milestones link \
   --repo infiquetra-core \
   --issue 42 \
   --milestone 3
 ```
 
-Also do this via gh CLI:
+Equivalent gh CLI:
+
 ```bash
-gh issue edit 42 --repo Infiquetra/infiquetra-core --milestone "Pilot: Platform Launch"
+gh issue edit 42 --repo infiquetra/infiquetra-core --milestone "Pilot: Platform Launch (2026-04-15)"
 ```
 
 ## Naming Convention
 
-### Milestone Title Format
+Milestone title:
 
-```
+```text
 {Type}: {Name} ({YYYY-MM-DD})
 ```
 
-| Type | Example Milestone Title |
-|------|------------------------|
+| Type | Example |
+|------|---------|
 | Pilot | `Pilot: Platform Launch (2026-04-15)` |
 | MVP | `MVP: Core Integration (2026-02-28)` |
 | Release | `Release: Olympus v1.0 (2026-05-30)` |
 | Program | `Program: Q1 KR1 - User Adoption (2026-03-31)` |
 
-### Label Format
-
-The Objective issue gets a label `objective:{short-kebab-case}`:
-
-| Milestone Title | Label |
-|----------------|-------|
-| `Pilot: Platform Launch (2026-04-15)` | `objective:platform-launch` |
-| `Release: Olympus v1.0 (2026-05-30)` | `objective:olympus-v1` |
-| `MVP: Core Integration (2026-02-28)` | `objective:core-integration` |
-| `Program: Q1 KR1 - User Adoption (2026-03-31)` | `objective:q1-kr1` |
-
-## Beads/Dolt Integration
-
-Objectives are tracked in two systems:
-
-1. **GitHub Milestones** — the backing store for progress tracking and issue linking
-2. **Beads parent tasks** — the coordination layer for Mount Olympus agents
-
-`bd` is the Beads/Dolt CLI for structured agent task coordination (see `docs/tools/index.md` for install instructions).
-
-When creating an Objective:
-```bash
-# Create the Beads parent task
-bd ready <objective-task-id>
-
-# Child capabilities are Beads subtasks
-bd claim <capability-task-id>  # An agent claims the capability
-bd update <capability-task-id> in-progress
-bd complete <capability-task-id>  # Syncs to GitHub Issue close
-```
-
-Beads tasks sync to GitHub Issues automatically. When a Beads subtask is completed,
-the corresponding GitHub Issue is closed and the Milestone completion % updates.
-
 ## Objective Creation Workflow
 
-When a user says "create an objective", run through these steps:
+1. Create the Objective issue.
+2. Create the GitHub Milestone if due-date rollup is useful.
+3. Add the Objective issue to the target board.
+4. Set `Initiative`, `Objective`, and `Status` project fields when those fields exist.
+5. Create child work items just in time.
+6. Link child issues as native GitHub sub-issues and, when useful, to the milestone.
 
-### Step 1: Create the Objective Issue
-
-```bash
-python3 sdlc_manager.py issue create --repo <repo> --type objective
-```
-
-Gather during template:
-- Objective Name (descriptive, e.g., "Platform Launch MVP")
-- Objective Type: Pilot / MVP / Release / Program
-- Target Date (YYYY-MM-DD)
-- Success Criteria (testable checkboxes)
-- Included Capabilities list (even if not yet created)
-- Stakeholders
-- Risk Level
-
-### Step 2: Create the GitHub Milestone
+Example field update:
 
 ```bash
-python3 sdlc_manager.py milestones create \
-  --repo <repo> \
-  --title "{Type}: {Name}" \
-  --due-date {YYYY-MM-DD} \
-  --description "{Brief description}"
+python3 sdlc_manager.py flow set-field --project mount-olympus \
+  --repo <repo> --number <N> \
+  --field Objective --option "<Objective name>"
 ```
-
-Note the milestone number returned — you'll need it for linking.
-
-### Step 3: Apply Labels to the Objective Issue
-
-```bash
-# Apply objective label
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "objective:{short-name}"
-
-# Apply initiative label if applicable
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "initiative:{name}"
-```
-
-### Step 4: Link the Objective Issue to the Milestone
-
-```bash
-python3 sdlc_manager.py milestones link --repo <repo> --issue <N> --milestone <M>
-```
-
-### Step 5: Add to Project Board and Sync Fields
-
-```bash
-# Add to project board
-python3 sdlc_manager.py board add --repo <repo> --number <N>
-
-# Sync labels to project fields
-python3 sdlc_manager.py labels sync-fields --repo <repo> --number <N>
-```
-
-### Step 6: Create Capabilities
-
-Create individual Capability issues for the work inside the Objective.
-For each capability:
-1. `python3 sdlc_manager.py issue create --repo <repo> --type capability`
-2. Apply `objective:{name}` and `initiative:{name}` labels
-3. Link to the milestone: `milestones link --repo <repo> --issue <N> --milestone <M>`
-4. Add to project board: `board add --repo <repo> --number <N>`
 
 ## Risk Assessment
 
-Flag objectives as at-risk when:
-- Due date is **< 7 days away** AND milestone completion is **< 80%**
-- Any Capability in the milestone is **blocked**
-- Capabilities are **aging in development** (> 3 days in In Development)
+Flag Objectives as at-risk when:
 
-Check progress and calculate risk:
+- Due date is less than 7 days away and milestone completion is below 80%.
+- Any linked work item is blocked.
+- Linked work is aging in `Assigned`, `In Review`, `Active`, or `Verify`.
+- A required Jeff decision is still in `Needs Question` or equivalent state.
+
+Check progress:
+
 ```bash
 python3 sdlc_manager.py milestones progress --repo <repo> --milestone <N>
 ```
 
-When flagging at-risk: surface the due date, current completion %, and identify which
-specific issues are blocking progress.
-
 ## Cross-Repo Coordination
 
-For Objectives that span multiple repositories:
+For Objectives spanning multiple repositories:
 
-1. **Create identical milestones in each affected repo**:
-   ```bash
-   python3 sdlc_manager.py milestones create \
-     --repo infiquetra-core \
-     --title "Pilot: Platform Launch (2026-04-15)" \
-     --due-date 2026-04-15
-
-   python3 sdlc_manager.py milestones create \
-     --repo infiquetra-auth \
-     --title "Pilot: Platform Launch (2026-04-15)" \
-     --due-date 2026-04-15
-   ```
-
-2. **Apply consistent labels across all repos** — same `objective:*` and `initiative:*` labels
-
-3. **Link each repo's Capability issues to its local milestone**
-
-4. **Track aggregate progress** by checking progress across all repos:
-   ```bash
-   python3 sdlc_manager.py milestones progress --repo infiquetra-core --milestone <M>
-   python3 sdlc_manager.py milestones progress --repo infiquetra-auth --milestone <M>
-   ```
-
-## Natural Language Examples
-
-**"Create an objective for the platform launch"**
--> Run `issue create --type objective`, then `milestones create`, apply labels, link issue to milestone
-
-**"How's the platform launch going?"**
--> Find the milestone number, run `milestones progress --repo <repo> --milestone <N>`
-
-**"Add capability #42 to the platform-launch objective"**
--> Find milestone number for `objective:platform-launch`, then `milestones link --repo <repo> --issue 42 --milestone <M>`
-
-**"Show me all active objectives"**
--> `milestones list --repo <repo>` for each active repo; look for open milestones
-
-**"Which objectives are at risk?"**
--> Run progress for each open milestone, flag those with < 80% completion and < 7 days remaining
-
-**"Mark the platform launch as complete"**
--> Close the GitHub milestone via gh CLI:
-   ```bash
-   gh api repos/Infiquetra/<repo>/milestones/<N> -X PATCH -f state=closed
-   ```
-
-**"Create a release milestone for Olympus v1.0"**
--> `milestones create --repo infiquetra-core --title "Release: Olympus v1.0" --due-date 2026-05-30`
+1. Create matching milestone titles in each affected repo when milestone rollup is useful.
+2. Use the same Objective project field option across boards where available.
+3. Link each repo's work items to its local milestone.
+4. Use native sub-issues for parent/child structure.
+5. Track aggregate progress through project fields plus per-repo milestone progress.
 
 ## Objective Completion Criteria
 
 An Objective is complete when:
-- All Capabilities are in **Deployed** status on the board
-- Success criteria in the Objective issue are validated
-- GitHub Milestone is closed
-- Beads parent task is marked complete (`bd complete <objective-task-id>`)
 
-Completion checklist:
-1. Confirm all linked Capabilities are Deployed
-2. Review success criteria — mark each as complete
-3. Close milestone: `gh api repos/Infiquetra/<repo>/milestones/<N> -X PATCH -f state=closed`
-4. Update Objective issue with completion notes and close it
-5. Notify stakeholders via #mount-olympus Discord channel
+- Linked work items are in a terminal workflow status (`Done`, `Closed`, or equivalent).
+- Success criteria in the Objective issue are validated.
+- No critical/high defects remain open against the Objective.
+- The GitHub Milestone is closed if one was created.
+- The Objective issue has completion notes and is closed.
 
-## Key Behaviors
+## Natural Language Examples
 
-- **Always create a milestone when creating an Objective** — the milestone is how progress is tracked
-- **Milestone title includes the date** — format: `{Type}: {Name} ({YYYY-MM-DD})`
-- **Issue label uses short-name** — format: `objective:{short-kebab-case}` (no date)
-- **Cross-repo objectives** need milestones in every affected repo with identical titles
-- **At-risk flag** triggers at < 7 days + < 80% completion — surface proactively
-- **Capabilities are linked just-in-time** — 2-3 weeks before work starts, not all upfront
-- **Beads parent tasks** mirror Objectives for agent coordination
+**"Create an objective for the platform launch"**
+-> Create the Objective issue, create a milestone if useful, add to board, and set fields.
+
+**"How's the platform launch going?"**
+-> Find the milestone number and run `milestones progress`.
+
+**"Add capability #42 to the platform-launch objective"**
+-> Set the Objective field, link as a sub-issue, and link to the milestone if one exists.
+
+**"Which objectives are at risk?"**
+-> Run progress for each open milestone and check linked board status / WIP age.
 
 ## Reference Documents
 
-- `references/objective-workflow.md` — Complete Objective lifecycle, types, sizing, and examples
+- `references/objective-workflow.md` - Objective lifecycle, types, sizing, and examples

--- a/plugins/sdlc-manager/skills/sdlc-milestones/references/objective-workflow.md
+++ b/plugins/sdlc-manager/skills/sdlc-milestones/references/objective-workflow.md
@@ -1,279 +1,133 @@
 # Objective Workflow Reference
 
-Complete reference for the Objective lifecycle in the Infiquetra AI-Native SDLC.
-Synthesized from `docs/process/work-hierarchy.md` and `docs/process/issue-types.md`.
+Complete reference for Objective lifecycle in the Infiquetra SDLC. Source of truth:
+`$INFIQUETRA_SDLC_PATH/docs/process/work-hierarchy.md`,
+`$INFIQUETRA_SDLC_PATH/docs/process/board-topology.md`, and
+`$INFIQUETRA_SDLC_PATH/config/sdlc-schema.json`.
 
 ---
 
-## What is an Objective?
+## What Is An Objective?
 
-An **Objective** is a time-bounded deliverable set with a specific target date. It coordinates
-multiple Capabilities toward a common goal and provides the coordination layer between
-strategic Initiatives and day-to-day Capability work.
-
-**Objectives answer**: "What are we delivering by this date?"
+An Objective is a time-bounded deliverable set with a target date. It coordinates multiple
+work items toward a common outcome.
 
 | Attribute | Value |
 |-----------|-------|
-| Duration | 2-8 weeks |
-| Scope | Coordinated set of Capabilities delivering business value |
-| Work Happens Here | No — work happens in Capabilities |
-| GitHub Construct | GitHub Milestone + Label (`objective:{name}`) |
-| Beads Construct | Parent task with child capability subtasks |
-
-**Key principle**: Objectives are for grouping and reporting only. They do not decompose into
-tasks or get assigned to developers. Work flows at the Capability level.
-
----
-
-## The Three-Tier Model
-
-```
-INITIATIVE
-  Strategic objective spanning quarters (OKRs, Programs)
-  GitHub: Label (initiative:{name}) + Project View
-  |
-  +-- OBJECTIVE  <--- This document
-  |     Time-bounded deliverable (Pilots, MVPs, Releases)
-  |     GitHub: Milestone + Label (objective:{name})
-  |     Beads: Parent task
-  |
-  +-- CAPABILITY (primary unit of work)
-        1-4 weeks, deployable, flows through Kanban
-        GitHub: Issue
-        Beads: Subtask (claimable by agents)
-```
-
-Initiatives and Objectives are for grouping and reporting. Capabilities are for doing.
+| Duration | Usually 2-8 weeks |
+| Scope | Coordinated set of Capabilities, Enhancements, Defects, Explorations, or Context Updates |
+| Work happens here | No - work happens on child issues |
+| GitHub constructs | Objective issue, project field option, native sub-issues |
+| Optional construct | GitHub Milestone for repo-level due-date rollup |
 
 ---
 
 ## Objective Types
 
-| Type | When to Use | Naming Example |
-|------|-------------|----------------|
-| **Pilot** | Customer validation with specific participants and success criteria | `Pilot: Platform Launch (2026-04-15)` |
-| **MVP** | Minimum viable product for initial launch | `MVP: Core Integration (2026-02-28)` |
-| **Release** | Versioned delivery requiring coordinated feature rollout | `Release: Olympus v1.0 (2026-05-30)` |
-| **Program** | OKR milestone or strategic initiative phase | `Program: Q1 KR1 - User Adoption (2026-03-31)` |
+| Type | When to use | Example |
+|------|-------------|---------|
+| Pilot | Customer or operator validation with explicit success criteria | `Pilot: Platform Launch (2026-04-15)` |
+| MVP | Minimum viable product or service slice | `MVP: Core Integration (2026-02-28)` |
+| Release | Versioned delivery requiring coordination | `Release: Olympus v1.0 (2026-05-30)` |
+| Program | OKR or strategic initiative phase | `Program: Q1 KR1 - User Adoption (2026-03-31)` |
 
 ---
 
-## Naming Conventions
+## Creation Workflow
 
-### GitHub Milestone Title
-
-Format: `{Type}: {Name} ({YYYY-MM-DD})`
-
-The date is included in the milestone title for quick scanning in GitHub's milestone list.
-
-```
-Pilot: Platform Launch (2026-04-15)
-MVP: Core Integration (2026-02-28)
-Release: Olympus v1.0 (2026-05-30)
-Program: Q1 KR1 - User Adoption (2026-03-31)
-```
-
-### GitHub Label
-
-Format: `objective:{short-kebab-case}` (no date — labels are for filtering)
-
-```
-objective:platform-launch
-objective:core-integration
-objective:olympus-v1
-objective:q1-kr1
-```
-
-### Objective Issue Title
-
-Format: `[OBJECTIVE] {Name}` (template auto-prepends `[OBJECTIVE] `)
-
-```
-[OBJECTIVE] Platform Launch MVP
-[OBJECTIVE] Core Integration
-[OBJECTIVE] Olympus v1.0 Release
-[OBJECTIVE] Q1 KR1 - User Adoption
-```
-
----
-
-## Objective Sizing Guide
-
-Objectives typically contain **3-10 Capabilities**:
-
-| Size | Duration | Capabilities | Examples |
-|------|----------|--------------|---------|
-| **Small** | 2-4 weeks | 3-5 | Limited-scope pilot, focused MVP |
-| **Medium** | 4-6 weeks | 5-8 | Standard MVP or minor release |
-| **Large** | 6-8 weeks | 8-10 | Major release, program milestone |
-
-If > 10 Capabilities: consider breaking into multiple Objectives or extending the timeline.
-The goal is a coherent deliverable set, not an exhaustive backlog.
-
----
-
-## Creation Workflow (Step by Step)
-
-Typically performed during quarterly planning or when a new time-bounded deliverable is identified.
-
-### 1. Create the Objective Issue
+### 1. Create The Objective Issue
 
 ```bash
 python3 sdlc_manager.py issue create --repo <repo> --type objective
 ```
 
-Fill in the template:
-- **Objective Name**: Descriptive (e.g., "Platform Launch MVP")
-- **Objective Type**: Pilot / MVP / Release / Program
-- **Target Date**: Specific date in YYYY-MM-DD
-- **Success Criteria**: Measurable, testable checkboxes
-- **Included Capabilities**: Preliminary list (can add more later)
-- **Stakeholders**: Business Owner, Tech Lead, External contacts
-- **Risk Level**: Overall delivery risk assessment
+Capture:
 
-### 2. Create the GitHub Milestone
+- Objective name
+- Objective type
+- Target date
+- Success criteria
+- Included or expected child work
+- Risks and explicit non-goals
+
+### 2. Create A Milestone When Useful
 
 ```bash
 python3 sdlc_manager.py milestones create \
   --repo <repo> \
-  --title "Pilot: Platform Launch" \
+  --title "Pilot: Platform Launch (2026-04-15)" \
   --due-date 2026-04-15 \
-  --description "Validate core workflows with 5 early adopters"
+  --description "Validate core workflows with early adopters"
 ```
 
-Record the milestone number returned (e.g., `#3`).
+Use milestones when a repo-level due date and GitHub progress rollup help. Skip them for
+lightweight or exploratory Objectives where the Objective field and sub-issue tree are enough.
 
-### 3. Create the Beads Parent Task
-
-`bd` is the Beads/Dolt CLI for structured agent task coordination (see `docs/tools/index.md` for install instructions).
-
-```bash
-bd ready objective-platform-launch
-```
-
-This creates a parent task in Beads that child capability tasks will link to.
-
-### 4. Apply Labels to the Objective Issue
-
-```bash
-# Primary objective label
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "objective:platform-launch"
-
-# Parent initiative label (if applicable)
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "initiative:olympus-v1"
-```
-
-### 5. Link Objective Issue to Milestone
-
-```bash
-python3 sdlc_manager.py milestones link \
-  --repo <repo> \
-  --issue <N> \
-  --milestone <M>
-```
-
-### 6. Add to Project Board and Sync Fields
+### 3. Add To Board And Set Fields
 
 ```bash
 python3 sdlc_manager.py board add --repo <repo> --number <N>
-python3 sdlc_manager.py labels sync-fields --repo <repo> --number <N>
+python3 sdlc_manager.py flow set-field --project mount-olympus \
+  --repo <repo> --number <N> \
+  --field Objective --option "<Objective name>"
 ```
 
----
+Field helpers discover live board fields and fail with available options when a field or
+option is missing.
 
-## Execution Workflow
+### 4. Create Child Work Just In Time
 
-How Capabilities flow toward the Objective during the 2-8 week window.
-
-### Capability Creation (Just-in-Time)
-
-Create Capabilities 2-3 weeks before work starts, not all upfront. For each Capability:
+For each child item:
 
 ```bash
-# Create capability
 python3 sdlc_manager.py issue create --repo <repo> --type capability
-
-# Apply hierarchy labels
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "objective:platform-launch"
-gh issue edit <N> --repo Infiquetra/<repo> --add-label "initiative:olympus-v1"
-
-# Link to objective milestone
-python3 sdlc_manager.py milestones link --repo <repo> --issue <N> --milestone <M>
-
-# Add to project board
 python3 sdlc_manager.py board add --repo <repo> --number <N>
-python3 sdlc_manager.py labels sync-fields --repo <repo> --number <N>
-
-# Mark as ready for agent claiming in Beads
-bd ready <capability-task-id>
+python3 sdlc_manager.py flow link-sub-issue \
+  --parent-repo <objective-repo> --parent-number <objective-number> \
+  --child-repo <repo> --child-number <N>
+python3 sdlc_manager.py milestones link --repo <repo> --issue <N> --milestone <M>
 ```
 
-### Capability Flow Through Kanban
-
-Capabilities flow through the standard Kanban columns:
-
-```
-Backlog -> Ready -> In Development -> E2E Testing -> Deployment Ready -> Deployed
-```
-
-Progress is tracked via GitHub Milestone completion %:
-- Milestone % = closed issues / total issues linked to milestone
-
-### Standup Objective Check-in
-
-During standup, add an Objective Check-in (when an active time-bounded Objective exists):
-- Days until target date
-- Progress: X of Y Capabilities deployed
-- Any blockers risking the deadline?
-- Scope adjustments needed?
-
-### Progress Monitoring
-
-```bash
-# Check milestone progress
-python3 sdlc_manager.py milestones progress --repo <repo> --milestone <M>
-```
-
-**At-risk signals**:
-- < 7 days to due date AND < 80% completion -> flag as at-risk
-- Any Capability blocked for > 1 day
-- Capability aging > 3 days in In Development
+Use the milestone link only if a milestone exists.
 
 ---
 
-## Completion Workflow
+## Execution Flow
 
-### Completion Criteria
+Child work flows through the target board:
 
-An Objective is complete when ALL of the following are true:
-1. All Capabilities linked to the milestone are in **Deployed** status
-2. Success criteria in the Objective issue are validated and checked off
-3. No Critical or High defects open against the Objective
-4. Beads parent task marked complete
+| Board | Flow |
+|-------|------|
+| Jeff Intent / Asgard | Idea -> Shaping -> Ready -> Active -> Verify -> Done |
+| Olympus | Backlog -> Ready -> Planning -> Assigned -> In Review -> Done / Closed |
 
-### Closing the Milestone
+Progress can be read from:
 
-```bash
-# Close the GitHub Milestone
-gh api repos/Infiquetra/<repo>/milestones/<N> \
-  -X PATCH \
-  -f state=closed
-```
+- Objective issue sub-issues.
+- Project field filters by Objective.
+- GitHub Milestone completion percentage when a milestone exists.
 
-### Completing the Objective Issue
+---
 
-1. Update the Objective issue with completion notes
-2. Mark success criteria checkboxes as complete
-3. Add comment summarizing what was delivered vs. what was planned
-4. Close the issue
-5. Complete the Beads parent task: `bd complete <objective-task-id>`
+## At-Risk Signals
 
-### Post-Objective Activities
+- Due date is less than 7 days away and milestone completion is below 80%.
+- Linked work is blocked or waiting on Jeff.
+- Linked work is aging in active/review/verify statuses.
+- Success criteria are still ambiguous after shaping.
+- Critical/high defects remain open against the Objective.
 
-- Schedule outcome measurement (if Pilot: gather user feedback, if Release: monitor metrics)
-- Team retrospective if the Objective was a significant milestone
-- Notify stakeholders via #mount-olympus Discord channel
+---
+
+## Completion Criteria
+
+An Objective is complete when:
+
+1. Linked child work is in terminal workflow status.
+2. Success criteria are validated and checked off.
+3. Open critical/high defects are resolved or explicitly deferred.
+4. The milestone is closed if one was created.
+5. The Objective issue has completion notes and is closed.
 
 ---
 
@@ -281,141 +135,7 @@ gh api repos/Infiquetra/<repo>/milestones/<N> \
 
 For Objectives spanning multiple repositories:
 
-### Setup
-
-Create the same milestone title in each affected repo:
-
-```bash
-# Primary repo
-python3 sdlc_manager.py milestones create \
-  --repo infiquetra-core \
-  --title "Pilot: Platform Launch (2026-04-15)" \
-  --due-date 2026-04-15
-
-# Secondary repos with matching title
-python3 sdlc_manager.py milestones create \
-  --repo infiquetra-auth \
-  --title "Pilot: Platform Launch (2026-04-15)" \
-  --due-date 2026-04-15
-```
-
-Apply consistent labels across all repos (`objective:platform-launch`, `initiative:olympus-v1`).
-
-### Tracking
-
-Check progress in each repo:
-```bash
-python3 sdlc_manager.py milestones progress --repo infiquetra-core --milestone <M1>
-python3 sdlc_manager.py milestones progress --repo infiquetra-auth --milestone <M2>
-```
-
-Use GitHub Projects filter by `objective:platform-launch` label to see all Capabilities
-across all repos in one view.
-
----
-
-## Examples of Good Objectives
-
-### Example 1: Pilot Objective
-
-```
-Objective: Pilot: Platform Launch (2026-04-15)
-Type: Pilot
-Initiative: initiative:olympus-v1
-
-Success Criteria:
-- [ ] 5 early adopters onboarded and trained
-- [ ] Complete onboarding flow operational (signup + setup + first use)
-- [ ] Operations team has real-time dashboard visibility
-- [ ] No critical defects during the 2-week pilot period
-- [ ] > 80% onboarding completion rate without support intervention
-
-Included Capabilities (4):
-1. User Onboarding Service with REST API
-2. Auth Integration with OAuth2/OIDC
-3. Operations Dashboard MVP
-4. User Self-Service Flow
-
-Risk: Medium — new third-party integrations, early adopter availability
-```
-
-### Example 2: Release Objective
-
-```
-Objective: Release: Olympus v1.0 (2026-05-30)
-Type: Release
-Initiative: initiative:olympus-v1
-
-Success Criteria:
-- [ ] All v1.0 features deployed to production
-- [ ] 99.9% uptime for 2 weeks before release
-- [ ] All security reviews passed
-- [ ] Documentation complete and published
-- [ ] No open Critical or High defects
-
-Included Capabilities (7):
-1. Multi-Tenant Support
-2. Full User Workflow (signup + config + usage)
-3. Reporting Dashboard
-4. Self-Service Onboarding Portal
-5. Performance Optimization (p95 < 200ms)
-6. Audit Log Export
-7. Admin Role Management
-
-Risk: High — complex coordination, performance targets aggressive
-```
-
-### Example 3: Program Objective (OKR)
-
-```
-Objective: Program: Q1 KR1 - User Adoption (2026-03-31)
-Type: Program
-Initiative: initiative:q1-2026-okrs
-
-Key Result: 10 users actively using the platform
-
-Success Criteria:
-- [ ] 10+ users registered and active (at least 1 session per week)
-- [ ] Average 50+ transactions per user per week
-- [ ] 80%+ user satisfaction score (survey)
-
-Included Capabilities (3):
-1. Self-Service Onboarding Portal
-2. Interactive Tutorial Integration
-3. Simplified Workflow (feedback from pilot)
-
-Risk: Medium — user adoption is behavior change, not just technical delivery
-```
-
----
-
-## Common Questions
-
-**Q: Do all Capabilities need to be in an Objective?**
-
-No. Objectives are optional. Use them when:
-- Multiple Capabilities must deliver together (pilot, release)
-- Time-bounded coordination is needed
-- Executive visibility is required
-
-For ongoing enhancements, defect fixes, or single Capabilities: skip the Objective.
-
-**Q: Can a Capability belong to multiple Objectives?**
-
-No. A Capability should belong to at most one Objective. If it truly enables multiple,
-consider if the Objective boundaries are right.
-
-**Q: What if an Objective scope changes mid-flight?**
-
-Document the change in the Objective issue as a comment. Update the success criteria.
-If timeline changes, update the Milestone due date. Notify stakeholders.
-
-**Q: Can Enhancements and Defects be linked to Objectives?**
-
-Yes, if they're critical for the Objective's success (e.g., a blocking defect during
-a pilot). Otherwise, leave them unassigned to the Objective.
-
-**Q: How do I track progress when Capabilities span multiple repos?**
-
-Check each repo's milestone separately. The GitHub Projects board filtered by
-`objective:{name}` label gives a unified cross-repo view.
+1. Create matching milestone titles in each repo if milestone rollup is useful.
+2. Use the same Objective field option across project boards.
+3. Link child work to the Objective issue using native sub-issues.
+4. Track aggregate progress through board filters and per-repo milestone progress.

--- a/plugins/sdlc-manager/skills/sdlc-rollout/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-rollout/SKILL.md
@@ -3,7 +3,7 @@ name: sdlc-rollout
 description: |
   Track and drive SDLC rollout across Infiquetra organization repositories. Provides rollout
   status dashboards, gap analysis per repo, label and template deployment, and progress tracking.
-  Integrates with Beads/Dolt for agent-driven rollout coordination.
+  Uses GitHub repos, issue templates, labels, project mapping, and rollout-status tracking.
 when_to_use: |
   Use this skill when the user wants to:
 
@@ -82,23 +82,11 @@ Each repo tracks four fields in `rollout-status.json`:
 
 Status values: `pending`, `complete`, `n/a` (for Tier 3 repos where project board is excluded)
 
-## Beads/Dolt Integration
+## Coordination
 
-Rollout tasks can be tracked in Beads for agent-driven coordination:
-
-```bash
-# Create a rollout task for a repo
-bd ready sdlc-rollout-infiquetra-core
-
-# An agent claims the rollout task
-bd claim sdlc-rollout-infiquetra-core
-
-# Agent completes the rollout
-bd complete sdlc-rollout-infiquetra-core
-```
-
-When a Beads rollout task is completed, the corresponding `rollout-status.json` entry
-should be updated to reflect completion.
+Rollout work is tracked through GitHub issues, project fields, and
+`rollout-status.json`. When a rollout task completes, update the corresponding
+`rollout-status.json` entry so later gap reports do not re-open finished work.
 
 ## Core Operations
 

--- a/plugins/sdlc-manager/skills/sdlc-rollout/references/work-hierarchy.md
+++ b/plugins/sdlc-manager/skills/sdlc-rollout/references/work-hierarchy.md
@@ -1,223 +1,89 @@
 # Work Hierarchy Reference
 
-Practical reference for the Infiquetra three-tier work hierarchy.
-Source: `$INFIQUETRA_SDLC_PATH/docs/process/work-hierarchy.md` and `docs/process/issue-types.md`.
+Practical reference for the Infiquetra work hierarchy. Source of truth:
+`$INFIQUETRA_SDLC_PATH/docs/process/work-hierarchy.md` and
+`$INFIQUETRA_SDLC_PATH/config/sdlc-schema.json`.
 
 ---
 
-## The Three-Tier Model
+## The Model
 
 ```
-Initiative (Strategic — quarters / OKRs)
-    +-- Objective (Time-bounded — Pilots / MVPs / Releases)
-            +-- Capability (Primary unit of work — Kanban flow)
+Initiative
+  +-- Objective
+        +-- Capability / Enhancement / Defect / Exploration / Context Update
 ```
 
-**Key principle**: Initiative and Objective exist for grouping, coordination, and reporting
-only. All actual work happens at the Capability level. WIP limits, flow metrics, and daily
-standup operate at the Capability level.
+Initiative and Objective are grouping and reporting fields. Actual execution happens on
+issues, usually under an Objective parent issue or milestone when the work needs a delivery
+target.
 
 ---
 
-## Level 1: Initiative
+## Initiative
 
-**Definition**: Strategic objective spanning one or more quarters. Answers: "What are we
-trying to achieve this year?"
+**Definition**: A broad strategic grouping that may span multiple Objectives.
 
-**Duration**: 1-4 quarters
+**GitHub construct**: Project field option, not a label by default.
 
-**GitHub construct**: Label (`initiative:{short-kebab-case}`) + Project View
+Use an Initiative when:
 
-**When to create**:
-- Multi-quarter strategic goals or OKRs
-- Aligning work with company/team OKRs
-- Coordinating multiple related Objectives
-- Providing executive-level program visibility
+- The work groups multiple Objectives.
+- Reporting needs a stable strategic category.
+- The grouping will outlive a single short task.
 
-**When NOT to create**:
-- Single capabilities or enhancements
-- Short-term work (< 1 quarter)
-
-**Naming**: `initiative:{short-kebab-case}`
-Examples: `initiative:olympus-v1`, `initiative:q1-2026-okrs`, `initiative:security-compliance`
-
-**Label color**: Dark blue (`#0052CC`)
-
-**Key behavior**: Initiatives are NOT issue types — no GitHub Issue template.
-Tracked purely via labels applied to Objectives and Capabilities.
+Do not create an Initiative for one-off work or raw operator intent.
 
 ---
 
-## Level 2: Objective
+## Objective
 
-**Definition**: Time-bounded deliverable set with a specific target date. Answers: "What
-are we delivering by this date?"
+**Definition**: A time-bounded deliverable set with a target date.
 
-**Duration**: 2-8 weeks
+**GitHub constructs**:
 
-**GitHub construct**: GitHub Milestone + Label (`objective:{short-kebab-case}`)
+- Objective issue, when the Objective itself needs discussion and acceptance criteria.
+- Project `Objective` field option for reporting.
+- GitHub Milestone when progress rollup by repo is useful.
+- Native GitHub sub-issues for child work.
 
-**Beads construct**: Parent task with child capability subtasks
-
-**Objective types**:
-| Type | Description | Example |
-|------|-------------|---------|
-| Pilot | Customer validation with specific participants | "Pilot: Platform Launch with 5 early adopters" |
-| MVP | Minimum viable product for initial launch | "MVP: Core Auth Integration" |
-| Release | Versioned delivery with coordinated features | "Release: Olympus v1.0" |
-| Program | OKR/Initiative phase or milestone | "Program: Q1 KR1 - User Adoption" |
-
-**When to create**:
-- Time-bounded deliverable with specific target date
-- Coordinating multiple Capabilities for unified delivery
-- Customer pilot or beta program
-- Versioned release requiring coordination
-- OKR milestone requiring focus
-
-**When NOT to create**:
-- Single Capability (assign directly to Initiative or leave unassigned)
-- Informal team coordination (use daily standup)
-- Ongoing work without delivery target
-
-**Naming**:
-- Milestone: `{Type}: {Name} ({YYYY-MM-DD})` — e.g., `Pilot: Platform Launch (2026-04-15)`
-- Label: `objective:{short-kebab-case}` — e.g., `objective:platform-launch`
-
-**Label color**: Blue (`#1D76DB`)
-
-**Typical size**: 3-10 Capabilities
-- Small (2-4 weeks): 3-5 capabilities
-- Medium (4-6 weeks): 5-8 capabilities
-- Large (6-8 weeks): 8-10 capabilities
-
-**Cross-repo coordination**: Create identical milestones in each affected repo, apply
-consistent labels across all repos, use Project for unified view.
+Use an Objective when multiple issues must land together or when Jeff needs a progress view.
 
 ---
 
-## Level 3: Capability
+## Capability And Other Work Items
 
-**Definition**: Complete, deployable piece of system functionality. The PRIMARY unit of
-work in the SDLC. This level is unchanged by the hierarchy extension.
+Capabilities, enhancements, defects, explorations, and context updates are execution cards.
+They flow through the target board:
 
-**Duration**: 1-4 weeks with AI assistance
+| Board | Flow |
+|-------|------|
+| Jeff Intent / Asgard | Idea -> Shaping -> Ready -> Active -> Verify -> Done |
+| Olympus | Backlog -> Ready -> Planning -> Assigned -> In Review -> Done / Closed |
 
-**GitHub construct**: Issue (with optional Milestone and Initiative label links)
-
-**Beads construct**: Subtask (claimable by Mount Olympus agents via `bd claim`)
-
-**Sizes**:
-| Size | Duration | Examples |
-|------|----------|---------|
-| XS | 1-2 days | Add new API endpoint with basic CRUD |
-| S | 3-5 days | Implement auth integration with external provider |
-| M | 1-2 weeks | Build notification system with message queue + workers |
-| L | 2-4 weeks | Create identity verification service with multiple providers |
-
-**Cycle time target (P85)**: < 5 days
-
-**What changes with hierarchy**: Capabilities can now optionally link to parent Objectives
-(via milestone) and Initiatives (via label). This does not change how Capabilities flow.
-
----
-
-## How the Hierarchy Flows in Practice
-
-```
-Quarterly planning (1-2 hours, end of each quarter)
-    +- Team identifies Initiatives for Q+1
-       +- Team defines Objectives with target dates within each Initiative
-          +- Team estimates Capabilities needed per Objective
-
-Just-in-time (2-3 weeks before work starts)
-    +- Capabilities created and linked to Objective milestone
-       +- Capabilities move to Ready when prioritized
-       +- Beads tasks created and marked ready for claiming
-
-Daily work (continuous Kanban flow)
-    +- Agent or developer claims Capability (bd claim <task-id>)
-       +- Capability flows: In Development -> E2E Testing -> Deployment Ready -> Deployed
-
-Objective complete when all Capabilities deployed
-    +- GitHub Milestone closes
-       +- Beads parent task marked complete
-```
-
----
-
-## Beads/Dolt Integration
-
-The Mount Olympus team uses Beads/Dolt as the primary coordination layer for agent-driven
-development:
-
-| Level | Beads Construct | Sync |
-|-------|----------------|------|
-| Initiative | -- | Label only, no Beads task |
-| Objective | Parent task | Syncs to GitHub Milestone progress |
-| Capability | Subtask (claimable) | Syncs to GitHub Issue state |
-
-`bd` is the Beads/Dolt CLI for structured agent task coordination (see `docs/tools/index.md` for install instructions).
-
-### Agent Workflow with Beads
-
-```bash
-# Task is made available for claiming
-bd ready <capability-task-id>
-
-# An agent (e.g., Hermes, Athena) claims the task
-bd claim <capability-task-id>
-
-# Agent updates progress
-bd update <capability-task-id> in-progress
-
-# Agent completes the task (syncs to GitHub Issue close)
-bd complete <capability-task-id>
-```
+Use native GitHub sub-issues for parent/child structure. Do not rely on removed Beads/Dolt
+task state.
 
 ---
 
 ## GitHub Constructs Summary
 
-| Level | Label | Milestone | Issue Template |
-|-------|-------|-----------|----------------|
-| Initiative | `initiative:{name}` (dark blue) | -- | None — label only |
-| Objective | `objective:{name}` (blue) + `objective-type:{type}` (yellow) | Yes, with due date | `objective.yml` |
-| Capability | `capability` | Optional (link to Objective) | `capability.yml` |
-
----
-
-## Labels Reference
-
-**Initiative labels** (dark blue `#0052CC`): `initiative:{kebab-name}`
-
-**Objective labels** (blue `#1D76DB`): `objective:{kebab-name}`
-
-**Objective type labels** (yellow `#FBCA04`):
-- `objective-type:pilot`
-- `objective-type:mvp`
-- `objective-type:release`
-- `objective-type:program`
+| Level | Preferred construct | Optional construct |
+|-------|---------------------|--------------------|
+| Initiative | Project field option | Label only when repo-local filtering needs it |
+| Objective | Objective issue + project field option | Milestone for due-date rollup |
+| Work item | GitHub Issue / PR card | Native sub-issue relationship |
 
 ---
 
 ## Common Questions
 
 **Do I need an Objective for every Capability?**
-No. Objectives are optional. Use them when time-bounded coordination is needed (pilots,
-releases, OKR milestones). For standalone or ongoing work, skip the Objective.
+No. Use Objectives when a time-bounded delivery target or progress rollup is useful.
 
-**Can Enhancements and Defects be assigned to Objectives?**
-Yes, but it's optional. Assign them only if they are critical for an Objective's success
-(e.g., a defect blocking a pilot). Otherwise leave them unassigned.
-
-**Can a Capability belong to multiple Initiatives?**
-Technically yes (apply multiple labels), but discouraged. A Capability should contribute
-to one Initiative. If it truly spans multiple, check whether Initiative boundaries need
-to be redrawn.
-
-**Can Objectives span multiple Initiatives?**
-No. Each Objective belongs to exactly one Initiative for clear strategic alignment.
+**Can Enhancements and Defects belong to Objectives?**
+Yes, when they materially affect the Objective. Otherwise leave them outside the Objective.
 
 **How do I track progress toward an Objective?**
-Two ways: (1) GitHub Milestone completion % (closed vs. open issues) and (2)
-Project filtered by Objective — shows Kanban status of all linked Capabilities.
+Use the Objective project field, the Objective issue's sub-issue tree, and optional
+GitHub Milestone progress.

--- a/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
+++ b/plugins/sdlc-manager/tests/test_project_mappings_resolution.py
@@ -31,6 +31,13 @@ def fake_vendored_path(tmp_path, monkeypatch):
     return fake_path
 
 
+@pytest.fixture
+def fake_schema_path(tmp_path, monkeypatch):
+    fake_path = tmp_path / "vendored-sdlc-schema.json"
+    monkeypatch.setattr(sdlc_manager, "_VENDORED_SDLC_SCHEMA_PATH", fake_path)
+    return fake_path
+
+
 def test_external_override_wins_over_vendored(tmp_path, fake_vendored_path) -> None:
     """If $INFIQUETRA_SDLC_PATH/config/project-mappings.json exists, it
     takes precedence over the vendored copy. This lets a developer test
@@ -117,8 +124,12 @@ def test_vendored_project_mappings_has_expected_canonical_state() -> None:
     data = json.loads(vendored.read_text())
     assert data["organization"] == "infiquetra"
     assert "mount-olympus" in data["projects"]
+    assert "asgard" in data["projects"]
+    assert "jeff-intent" in data["projects"]
     olympus = data["projects"]["mount-olympus"]
     assert olympus["number"] == 1
+    assert data["projects"]["asgard"]["number"] == 2
+    assert data["projects"]["jeff-intent"]["number"] == 3
 
     # Exact repo set from `gh repo list infiquetra --json name --jq '.[].name'`
     # captured 2026-05-04. If the org adds/removes a repo, the vendored
@@ -141,3 +152,79 @@ def test_vendored_project_mappings_has_expected_canonical_state() -> None:
         f"Missing: {expected_repos - actual_repos}; "
         f"Unexpected: {actual_repos - expected_repos}"
     )
+
+
+def test_sdlc_schema_external_override_wins(tmp_path, fake_schema_path) -> None:
+    sdlc_path = tmp_path / "infiquetra-sdlc"
+    cfg_dir = sdlc_path / "config"
+    cfg_dir.mkdir(parents=True)
+    override_data = {"schema_version": "override", "workflows": {}}
+    (cfg_dir / "sdlc-schema.json").write_text(json.dumps(override_data))
+    fake_schema_path.write_text(json.dumps({"schema_version": "vendored"}))
+
+    result = sdlc_manager._resolve_sdlc_schema(sdlc_path)
+
+    assert result == override_data
+
+
+def test_sdlc_schema_vendored_used_when_no_override(tmp_path, fake_schema_path) -> None:
+    fake_schema_path.write_text(
+        json.dumps({"schema_version": "vendored", "workflows": {"intent_flow": {}}})
+    )
+
+    result = sdlc_manager._resolve_sdlc_schema(tmp_path / "missing-sdlc")
+
+    assert result["schema_version"] == "vendored"
+
+
+def test_vendored_sdlc_schema_declares_current_live_boards() -> None:
+    vendored = sdlc_manager._VENDORED_SDLC_SCHEMA_PATH
+    assert vendored.exists(), f"Vendored schema missing at {vendored}"
+    data = json.loads(vendored.read_text())
+
+    assert data["boards"]["jeff_intent"]["status"] == "active"
+    assert data["boards"]["jeff_intent"]["live_creation"] == "created_2026-05-29_project_3"
+    assert data["boards"]["asgard"]["status"] == "active"
+    assert data["boards"]["asgard"]["live_creation"] == "created_2026-05-29_project_2"
+    assert data["workflows"]["intent_flow"]["statuses"] == [
+        "Idea",
+        "Shaping",
+        "Ready",
+        "Active",
+        "Verify",
+        "Done",
+    ]
+
+
+def test_schema_backed_status_order_includes_live_olympus_in_progress() -> None:
+    config = {
+        "sdlc_schema": {
+            "boards": {"olympus": {"workflow": "olympus_execution"}},
+            "workflows": {
+                "olympus_execution": {
+                    "statuses": [
+                        "Backlog",
+                        "Ready",
+                        "Planning",
+                        "Assigned",
+                        "In Review",
+                        "Done",
+                        "Closed",
+                    ],
+                    "pause_states": ["Blocked"],
+                }
+            },
+        }
+    }
+    proj = {"board_key": "olympus", "workflow": "olympus_execution"}
+
+    order = sdlc_manager._status_order(config, "mount-olympus", proj)
+
+    assert order.index("Assigned") < order.index("In Progress") < order.index("In Review")
+    assert "Blocked" in order
+
+
+def test_legacy_status_hint_points_to_current_status() -> None:
+    hint = sdlc_manager._legacy_status_hint("E2E Testing", ["Assigned", "In Review", "Done"])
+
+    assert hint == "'E2E Testing' is legacy; use 'In Review' on this board."


### PR DESCRIPTION
## Summary

- Vendored the SDLC board schema and updated `sdlc_manager.py` to load external/vendored/remote schema config.
- Added Jeff Intent and Asgard project mappings, plus explicit `--project` targeting for board add/move.
- Reworked board, metrics, milestones, labels, rollout, and operator guidance around the current Jeff Intent / Asgard / Olympus topology.
- Preserved compatibility for live/legacy Olympus statuses while steering new moves to the current schema.

## Verification

- `python3 -m json.tool plugins/sdlc-manager/config/sdlc-schema.json`
- `python3 -m py_compile plugins/sdlc-manager/scripts/sdlc_manager.py`
- `uv run ruff check plugins/sdlc-manager/scripts/sdlc_manager.py plugins/sdlc-manager/tests/test_project_mappings_resolution.py`
- `python3 -m pytest plugins/sdlc-manager/tests`
- `python3 plugins/sdlc-manager/scripts/sdlc_manager.py board view --help`
- `python3 plugins/sdlc-manager/scripts/sdlc_manager.py board move --help`
- `python3 plugins/sdlc-manager/scripts/sdlc_manager.py --format json board discover-fields --project asgard`
- `python3 plugins/sdlc-manager/scripts/sdlc_manager.py --format json board discover-fields --project jeff-intent`
- `python3 plugins/sdlc-manager/scripts/sdlc_manager.py board wip --project asgard`

Note: the local shell init still emits sandbox warnings for oh-my-posh/jenv in this temp checkout, but the commands completed successfully.
