### PR TITLE
feat(infiquetra-loop): add doc review workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -310,6 +310,7 @@
         "strategy",
         "ideation",
         "brainstorm",
+        "doc-review",
         "code-review",
         "optimize",
         "qa",

--- a/docs/brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md
+++ b/docs/brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md
@@ -1,0 +1,264 @@
+# Requirements: Infiquetra Loop Doc Review
+
+**Date.** 2026-05-29
+**Status.** Ready for planning
+**Source idea.** `docs/ideation/2026-05-29-infiquetra-loop-doc-review.md`
+
+## Problem
+
+`infiquetra-loop` is intended to replace daily Superpowers and Compound Engineering
+lifecycle use, but it does not yet replace the frequent `/ce-doc-review` workflow.
+The missing use case is not generic prose review. It is plan and requirements review
+before a document drives implementation.
+
+Without this command, agents can proceed from plans or requirements documents that
+contain unverified claims, wrong assumptions, incorrect requirement mappings, missing
+contract fields, unresolved implementation choices, or misplaced follow-up work.
+
+## Primary User
+
+The primary user is an Infiquetra founder / tech lead / staff engineer using lifecycle
+documents to guide implementation, issue progress, pull requests, and deployments.
+
+## Product Shape
+
+Add `/doc-review` to `infiquetra-loop` as an implementation-readiness skeptic for plans,
+requirements documents, and formal SDLC artifacts.
+
+The command should answer:
+
+> Can this document safely drive implementation without the agent inventing missing
+> decisions or acting on unverified assumptions?
+
+## Goals
+
+- Review plans and requirements documents for implementation readiness.
+- Catch unverified claims, unsupported actions, wrong assumptions, and incorrect
+  mappings before execution.
+- Apply narrow safe fixes in place by default.
+- Report remaining findings using `P0` / `P1` / `P2` / `P3` priorities.
+- Block `/work` on unresolved `P0` or `P1` findings unless the user explicitly
+  overrides.
+- Route formal Infiquetra SDLC artifacts through `blueprint-reviewer` first, then run
+  a second readiness-skeptic pass.
+- Persist a review artifact under `docs/reviews/` when edits or findings are
+  significant.
+
+## Non-Goals
+
+- Do not clone all Compound Engineering document-review behavior.
+- Do not add a `/ce-doc-review` compatibility alias.
+- Do not replace `blueprint-reviewer` rubrics.
+- Do not make document review a generic copy-editing or style-polishing command.
+- Do not make `/work` run document review automatically without asking.
+- Do not mutate documents when the fix is not clearly supported by document evidence.
+
+## Command Surface
+
+### `/doc-review`
+
+Reviews a provided document path or an obvious current lifecycle document.
+
+Expected examples:
+
+```text
+/doc-review docs/plans/example.md
+/doc-review docs/brainstorms/example-requirements.md
+/doc-review STRATEGY.md
+```
+
+No `/ce-doc-review` alias should be added for v1.
+
+## Default Workflow
+
+1. Resolve the target document.
+2. Classify the document type.
+3. If the document is a formal Infiquetra SDLC artifact, run the appropriate
+   `blueprint-reviewer` review first.
+4. Run the readiness-skeptic review.
+5. Apply safe fixes in place.
+6. Report remaining findings using priority levels.
+7. Write `docs/reviews/` output when edits or findings are significant.
+8. Return a clear summary of fixes applied, findings remaining, and whether the
+   document can drive `/work`.
+
+## Document Classification
+
+The command should classify documents by content and path.
+
+### Formal SDLC Artifacts
+
+Examples:
+
+- blueprint sections
+- specifications
+- GitHub issue drafts or issue-derived documents
+
+Behavior:
+
+- Run the matching `blueprint-reviewer` workflow first.
+- Then run `/doc-review`'s readiness-skeptic pass.
+- In v1, keep this as sequential composition rather than a merged rubric system.
+
+### Plans And Requirements
+
+Examples:
+
+- `docs/plans/*.md`
+- `docs/brainstorms/*requirements*.md`
+- implementation plans produced by `/plan`
+- requirements documents produced by `/brainstorm`
+
+Behavior:
+
+- Run the readiness-skeptic review directly.
+- Focus on whether the document can safely guide implementation.
+
+### Strategy Or Scope Documents
+
+Examples:
+
+- `STRATEGY.md`
+- strategy updates
+- founder-scope docs
+
+Behavior:
+
+- Run readiness review when the document is about to drive implementation.
+- Mention `/founder-review` as an optional additional lens when scope, ambition, or
+  product framing risk is prominent.
+
+## Review Lenses
+
+### Always-On
+
+- **Verification.** Identify claims, requirements, and actions that are not supported by
+  cited evidence or by the document itself.
+- **Assumption audit.** Find wrong, stale, or unstated assumptions that would affect
+  implementation.
+- **Requirement mapping.** Check that origin requirements, acceptance criteria, schema
+  requirements, and implementation requirements map correctly.
+- **Completeness.** Detect missing fields, missing schema requirements, missing gates,
+  or missing decision points that the document already implies.
+- **Open-choice pressure.** Flag implementation choices that should be defaults,
+  decisions, or explicit evidence-gathering tasks.
+- **Adversarial review.** Ask what would break if the agent followed this document
+  literally.
+
+### Triggered
+
+- **Security / ops.** Trigger when the document touches secrets, authorization,
+  deployment, infrastructure, data, or external integrations.
+- **Founder / product.** Trigger when the document changes user-facing behavior,
+  product scope, strategy, or ambition.
+- **Deployment readiness.** Trigger when the document includes deploy, rollback,
+  release, environment, or CI/CD behavior.
+
+## Safe Auto-Fixes
+
+Safe fixes are enabled by default and should edit the reviewed document in place.
+
+Safe means the document itself, linked source, or local repository evidence clearly
+supports the change. Examples:
+
+- add missing schema fields already implied elsewhere in the document
+- correct origin requirement mappings when the right mapping is evident
+- move follow-up work out of canonical schema and into prose or runbook sections
+- fill in missing gates or checklist items already required by the surrounding section
+- fix stale internal references, broken headings, or obvious inconsistent naming
+
+Unsafe changes should be reported as findings instead of applied.
+
+Unsafe examples:
+
+- inventing acceptance criteria
+- choosing an architecture without evidence
+- changing scope based on preference rather than document support
+- resolving a product decision without user input
+- adding new requirements not implied by the source material
+
+## Finding Priorities
+
+Findings should lead with priority levels.
+
+- **P0.** The document would cause unsafe, incorrect, destructive, or materially wrong
+  execution.
+- **P1.** The document is not ready to drive implementation because a core assumption,
+  mapping, requirement, default, or gate is missing or wrong.
+- **P2.** The document can probably drive work, but the issue creates meaningful
+  rework, ambiguity, or review risk.
+- **P3.** Nice-to-fix clarity, maintainability, or polish issue.
+
+The command may include a one-line readiness summary, but priorities are the primary
+output language.
+
+## Loop Integration
+
+`/doc-review` should be explicit by default. `infiquetra-loop` should not silently run it.
+
+When `/work` is about to use a plan or requirements document, the loop should ask whether
+to run `/doc-review` first. If review runs and finds unresolved `P0` or `P1` findings,
+`/work` should block unless the user explicitly overrides.
+
+For issue-attached work, review summaries should be usable in issue progress comments:
+
+- fixes applied
+- remaining `P0` / `P1` / `P2` findings
+- whether execution is blocked
+- review artifact link when one was written
+
+## Durable Review Artifacts
+
+Inline output is enough for minor safe fixes and small findings.
+
+Write a review artifact under `docs/reviews/` when:
+
+- edits are significant
+- remaining findings are significant
+- the review blocks `/work`
+- the review involved a formal SDLC artifact plus readiness pass
+- the review is part of an issue-attached lifecycle flow
+
+Suggested artifact contents:
+
+- reviewed document path
+- review type and routed delegates
+- safe fixes applied
+- remaining findings by priority
+- evidence checked
+- execution readiness summary
+- issue or plan links when available
+
+## Failure And Fallback Behavior
+
+- If `blueprint-reviewer` is unavailable for a formal SDLC artifact, say so clearly and
+  run the readiness-skeptic pass only.
+- If the target document is ambiguous, ask for the document path.
+- If safe fixes require evidence that is not present, do not edit. Emit a finding.
+- If no issues are found, say that clearly and report any residual risk from limited
+  evidence.
+
+## Future Work
+
+The relationship between `/doc-review` and `blueprint-reviewer` should be revisited after
+v1 usage. They may eventually become a joined review flow, but v1 should keep ownership
+clear:
+
+- `blueprint-reviewer`: formal Infiquetra SDLC rubric quality
+- `/doc-review`: implementation-readiness skepticism for documents that will drive work
+
+## Acceptance Criteria
+
+- `infiquetra-loop` includes a `/doc-review` command and matching skill.
+- No `/ce-doc-review` alias is added.
+- `/doc-review` can classify formal SDLC artifacts, plans, requirements docs, and
+  strategy/scope docs.
+- Formal SDLC artifacts run `blueprint-reviewer` first, then the readiness-skeptic pass.
+- Safe fixes are applied in place by default.
+- Remaining findings are reported as `P0` / `P1` / `P2` / `P3`.
+- `P0` and `P1` findings block `/work` unless explicitly overridden.
+- Significant reviews produce artifacts under `docs/reviews/`.
+- `/work` asks whether to run `/doc-review` before executing from a plan or requirements
+  document.
+- README, changelog, and marketplace/plugin metadata are updated if command registration
+  requires it.

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -10,6 +10,28 @@
 
 ## Shipped
 
+### Add Infiquetra loop `/doc-review` command  {#infiquetra-loop-doc-review}
+
+**SHIPPED 2026-05-29** (commit pending).
+
+**Summary.** Added `/doc-review` to `infiquetra-loop` as an implementation-readiness review
+surface for plans, requirements documents, formal SDLC artifacts, and strategy/scope documents
+that are about to drive implementation.
+
+**What shipped.**
+- `/doc-review` command and skill.
+- Safe in-place fixes, P-level findings, durable `docs/reviews/` artifact triggers, and a
+  review-result contract.
+- Formal SDLC routing through `blueprint-reviewer` delegates followed by readiness review.
+- `/work` prompt/block guidance and issue-progress rendering fields for doc-review summaries.
+- README, changelog, marketplace/plugin metadata, and contract tests.
+
+**Refs.**
+- Idea doc: [2026-05-29-infiquetra-loop-doc-review.md](../ideation/2026-05-29-infiquetra-loop-doc-review.md).
+- Requirements: [2026-05-29-infiquetra-loop-doc-review-requirements.md](../brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md).
+- Plan: [2026-05-29-001-feat-infiquetra-doc-review-plan.md](../plans/2026-05-29-001-feat-infiquetra-doc-review-plan.md).
+- Plan review: [2026-05-29-infiquetra-doc-review-plan-review.md](../reviews/2026-05-29-infiquetra-doc-review-plan-review.md).
+
 ### PR #112 — register `blueprint-reviewer` in marketplace + gitignore `.claude/`  {#pr-112-marketplace-fix}
 
 **SHIPPED 2026-05-01** (commit `4da5705`, squash-merged from `fix/marketplace-register-blueprint-reviewer`).
@@ -28,7 +50,15 @@
 
 ## Rejected
 
-*(none yet — this section will populate as ideas in `QUEUED.md` get explicitly declined with their reason.)*
+### `/ce-doc-review` compatibility alias for `infiquetra-loop`  {#rejected-ce-doc-review-alias}
+
+**REJECTED 2026-05-29.**
+
+**Reason.** During requirements discussion, the user chose not to preserve the CE command name.
+The Infiquetra command surface should be `/doc-review`.
+
+**Revisit when.** Multiple users migrate from Compound Engineering and repeatedly fail to find
+the Infiquetra command after normal README and marketplace documentation.
 
 ---
 

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,37 @@
 
 ---
 
+## 2026-05-29
+
+### Schema migrations need legacy fallback contract tests  {#schema-migration-legacy-fallbacks}
+
+**Context.** Updating the doc-review PR branch from `main` pulled in the sdlc-manager schema
+migration and exposed a CI failure in `board_wip`: mocked legacy WIP limits were ignored when no
+`sdlc_schema` was present.
+
+**Evidence.** PR #158 CI failed
+`tests/test_sdlc_manager.py::TestWipLimitsConfigurable::test_uses_config_wip_limits`; local
+`uv run python -m pytest -q` reproduced the same `Ready 0/10` output instead of the configured
+`Ready 0/5`.
+
+**Mechanism.** `_wip_limits()` was changed to read schema-backed board limits first, but the
+migration removed the previous `legacy_rollout_config.wip_limits` fallback path. Test fixtures and
+older operator configs that intentionally inject only legacy config then silently fell through to
+defaults.
+
+**Fix.** Keep the schema as canonical when present, and restore the Mount Olympus legacy fallback
+only when schema limits are absent.
+
+**Validation.** `uv run python -m pytest tests/test_sdlc_manager.py::TestWipLimitsConfigurable -q`
+and `uv run python -m ruff format --check .` pass after the fix.
+
+**Generalizable rule.** When migrating plugin runtime config from a legacy source to a canonical
+schema, encode the fallback contract directly in tests before deleting old read paths.
+
+**Refs.** PR #158.
+
+---
+
 ## 2026-05-27
 
 ### Setup commands must prove every bundled asset path exists  {#team-setup-asset-drift}

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -41,6 +41,38 @@
 
 ## P2 — important
 
+### Evaluate joined `doc-review` plus `blueprint-reviewer` review flow  {#doc-review-blueprint-unification}
+
+**Priority.** P2.
+
+**Effort.** Half-day to 1 day after v1 has real examples.
+
+**Worth it when.** `/doc-review` and `blueprint-reviewer` are both being used on the same
+formal SDLC artifacts often enough that the sequential handoff feels repetitive or findings
+start duplicating each other.
+
+**Context.**
+- Shipped v1 keeps ownership clear: `blueprint-reviewer` owns formal rubric quality;
+  `/doc-review` owns implementation-readiness skepticism.
+- Revisit whether a unified review flow or shared artifact schema is better once there are
+  real `docs/reviews/` examples to compare.
+
+### Consider deterministic `doc-review` classification helper  {#doc-review-classifier}
+
+**Priority.** P2.
+
+**Effort.** Half-day.
+
+**Worth it when.** Real `/doc-review` runs route the same kind of artifact differently across
+sessions, or formal SDLC artifacts miss `blueprint-reviewer` delegation because instruction-only
+classification is too variable.
+
+**Context.**
+- v1 uses explicit classification precedence and representative examples in the skill instead
+  of a helper script.
+- A future helper could return `blueprint`, `spec`, `issue`, `plan`, `requirements`, or
+  `strategy-scope` from path and content-shape signals.
+
 ### Phase 5 spawn primitive: tmux-wrapped foreground sessions (replaces `--bg` from current plan)  {#phase5-spawn-via-tmux}
 
 **Priority.** P2. Blocks Phase 5 implementation but Phase 5 hasn't started yet.

--- a/docs/ideation/2026-05-29-infiquetra-loop-doc-review.md
+++ b/docs/ideation/2026-05-29-infiquetra-loop-doc-review.md
@@ -1,0 +1,158 @@
+# Ideation: Infiquetra Loop Doc Review
+
+**Date.** 2026-05-29
+**Status.** Ready for brainstorm
+**Source.** User feedback after the initial `infiquetra-loop` command set: `/ce-doc-review`
+is used often and was not carried forward as a first-class command.
+
+## Prompt
+
+`infiquetra-loop` is meant to replace daily Superpowers and Compound Engineering
+lifecycle use. The current command set covers ideation, brainstorming, planning, work,
+QA, code review, founder review, optimization, retro, and resume. It does not yet
+cover CE's generic document review workflow.
+
+The missing question:
+
+> What should an Infiquetra-native `/doc-review` do so that `/ce-doc-review` can be
+> retired without losing useful review behavior?
+
+## Grounding
+
+- `plugins/infiquetra-loop/skills/ideate/SKILL.md` says selected ideas persist under
+  `docs/ideation/`.
+- `plugins/infiquetra-loop/skills/brainstorm/SKILL.md` says requirement discovery
+  persists under `docs/brainstorms/`.
+- `plugins/infiquetra-loop/skills/code-review/SKILL.md` covers diffs, PRs, and
+  pre-shipping gates, not prose documents.
+- `blueprint-reviewer` already owns formal Infiquetra SDLC rubric review for
+  blueprint sections, specs, and GitHub issues.
+- No `plugins/infiquetra-loop/commands/doc-review.md` or matching skill currently
+  exists.
+
+## Problem
+
+Without a generic document-review surface, uninstalling Compound Engineering removes
+a frequent review primitive for plans, requirements, strategy updates, brainstorm
+outputs, ADR-like proposals, and other markdown documents.
+
+The adjacent commands do not fully cover the need:
+
+- `/code-review` is too implementation- and diff-oriented.
+- `blueprint-reviewer` is valuable, but intentionally phase-specific and rubric-driven.
+- `/founder-review` is scope and ambition oriented, not a structured document review.
+- `/qa` is verification oriented, not document coherence review.
+
+## Candidate Directions
+
+### 1. Add a thin `/doc-review` wrapper around existing commands
+
+Route formal SDLC docs to `blueprint-reviewer`, route code-like requests to
+`/code-review`, and otherwise give a short manual review.
+
+**Pros.**
+- Smallest implementation.
+- Avoids overlapping too much with `blueprint-reviewer`.
+
+**Cons.**
+- Does not preserve the CE-style multi-lens review value.
+- Easy for the command to feel shallow.
+- Still leaves no durable generic review rubric inside `infiquetra-loop`.
+
+### 2. Add CE-style generic document review inside `infiquetra-loop`
+
+Create `/doc-review` with document classification, multi-lens review, headless mode,
+and optional durable output under `docs/reviews/`.
+
+Suggested lenses:
+
+- coherence and internal consistency
+- feasibility and operational realism
+- scope and sequencing
+- product or founder lens when user-facing or strategic
+- security and deployment lens when relevant
+- adversarial lens for hidden failure modes
+
+**Pros.**
+- Best replacement for `/ce-doc-review`.
+- Useful across plans, brainstorms, strategy docs, ADR-like proposals, and specs.
+- Can become a gate inside `/plan`, `/work`, `/qa`, and `/loop`.
+
+**Cons.**
+- Needs careful boundaries so it does not duplicate `blueprint-reviewer`.
+- More command and skill surface to maintain.
+
+### 3. Make `/doc-review` a router with specialized delegates
+
+Use `/doc-review` as the user-facing entry point, but route based on document type:
+
+- blueprint section, spec, or issue: delegate to `blueprint-reviewer`
+- code diff or PR: delegate to `/code-review`
+- strategy or founder-scope document: offer `/founder-review` as an additional lens
+- plan, brainstorm, requirements doc, ADR-like proposal, or arbitrary markdown:
+  run the generic document-review workflow
+
+**Pros.**
+- Preserves a single memorable command.
+- Keeps formal SDLC review owned by the plugin that already has the rubrics.
+- Lets generic doc review focus on documents that have no better specialized owner.
+
+**Cons.**
+- Router behavior must be explicit so users understand which review they received.
+- Requires good fallback behavior when `blueprint-reviewer` is unavailable.
+
+### 4. Add compatibility aliases for high-frequency CE commands
+
+For users migrating from Compound Engineering, add aliases such as `/ce-doc-review`
+and possibly `/ce-ideate`, `/ce-brainstorm`, `/ce-plan`, `/ce-work`, and
+`/ce-strategy` where command aliasing is supported.
+
+**Pros.**
+- Reduces migration friction and muscle-memory loss.
+- Makes uninstalling CE safer.
+
+**Cons.**
+- May blur the boundary between Infiquetra-native workflows and CE compatibility.
+- Alias support and command collision behavior need verification.
+
+## Recommended Survivor
+
+The strongest direction is **candidate 3 with candidate 2 as the generic fallback**:
+
+`/doc-review` should be a router that delegates to existing specialized Infiquetra
+review surfaces when they are clearly right, and otherwise runs an Infiquetra-adapted
+CE-style multi-lens document review.
+
+Add `/ce-doc-review` as a compatibility alias if the command system supports it
+cleanly after Compound Engineering is uninstalled.
+
+## Non-Goals
+
+- Do not clone all CE review utilities.
+- Do not replace `blueprint-reviewer` rubrics.
+- Do not make document review mutate files by default.
+- Do not make this a generic GitHub helper or cleanup workflow.
+- Do not embed long context-library content. Link to the context library as the
+  durable source of truth.
+
+## Brainstorm Seeds
+
+Use these as the opening decision surface for `/brainstorm`:
+
+1. Should `/doc-review` be primarily a router, a standalone generic reviewer, or both?
+2. Which document classes deserve specialized handling on day one?
+3. Should `/ce-doc-review` be a real compatibility alias, or should migration push users
+   to `/doc-review` only?
+4. What findings should block `/plan`, `/work`, or `/qa` in headless mode?
+5. When should the command write `docs/reviews/` artifacts versus reporting inline only?
+6. Which review lenses are mandatory, optional, or trigger-based?
+7. How should issue progress comments reference a document review when work is attached
+   to an SDLC issue?
+
+## Next Step
+
+Run a brainstorm on this question:
+
+> Design the Infiquetra-native `/doc-review` command so it replaces the useful parts of
+> `/ce-doc-review`, routes formal SDLC documents to `blueprint-reviewer`, and can act as
+> a review gate inside `infiquetra-loop`.

--- a/docs/plans/2026-05-29-001-feat-infiquetra-doc-review-plan.md
+++ b/docs/plans/2026-05-29-001-feat-infiquetra-doc-review-plan.md
@@ -1,0 +1,382 @@
+---
+title: "feat: Add Infiquetra doc-review"
+type: "feat"
+status: "completed"
+date: "2026-05-29"
+origin: "docs/brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md"
+---
+
+# feat: Add Infiquetra doc-review
+
+## Summary
+
+Add `/doc-review` to `infiquetra-loop` as an implementation-readiness skeptic for plans,
+requirements documents, formal SDLC artifacts, and strategy or scope documents that are about
+to drive implementation. The command should apply narrow safe fixes in place, report remaining
+findings as `P0` / `P1` / `P2` / `P3`, and let `/work` prompt for review before executing from
+a plan or requirements document.
+
+---
+
+## Problem Frame
+
+`infiquetra-loop` currently covers ideation, brainstorming, planning, work execution, QA, code
+review, founder review, optimization, retro, and resume, but it does not replace the frequent
+Compound Engineering `/ce-doc-review` workflow. The missing job is not generic prose review.
+It is readiness review for documents that will drive implementation.
+
+The plan is sourced from `docs/brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md`.
+
+---
+
+## Requirements
+
+**Command surface**
+
+- R1. `infiquetra-loop` exposes `/doc-review` as the primary command.
+- R2. No `/ce-doc-review` compatibility alias is added.
+- R3. The command accepts a document path and asks for a path when the target is ambiguous.
+
+**Review behavior**
+
+- R4. `/doc-review` classifies formal SDLC artifacts, plans, requirements documents, and
+  strategy or scope documents.
+- R5. Formal SDLC artifacts route through the matching `blueprint-reviewer` workflow first,
+  then receive the readiness-skeptic pass.
+- R6. Plans and requirements documents run the readiness-skeptic pass directly.
+- R7. Strategy or scope documents receive readiness review when they are about to drive
+  implementation, with `/founder-review` suggested as an optional additional lens when
+  product or ambition risk is prominent.
+- R8. The readiness-skeptic pass checks verification, assumptions, requirement mappings,
+  completeness, open implementation choices, and adversarial failure modes.
+
+**Mutation and output**
+
+- R9. Safe auto-fixes are enabled by default and edit the reviewed document in place.
+- R10. Unsafe or unsupported changes are reported as findings instead of applied.
+- R11. Remaining findings use `P0` / `P1` / `P2` / `P3` priorities.
+- R12. Significant reviews write durable artifacts under `docs/reviews/`.
+- R13. Durable review artifacts include a stable review-result contract: target path,
+  reviewed revision when available, blocked status, finding priorities and statuses, artifact
+  path, and override rationale when applicable.
+
+**Loop integration**
+
+- R14. `/work` asks whether to run `/doc-review` before executing from a plan or requirements
+  document.
+- R15. Unresolved `P0` or `P1` findings block `/work` unless the user explicitly overrides.
+- R16. Issue-attached work can summarize doc-review fixes, findings, block status, and review
+  artifact links in progress comments.
+- R17. README, changelog, marketplace entry, and plugin metadata make `/doc-review`
+  discoverable after installation.
+
+---
+
+## Key Technical Decisions
+
+- **Skill-first implementation with explicit contracts:** Implement `/doc-review` as a command
+  plus skill, matching the existing `infiquetra-loop` pattern. v1 uses explicit classification
+  precedence and examples in the skill rather than a deterministic classifier script, but it
+  does update `scripts/issue_progress.py` because issue-comment rendering is already mechanical.
+- **Router plus skeptic pass:** Use routing language inside the skill rather than splitting
+  into multiple commands. This preserves one user-facing command while keeping
+  `blueprint-reviewer`, `/code-review`, and `/founder-review` ownership clear.
+- **No CE alias:** Do not add `/ce-doc-review`. The plugin should migrate daily workflow to the
+  Infiquetra command surface rather than preserving CE command names.
+- **Safe fixes in place:** The skill should instruct agents to edit the source document only
+  when the document itself, linked source, or local repository evidence supports the fix. This
+  preserves the useful CE behavior without authorizing speculative rewriting.
+- **P-level gate language with durable result shape:** Findings are reported primarily as
+  priorities. A readiness summary may be included, but `/work` gating keys on unresolved `P0`
+  and `P1` findings from same-session output or the latest matching `docs/reviews/` artifact.
+  Overrides require an explicit rationale that can be carried into issue progress or
+  work-session notes.
+- **Sequential SDLC review:** Formal SDLC artifacts run `blueprint-reviewer` first, then the
+  readiness-skeptic pass. After the formal delegate runs, `/doc-review` re-reads the target
+  document, collects any review log or delegate artifact, and includes unresolved formal
+  findings in the readiness summary without reclassifying them as readiness findings. Joining
+  the rubric systems is future work after v1 usage proves the right boundary.
+- **Concrete artifact triggers:** v1 treats a review as significant when it has any `P0` or
+  `P1`, any safe fix edits the document, any formal SDLC delegate runs, any issue-attached
+  lifecycle flow is active, or more than three findings remain after fixes.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["/doc-review target"] --> B{"Classify document"}
+  B -->|blueprint or ADR| C["/blueprint-review"]
+  B -->|spec| D["/spec-review"]
+  B -->|issue artifact| E["/issue-review"]
+  B -->|plan or requirements| F["Readiness skeptic pass"]
+  B -->|strategy or scope| G["Readiness pass plus optional founder-review suggestion"]
+  C --> F
+  D --> F
+  E --> F
+  F --> H{"Safe fixes?"}
+  H -->|supported by evidence| I["Edit source document in place"]
+  H -->|unsupported| J["Emit prioritized finding"]
+  I --> K{"Significant review?"}
+  J --> K
+  K -->|trigger matched| L["Write docs/reviews artifact with result contract"]
+  K -->|no| M["Inline summary only"]
+  L --> N["Return P-level findings and work readiness"]
+  M --> N
+```
+
+```mermaid
+flowchart TB
+  A["/work loads plan or requirements doc"] --> B{"Ask to run /doc-review?"}
+  B -->|skip| C["Proceed with explicit skip rationale"]
+  B -->|run| D["Run /doc-review"]
+  D --> E{"Result says blocked?"}
+  E -->|yes| F{"User override?"}
+  F -->|yes| G["Proceed and record override"]
+  F -->|no| H["Block execution"]
+  E -->|no| I["Proceed to implementation"]
+```
+
+---
+
+## Output Structure
+
+```text
+plugins/infiquetra-loop/
+  commands/
+    doc-review.md
+  skills/
+    doc-review/
+      SKILL.md
+  scripts/
+    issue_progress.py
+
+docs/
+  plans/
+    2026-05-29-001-feat-infiquetra-doc-review-plan.md
+  reviews/
+    <runtime review artifacts with target, revision, blocked, findings, and override fields>
+```
+
+---
+
+## Implementation Units
+
+### U1. Add the doc-review command and skill
+
+- **Goal:** Create the primary `/doc-review` command and skill with target resolution,
+  document classification, review lenses, safe-fix rules, P-level findings, and durable
+  artifact thresholds.
+- **Requirements:** R1, R2, R3, R4, R8, R9, R10, R11, R12, R13.
+- **Dependencies:** None.
+- **Files:**
+  - `plugins/infiquetra-loop/commands/doc-review.md`
+  - `plugins/infiquetra-loop/skills/doc-review/SKILL.md`
+  - `tests/test_infiquetra_loop_plugin.py`
+- **Approach:** Follow the existing command wrappers such as
+  `plugins/infiquetra-loop/commands/code-review.md` and skill docs such as
+  `plugins/infiquetra-loop/skills/code-review/SKILL.md`. The command should load the
+  skill and pass through arguments. The skill should be explicit that safe fixes are
+  allowed only when evidence supports them. Document a stable review-result contract for
+  durable artifacts, including target path, reviewed revision when available, blocked status,
+  finding priorities and statuses, artifact path, and override rationale when applicable.
+  Define concrete artifact triggers: any `P0` or `P1`, any applied edit, any formal SDLC
+  delegate, any issue-attached flow, or more than three remaining findings.
+- **Patterns to follow:** Existing `infiquetra-loop` command/skill pairing and frontmatter
+  naming conventions.
+- **Test scenarios:**
+  - Assert `plugins/infiquetra-loop/commands/doc-review.md` exists.
+  - Assert `plugins/infiquetra-loop/skills/doc-review/SKILL.md` has frontmatter name
+    `doc-review`.
+  - Assert the skill text includes safe in-place fixes, unsafe finding behavior,
+    `P0` / `P1` / `P2` / `P3`, and `docs/reviews/`.
+  - Assert the skill defines the review-result contract fields and concrete artifact triggers.
+  - Assert the command set intentionally does not include `ce-doc-review`.
+- **Verification:** Contract tests prove the plugin package includes the command and skill,
+  and the skill documents the required behavior.
+
+### U2. Document SDLC routing and specialized review ownership
+
+- **Goal:** Make `/doc-review` route formal SDLC artifacts through `blueprint-reviewer`
+  first, while keeping readiness review as the second pass.
+- **Requirements:** R4, R5, R6, R7.
+- **Dependencies:** U1.
+- **Files:**
+  - `plugins/infiquetra-loop/skills/doc-review/SKILL.md`
+  - `tests/test_infiquetra_loop_plugin.py`
+- **Approach:** Add routing rules for blueprint sections, ADRs, specs, and issue artifacts.
+  Reference `/blueprint-review`, `/spec-review`, and `/issue-review` as the formal rubric
+  delegates. Define classification precedence in the skill: explicit user command context first,
+  then known SDLC paths or identifiers, then content-shape signals, then path tie-breakers.
+  Include representative examples for blueprint/ADR, spec, issue, plan, requirements, and
+  strategy/scope documents. Keep the language advisory when a delegate is unavailable: say what
+  is missing and continue with readiness review where safe. After any formal delegate runs,
+  re-read the target document, collect the delegate artifact or appended review log when present,
+  and include unresolved formal findings in the readiness summary without turning them into
+  readiness findings.
+- **Patterns to follow:** `plugins/blueprint-reviewer/commands/blueprint-review.md`,
+  `plugins/blueprint-reviewer/commands/spec-review.md`, and
+  `plugins/blueprint-reviewer/commands/issue-review.md`.
+- **Test scenarios:**
+  - Assert the doc-review skill names `blueprint-reviewer`.
+  - Assert the skill references `/blueprint-review`, `/spec-review`, and `/issue-review`.
+  - Assert the skill describes the second readiness-skeptic pass after formal review.
+  - Assert the skill documents classification precedence and representative route examples.
+  - Assert the skill documents the formal-delegate handoff boundary.
+  - Assert the skill mentions `/founder-review` as optional for strategy or scope risk.
+- **Verification:** Tests prove the route ownership is documented in the package contract.
+
+### U3. Integrate doc-review into loop and work behavior
+
+- **Goal:** Make `infiquetra-loop` offer `/doc-review` before executing from plans or
+  requirements documents and block `/work` on unresolved `P0` or `P1` findings unless
+  explicitly overridden.
+- **Requirements:** R14, R15, R16.
+- **Dependencies:** U1.
+- **Files:**
+  - `plugins/infiquetra-loop/skills/work/SKILL.md`
+  - `plugins/infiquetra-loop/skills/loop/SKILL.md`
+  - `plugins/infiquetra-loop/scripts/issue_progress.py`
+  - `tests/test_infiquetra_loop_plugin.py`
+- **Approach:** Update `/work` guidance to prompt before execution when the active artifact
+  is a plan or requirements document. Update `/loop` gates so doc-review is part of the
+  review vocabulary, while still remaining explicit and user-approved. Extend
+  `scripts/issue_progress.py` so rendered progress comments can include doc-review fixes,
+  remaining findings, block status, override rationale, and review artifact links. `/work`
+  should consume same-session review output or the latest matching `docs/reviews/` artifact;
+  when a user overrides a block, the override rationale must be recorded in issue progress or
+  work-session notes.
+- **Patterns to follow:** Existing `/work` issue-progress and test-gate language in
+  `plugins/infiquetra-loop/skills/work/SKILL.md` and existing `/loop` gate wording in
+  `plugins/infiquetra-loop/skills/loop/SKILL.md`.
+- **Test scenarios:**
+  - Assert `/work` says it asks whether to run `/doc-review` before executing from a plan
+    or requirements document.
+  - Assert `/work` blocks on unresolved `P0` or `P1` findings unless the user overrides.
+  - Assert `/loop` mentions doc-review in review gates without making it automatic.
+  - Assert `issue_progress.render_issue_comment` can render doc-review fixes, remaining
+    findings, block status, override rationale, and review artifact links.
+  - Assert issue-progress guidance includes review artifact links and doc-review findings.
+- **Verification:** Contract tests cover the prompt and blocking behavior documented in the
+  lifecycle skills.
+
+### U4. Update package metadata and user-facing docs
+
+- **Goal:** Make the new command discoverable in plugin metadata, README, changelog, and
+  marketplace keywords.
+- **Requirements:** R1, R17.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `plugins/infiquetra-loop/.claude-plugin/plugin.json`
+  - `.claude-plugin/marketplace.json`
+  - `plugins/infiquetra-loop/README.md`
+  - `plugins/infiquetra-loop/CHANGELOG.md`
+  - `tests/test_infiquetra_loop_plugin.py`
+- **Approach:** Add `doc-review` to keywords and command documentation. Keep the plugin
+  version unchanged unless the repository's current release policy requires a version bump
+  for command additions. Update tests so marketplace and plugin metadata remain aligned.
+- **Patterns to follow:** Current `infiquetra-loop` metadata and README command list.
+- **Test scenarios:**
+  - Assert plugin metadata includes `doc-review` in keywords.
+  - Assert marketplace entry remains version-aligned with plugin metadata.
+  - Assert README lists `/doc-review`.
+  - Assert changelog mentions the new command and loop/work integration.
+- **Verification:** Contract tests and diff review show the command is discoverable.
+
+### U5. Preserve engineering-journal traceability
+
+- **Goal:** Keep the existing journal queue accurate when the feature ships.
+- **Requirements:** Repository engineering-journal maintenance policy; no direct origin R-ID.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:**
+  - `docs/engineering-journal/QUEUED.md`
+  - `docs/engineering-journal/ARCHIVE.md`
+  - `docs/engineering-journal/DECISIONS.md`
+- **Approach:** When implementation completes, split the queued doc-review item rather than
+  moving it wholesale if it still contains unshipped ideas. Archive only the shipped `/doc-review`
+  scope. Keep or revise unshipped queue items such as compatibility aliases, automatic
+  execution, unified rubric work, richer artifacts, or future deterministic classification.
+  Add a `DECISIONS.md` entry only if implementation commits a durable plugin-pattern decision
+  beyond the requirements already documented here, such as changing plugin version policy.
+- **Patterns to follow:** The entry format documented at the top of
+  `docs/engineering-journal/QUEUED.md`.
+- **Test scenarios:** Test expectation: none -- this is durable documentation maintenance.
+- **Verification:** Diff review confirms the queue does not retain the shipped scope, unshipped
+  follow-up ideas remain queued or archived as rejected, and any pattern decision is documented.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- `/doc-review` command and skill.
+- Safe in-place fixes documented as the default.
+- `P0` / `P1` / `P2` / `P3` findings.
+- Formal SDLC delegate routing followed by readiness review.
+- `/work` prompt and `P0` / `P1` block behavior.
+- Review-result contract fields and concrete `docs/reviews/` artifact triggers.
+- Issue-progress rendering support for doc-review summaries.
+- README, changelog, marketplace/plugin metadata, and contract tests.
+
+### Out Of Scope
+
+- `/ce-doc-review` alias.
+- A merged `blueprint-reviewer` plus `/doc-review` rubric engine.
+- Generic GitHub helpers, cleanup utilities, or CE plugin management.
+- Automatic `/doc-review` execution without asking the user.
+- Runtime mutation of issue state by `/doc-review` itself. Issue comments stay owned by
+  `sdlc-manager` and loop/work progress behavior; this plan only extends the renderer data
+  that loop/work can pass to that owner.
+
+### Deferred to Follow-Up Work
+
+- Join `blueprint-reviewer` and `/doc-review` into a unified review experience after v1
+  usage clarifies the right boundary.
+- Add a deterministic classification helper only if explicit v1 precedence and examples prove
+  too inconsistent in real use.
+- Consider richer review artifact templates once real `docs/reviews/` output examples exist.
+
+---
+
+## Risks & Dependencies
+
+- **Ambiguous ownership with `blueprint-reviewer`:** Mitigate by making formal rubric review
+  delegate first and readiness review second, with clear wording in the skill.
+- **Unsafe auto-fixes:** Mitigate with narrow safe-fix criteria and a hard rule that unsupported
+  changes become findings.
+- **Classification drift:** Mitigate with explicit precedence and representative examples in the
+  skill. Revisit deterministic classification only if real runs route the same artifact
+  differently.
+- **Gating drift after resume:** Mitigate with the durable review-result contract and `/work`
+  reading same-session output or the latest matching `docs/reviews/` artifact.
+- **Loop gate friction:** Mitigate by asking before `/doc-review`; do not make it automatic.
+
+---
+
+## Documentation and Operational Notes
+
+- The README command list should include `/doc-review` near `/code-review`.
+- The changelog should describe the command as a plan and requirements readiness review.
+- Runtime review artifacts belong under `docs/reviews/` in target repositories. v1 does not
+  require a static template file, but the skill must document the stable fields every significant
+  review artifact contains.
+- `.claude/infiquetra-loop/` remains ignored local state and should not hold durable review
+  output.
+
+---
+
+## Sources and Research
+
+- Origin requirements: `docs/brainstorms/2026-05-29-infiquetra-loop-doc-review-requirements.md`.
+- Idea source: `docs/ideation/2026-05-29-infiquetra-loop-doc-review.md`.
+- Current command pattern: `plugins/infiquetra-loop/commands/code-review.md`.
+- Current skill pattern: `plugins/infiquetra-loop/skills/code-review/SKILL.md`.
+- Loop gate pattern: `plugins/infiquetra-loop/skills/loop/SKILL.md`.
+- Work execution pattern: `plugins/infiquetra-loop/skills/work/SKILL.md`.
+- Contract test pattern: `tests/test_infiquetra_loop_plugin.py`.
+- Formal SDLC review delegates:
+  - `plugins/blueprint-reviewer/commands/blueprint-review.md`
+  - `plugins/blueprint-reviewer/commands/spec-review.md`
+  - `plugins/blueprint-reviewer/commands/issue-review.md`

--- a/docs/reviews/2026-05-29-infiquetra-doc-review-plan-review.md
+++ b/docs/reviews/2026-05-29-infiquetra-doc-review-plan-review.md
@@ -1,0 +1,45 @@
+# Review: Infiquetra Doc Review Plan
+
+**Date.** 2026-05-29
+**Reviewed document.** `docs/plans/2026-05-29-001-feat-infiquetra-doc-review-plan.md`
+**Review mode.** CE doc review with auto-resolve best judgment
+**Result.** Plan updated; no unresolved blocking findings remain.
+
+## Fixes Applied
+
+- Added `R16` for package discoverability and moved metadata/docs traceability from `R12`
+  to `R16`.
+- Changed U5 traceability from `R12` to the repository engineering-journal policy.
+- Expanded the summary to include strategy and scope documents that are about to drive
+  implementation.
+- Added a durable review-result contract requirement for `docs/reviews/` artifacts.
+- Added concrete significant-review artifact triggers.
+- Added explicit classification precedence and representative route examples to U2.
+- Added the formal-delegate handoff boundary: re-read the target, collect delegate review logs
+  or artifacts, and summarize unresolved formal findings separately from readiness findings.
+- Added `plugins/infiquetra-loop/scripts/issue_progress.py` to U3 with tests for doc-review
+  fields in rendered issue comments.
+- Tightened `/work` gating so it reads same-session output or the latest matching review
+  artifact and records override rationale.
+- Narrowed U5 journal handling so shipped scope is archived while unshipped ideas remain queued
+  or are explicitly rejected.
+
+## Findings Resolved
+
+- **P1. Issue-progress renderer is omitted.** Resolved by adding `issue_progress.py` to U3
+  files, approach, and test scenarios.
+- **P1. Gating lacks durable status contract.** Resolved by adding the review-result contract
+  and `/work` consumption rule.
+- **P1. Classification is load-bearing but prose-only.** Resolved by adding explicit
+  classification precedence and route examples with tests instead of adding a v1 classifier.
+- **P2. Significant artifact threshold is under-specified.** Resolved by defining concrete v1
+  artifact triggers.
+- **P2. Queue archival scope is too broad.** Resolved by requiring split archive/queue handling.
+- **FYI. Sequential reviews need a handoff boundary.** Resolved by documenting the delegate
+  handoff.
+
+## Residual Risk
+
+The plan intentionally keeps classification instruction-based for v1. If real use shows the
+same artifact routes differently across runs, the deferred deterministic classifier should move
+from follow-up to implementation scope.

--- a/docs/work-sessions/2026-05-29-infiquetra-doc-review.md
+++ b/docs/work-sessions/2026-05-29-infiquetra-doc-review.md
@@ -1,0 +1,34 @@
+# Work Session: Infiquetra Doc Review
+
+**Date.** 2026-05-29
+**Plan.** `docs/plans/2026-05-29-001-feat-infiquetra-doc-review-plan.md`
+**Status.** Complete
+
+## Summary
+
+Implemented `/doc-review` for `infiquetra-loop` as an implementation-readiness review command
+for plans, requirements documents, formal SDLC artifacts, and strategy/scope documents.
+
+## Changes
+
+- Added `plugins/infiquetra-loop/commands/doc-review.md`.
+- Added `plugins/infiquetra-loop/skills/doc-review/SKILL.md`.
+- Updated `/loop` and `/work` guidance to prompt for doc review before execution and block on
+  unresolved `P0` / `P1` findings unless explicitly overridden.
+- Extended `plugins/infiquetra-loop/scripts/issue_progress.py` to render doc-review artifacts,
+  block status, fixes, findings, and override rationale.
+- Updated plugin metadata, marketplace keywords, README, changelog, and contract tests.
+- Archived the shipped queue item, rejected the `/ce-doc-review` alias, and queued follow-up
+  unification/classification ideas.
+
+## Verification
+
+- `uv run pytest tests/test_infiquetra_loop_plugin.py -q`
+- `uv run pytest -q`
+- `uv run ruff check plugins/infiquetra-loop/scripts/issue_progress.py tests/test_infiquetra_loop_plugin.py`
+- `git diff --check`
+
+## Residual Risk
+
+`/doc-review` classification is instruction-based in v1. The journal queues a deterministic
+classifier helper if real use shows inconsistent routing.

--- a/plugins/infiquetra-loop/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-loop/.claude-plugin/plugin.json
@@ -13,6 +13,7 @@
     "strategy",
     "ideation",
     "brainstorm",
+    "doc-review",
     "code-review",
     "optimize",
     "qa",

--- a/plugins/infiquetra-loop/CHANGELOG.md
+++ b/plugins/infiquetra-loop/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.0 - 2026-05-29
 
 - Add the Infiquetra lifecycle command set from office-hours through resume.
+- Add `/doc-review` for plan, requirements, and formal SDLC implementation-readiness review.
 - Add durable repository artifact guidance and ignored local runtime-state guidance.
 - Add helper scripts for destination selection, issue progress comments, deploy strategy
   detection, team-execution escalation, and engineering-journal triggers.

--- a/plugins/infiquetra-loop/README.md
+++ b/plugins/infiquetra-loop/README.md
@@ -9,6 +9,8 @@ Infiquetra lifecycle workflow plugin for day-to-day engineering work.
 - `/strategy` maintains the root `STRATEGY.md`.
 - `/plan`, `/work`, `/qa`, `/retro`, and `/resume` run the durable work loop.
 - `/founder-review` and `/ceo-review` review ambition, scope, and operator risk.
+- `/doc-review` reviews plans, requirements, and formal SDLC artifacts for implementation
+  readiness.
 - `/code-review` runs a structured pre-PR review.
 - `/optimize` runs metric-driven improvement loops.
 
@@ -43,3 +45,4 @@ Ignored local state belongs under `.claude/infiquetra-loop/`.
 - `scripts/load_saga_context.py` reconstructs prior issue, PR, checkpoint, and journal context.
 - `scripts/discover_subissues.py` discovers GitHub sub-issues through GraphQL.
 - `scripts/detect_deploy_strategy.py` classifies tag-promotion workflow coverage.
+- `scripts/issue_progress.py` renders issue comments, including doc-review status when present.

--- a/plugins/infiquetra-loop/commands/doc-review.md
+++ b/plugins/infiquetra-loop/commands/doc-review.md
@@ -1,0 +1,13 @@
+---
+name: doc-review
+description: Review an Infiquetra plan or requirements document for implementation readiness
+argument-hint: "[document path]"
+---
+
+Load `infiquetra-loop/skills/doc-review/SKILL.md`. Review the target document for readiness
+to drive implementation, apply only evidence-backed safe fixes in place, and report remaining
+findings as `P0` / `P1` / `P2` / `P3`.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/scripts/issue_progress.py
+++ b/plugins/infiquetra-loop/scripts/issue_progress.py
@@ -30,6 +30,14 @@ def _checks_lines(checks_run: Sequence[str] | None) -> list[str]:
     return lines
 
 
+def _list_lines(label: str, values: Sequence[str] | None) -> list[str]:
+    if not values:
+        return []
+    lines = [f"- {label}:"]
+    lines.extend(f"  - {value}" for value in values)
+    return lines
+
+
 def render_issue_comment(
     *,
     event: str,
@@ -43,6 +51,11 @@ def render_issue_comment(
     blockers: str | None = None,
     pr_url: str | None = None,
     review_status: str | None = None,
+    doc_review_artifact: str | None = None,
+    doc_review_blocked: bool | None = None,
+    doc_review_fixes: Sequence[str] | None = None,
+    doc_review_findings: Sequence[str] | None = None,
+    doc_review_override: str | None = None,
     deploy_status: str | None = None,
     workflow_url: str | None = None,
     evidence_link: str | None = None,
@@ -58,6 +71,12 @@ def render_issue_comment(
         _line("commit", commit_sha),
         _line("PR", pr_url),
         _line("review status", review_status),
+        _line("doc review artifact", doc_review_artifact),
+        _line(
+            "doc review blocked",
+            None if doc_review_blocked is None else ("yes" if doc_review_blocked else "no"),
+        ),
+        _line("doc review override", doc_review_override),
         _line("deployment status", deploy_status),
         _line("workflow", workflow_url),
         _line("evidence", evidence_link),
@@ -65,6 +84,8 @@ def render_issue_comment(
     ):
         if candidate:
             lines.append(candidate)
+    lines.extend(_list_lines("doc review fixes", doc_review_fixes))
+    lines.extend(_list_lines("doc review findings", doc_review_findings))
     lines.extend(_checks_lines(checks_run))
     return "\n".join(lines).rstrip() + "\n"
 

--- a/plugins/infiquetra-loop/skills/doc-review/SKILL.md
+++ b/plugins/infiquetra-loop/skills/doc-review/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: doc-review
+description: Review Infiquetra plans, requirements, and SDLC documents for implementation readiness.
+---
+
+# Doc Review
+
+Use this when a plan, requirements document, strategy document, or formal Infiquetra SDLC
+artifact is about to guide implementation.
+
+The core question is:
+
+> Can this document safely drive implementation without the agent inventing missing decisions
+> or acting on unverified assumptions?
+
+This is not a copy-editing workflow and it is not a replacement for code review.
+
+## Target Resolution
+
+1. If the user supplied a path, read that document.
+2. If no path was supplied, look for an obvious active plan or requirements document under
+   `docs/plans/` or `docs/brainstorms/`.
+3. If the target is still ambiguous, ask for the document path before reviewing.
+
+Do not create a `/ce-doc-review` alias. The Infiquetra command surface is `/doc-review`.
+
+## Classification
+
+Classify by explicit context first, then evidence. Use this precedence:
+
+1. Explicit user command context, such as "review this spec" or "review this issue".
+2. Known SDLC paths or identifiers:
+   - Blueprint sections or ADRs -> `/blueprint-review`
+   - Specs under `specs/` or documents with spec-phase metadata -> `/spec-review`
+   - GitHub issue references or issue-derived documents -> `/issue-review`
+3. Content-shape signals:
+   - Plan signals: `origin:`, `Implementation Units`, `Key Technical Decisions`, `U1`,
+     file lists, test scenarios, verification sections.
+   - Requirements signals: goals, non-goals, acceptance examples, flows, success criteria,
+     problem framing, `docs/brainstorms/`.
+   - Strategy/scope signals: `STRATEGY.md`, strategy updates, founder-scope documents,
+     scope or ambition decisions that are about to drive implementation.
+4. Path tie-breakers:
+   - `docs/plans/` -> plan
+   - `docs/brainstorms/` -> requirements
+   - `STRATEGY.md` -> strategy/scope
+
+When classification remains ambiguous, ask before routing. Do not silently guess on a formal
+SDLC artifact because routing determines which review responsibilities run.
+
+## Formal SDLC Routing
+
+Formal SDLC artifacts get the specialized Infiquetra rubric review first:
+
+- Blueprint sections and ADRs: run `/blueprint-review`.
+- Specifications: run `/spec-review`.
+- GitHub issues and issue-derived documents: run `/issue-review`.
+
+After the delegate finishes, run the readiness-skeptic pass. Re-read the target document,
+collect any delegate artifact or appended review log when present, and include unresolved
+formal findings in the readiness summary. Do not reclassify formal rubric findings as
+readiness findings.
+
+If `blueprint-reviewer` or a delegate command is unavailable, say so clearly and continue with
+readiness review where safe.
+
+## Readiness-Skeptic Pass
+
+Always check:
+
+1. **Verification.** Claims, requirements, and actions must be supported by cited evidence,
+   the document itself, linked source, or local repository evidence.
+2. **Assumptions.** Surface stale, wrong, or unstated assumptions that would affect execution.
+3. **Requirement mapping.** Check origin requirements, acceptance criteria, schema requirements,
+   implementation units, and gates map correctly.
+4. **Completeness.** Detect missing fields, schema requirements, gates, decisions, or review
+   artifacts the document already implies.
+5. **Open-choice pressure.** Flag implementation choices that should be defaults, decisions, or
+   explicit evidence-gathering tasks.
+6. **Adversarial failure modes.** Ask what breaks if an agent follows the document literally.
+
+Triggered lenses:
+
+- Use security/ops scrutiny when the document touches secrets, authorization, deployment,
+  infrastructure, data, or external integrations.
+- Suggest `/founder-review` as an additional lens when strategy, product scope, ambition, or
+  user-facing behavior is prominent.
+- Use deployment readiness scrutiny when the document includes deploy, rollback, release,
+  environment, or CI/CD behavior.
+
+## Safe In-Place Fixes
+
+Safe fixes are enabled by default and edit the reviewed document in place.
+
+Safe means the document itself, linked source, or local repository evidence clearly supports the
+change. Examples:
+
+- add missing schema fields already implied elsewhere in the document
+- correct origin requirement mappings when the right mapping is evident
+- move follow-up work out of canonical schema and into prose or runbook sections
+- fill in gates or checklist items already required by the surrounding section
+- fix stale internal references, broken headings, wrong counts, or inconsistent naming
+
+Unsafe changes become findings instead of edits:
+
+- inventing acceptance criteria
+- choosing architecture without evidence
+- changing scope based on preference
+- resolving product decisions without user input
+- adding requirements not implied by source material
+
+## Findings
+
+Report remaining findings using priorities:
+
+- `P0`: The document would cause unsafe, incorrect, destructive, or materially wrong execution.
+- `P1`: The document is not ready to drive implementation because a core assumption, mapping,
+  requirement, default, or gate is missing or wrong.
+- `P2`: The document can probably drive work, but the issue creates meaningful rework,
+  ambiguity, or review risk.
+- `P3`: Nice-to-fix clarity, maintainability, or polish issue.
+
+Lead with findings. A short readiness summary is useful, but P-level findings are the primary
+output language.
+
+## Durable Review Artifacts
+
+Write a review artifact under `docs/reviews/` when any trigger is true:
+
+- any `P0` or `P1` finding remains
+- any safe fix edits the document
+- a formal SDLC delegate ran
+- an issue-attached lifecycle flow is active
+- more than three findings remain after safe fixes
+
+Every significant review artifact should include:
+
+- This review-result contract:
+- target path
+- reviewed revision when available, such as a commit SHA or explicit "working tree"
+- blocked status
+- finding priorities and statuses
+- applied fixes
+- review artifact path
+- override rationale when applicable
+- linked issue, plan, or work-session path when available
+
+Ignored local state under `.claude/infiquetra-loop/` is not durable review output.
+
+## Loop And Work Integration
+
+`/doc-review` is explicit by default. `/work` should ask whether to run it before executing from
+a plan or requirements document.
+
+If `/doc-review` runs and unresolved `P0` or `P1` findings remain, `/work` blocks unless the
+user explicitly overrides. `/work` may consume same-session review output or the latest matching
+`docs/reviews/` artifact. Overrides need a rationale that can be carried into issue progress or
+work-session notes.
+
+For issue-attached work, summarize:
+
+- fixes applied
+- remaining findings
+- blocked status
+- override rationale, when present
+- review artifact link
+
+## Output Shape
+
+Use this structure:
+
+1. Applied fixes, if any.
+2. Readiness summary.
+3. Remaining findings by priority.
+4. Review artifact path, when written.
+5. Residual risk from limited evidence, if any.
+
+If no issues are found, say so clearly and name any remaining risk from limited evidence.

--- a/plugins/infiquetra-loop/skills/loop/SKILL.md
+++ b/plugins/infiquetra-loop/skills/loop/SKILL.md
@@ -59,6 +59,9 @@ movement at Infiquetra SDLC phase boundaries.
 
 - Behavior, security, infra, API, deployment, and data changes require tests.
 - Docs, config, and trivial changes may skip tests only with an explicit rationale.
+- Before `/work` executes from a plan or requirements document, ask whether to run `/doc-review`.
+  If review runs and reports unresolved `P0` or `P1` findings, block execution unless the user
+  explicitly overrides and gives a rationale.
 - Run an engineering review before execution on risky plans and before shipping gates.
 - Suggest founder review for strategy, scope, product, or user-facing work.
 

--- a/plugins/infiquetra-loop/skills/work/SKILL.md
+++ b/plugins/infiquetra-loop/skills/work/SKILL.md
@@ -11,12 +11,19 @@ Use this after a plan is approved or when resuming execution from a durable plan
 
 1. Load the plan and active issue or PR.
 2. Record the active pointer in `.claude/infiquetra-loop/`.
-3. Execute one meaningful phase at a time.
-4. After each phase, write a concise summary under `docs/work-sessions/`.
-5. Comment issue progress through `sdlc-manager` with plan path, work-session path, commit SHA,
-   checks run, and blockers.
-6. Run hard test gates for behavior, security, infra, API, deployment, or data changes.
-7. Run `/code-review` before PR or shipping gates.
-8. If the destination includes nonprod deploy, hand off deployment mutation to `infiquetra-deploy`.
+3. When executing from a plan or requirements document, ask whether to run `/doc-review` first.
+   If review runs and returns unresolved `P0` or `P1` findings, block execution unless the user
+   explicitly overrides and provides a rationale.
+4. Execute one meaningful phase at a time.
+5. After each phase, write a concise summary under `docs/work-sessions/`.
+6. Comment issue progress through `sdlc-manager` with plan path, work-session path, commit SHA,
+   checks run, blockers, and any doc-review artifact, findings, block status, or override
+   rationale.
+7. Run hard test gates for behavior, security, infra, API, deployment, or data changes.
+8. Run `/code-review` before PR or shipping gates.
+9. If the destination includes nonprod deploy, hand off deployment mutation to `infiquetra-deploy`.
 
 Do not close or move the issue until acceptance criteria and the selected destination are satisfied.
+
+For doc-review gating, use same-session review output or the latest matching artifact under
+`docs/reviews/`. Do not treat chat memory alone as durable evidence after resume.

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -227,9 +227,7 @@ def load_config() -> dict[str, Any]:
 _VENDORED_PROJECT_MAPPINGS_PATH = (
     Path(__file__).resolve().parent.parent / "config" / "project-mappings.json"
 )
-_VENDORED_SDLC_SCHEMA_PATH = (
-    Path(__file__).resolve().parent.parent / "config" / "sdlc-schema.json"
-)
+_VENDORED_SDLC_SCHEMA_PATH = Path(__file__).resolve().parent.parent / "config" / "sdlc-schema.json"
 PROJECT_CHOICES = ("mount-olympus", "asgard", "jeff-intent")
 LIVE_LEGACY_STATUS_ALIASES = {
     "In Progress": "Assigned",
@@ -375,9 +373,19 @@ def _wip_limits(config: dict, project_name: str, proj: dict) -> dict[str, Any]:
     schema = config.get("sdlc_schema", {})
     board_key = _project_board_key(project_name, proj)
     limits = schema.get("wip_limits", {}).get(board_key, {})
-    if not limits:
-        return {"Ready": 10, "In Progress": 10 if project_name == "mount-olympus" else 5}
-    return cast(dict[str, Any], limits)
+    if limits:
+        return cast(dict[str, Any], limits)
+
+    legacy_limits = config.get("legacy_rollout_config", {}).get("wip_limits", {})
+    if project_name == "mount-olympus" and isinstance(legacy_limits, dict) and legacy_limits:
+        return {
+            "Ready": legacy_limits.get("ready", 10),
+            "In Development": legacy_limits.get("in_development", 10),
+            "E2E Testing": legacy_limits.get("e2e_testing", 3),
+            "Deployment Ready": legacy_limits.get("deployment_ready", 5),
+        }
+
+    return {"Ready": 10, "In Progress": 10 if project_name == "mount-olympus" else 5}
 
 
 def _terminal_statuses(config: dict, project_name: str, proj: dict) -> list[str]:

--- a/tests/test_infiquetra_loop_plugin.py
+++ b/tests/test_infiquetra_loop_plugin.py
@@ -43,7 +43,7 @@ def test_infiquetra_loop_metadata_and_marketplace_entry_match() -> None:
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/infiquetra-loop"
     assert "lifecycle" in plugin_json["description"]
-    assert {"loop", "lifecycle", "strategy", "code-review", "optimize"} <= set(
+    assert {"loop", "lifecycle", "strategy", "doc-review", "code-review", "optimize"} <= set(
         plugin_json["keywords"]
     )
 
@@ -62,6 +62,7 @@ def test_infiquetra_loop_commands_are_packaged() -> None:
         "resume",
         "founder-review",
         "ceo-review",
+        "doc-review",
         "code-review",
         "optimize",
     ):
@@ -81,6 +82,7 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "retro",
         "resume",
         "founder-review",
+        "doc-review",
         "code-review",
         "optimize",
     }
@@ -97,6 +99,7 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "infiquetra-deploy",
         "sdlc-manager",
         "issue progress",
+        "doc-review",
         "engineering-journal",
     ):
         assert required in loop_doc
@@ -107,8 +110,28 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "find_inflight_work.py",
         "load_saga_context.py",
         "discover_subissues.py",
+        "issue_progress.py",
     ):
         assert (PLUGIN_ROOT / "scripts" / script).exists()
+
+    doc_review_doc = _read(PLUGIN_ROOT / "skills" / "doc-review" / "SKILL.md")
+    for required in (
+        "/blueprint-review",
+        "/spec-review",
+        "/issue-review",
+        "/founder-review",
+        "classification",
+        "review-result contract",
+        "target path",
+        "reviewed revision",
+        "blocked status",
+        "override rationale",
+        "any `P0` or `P1`",
+        "safe fixes",
+        "docs/reviews/",
+    ):
+        assert required in doc_review_doc
+    assert not (PLUGIN_ROOT / "commands" / "ce-doc-review.md").exists()
 
 
 def test_destination_selector_and_escalation_helpers() -> None:
@@ -168,6 +191,24 @@ def test_issue_progress_comments_include_required_evidence() -> None:
     assert "docs/work-sessions/2026-05-29-phase-1.md" in phase
     assert "abc1234" in phase
     assert "uv run pytest tests/test_service.py -q" in phase
+
+    review = issue_progress.render_issue_comment(
+        event="phase",
+        issue_ref="infiquetra/campps-service#42",
+        destination="pr",
+        doc_review_artifact="docs/reviews/2026-05-29-doc-review.md",
+        doc_review_blocked=True,
+        doc_review_fixes=["Added missing gate."],
+        doc_review_findings=["P1 Missing rollback evidence."],
+        doc_review_override="Proceeding after owner accepted risk.",
+    )
+    assert "doc review artifact: docs/reviews/2026-05-29-doc-review.md" in review
+    assert "doc review blocked: yes" in review
+    assert "doc review override: Proceeding after owner accepted risk." in review
+    assert "doc review fixes:" in review
+    assert "Added missing gate." in review
+    assert "doc review findings:" in review
+    assert "P1 Missing rollback evidence." in review
 
 
 def test_deploy_strategy_detection_matches_infiquetra_policy() -> None:


### PR DESCRIPTION
## Summary
- add /doc-review command and skill for plan and requirements readiness review
- wire loop/work gating and issue-progress rendering for doc-review artifacts, findings, and overrides
- update marketplace metadata, docs, tests, and engineering journal artifacts

## Tests
- uv run pytest tests/test_infiquetra_loop_plugin.py -q
- uv run pytest -q
- uv run ruff check plugins/infiquetra-loop/scripts/issue_progress.py tests/test_infiquetra_loop_plugin.py
- git diff --check