### PR TITLE
feat(sdlc-manager): add prepared issue workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -345,8 +345,8 @@
     {
       "name": "sdlc-manager",
       "source": "./plugins/sdlc-manager",
-      "version": "1.0.0",
-      "description": "SDLC workflow manager for the Mount Olympus all-agent team. Kanban board management, issue lifecycle, flow metrics, and Beads coordination via Python CLI. Skills: sdlc-board, sdlc-issues, sdlc-labels, sdlc-metrics, sdlc-milestones, sdlc-rollout.",
+      "version": "1.5.0",
+      "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. Schema-backed board management, issue lifecycle, project fields, sub-issues, labels, flow metrics, milestones, and rollout helpers via Python CLI.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"
@@ -358,8 +358,10 @@
         "kanban",
         "project-management",
         "github-projects",
-        "beads",
         "mount-olympus",
+        "asgard",
+        "jeff-intent",
+        "project-fields",
         "workflow"
       ],
       "category": "development"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -345,8 +345,8 @@
     {
       "name": "sdlc-manager",
       "source": "./plugins/sdlc-manager",
-      "version": "1.5.0",
-      "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. Schema-backed board management, issue lifecycle, project fields, sub-issues, labels, flow metrics, milestones, and rollout helpers via Python CLI.",
+      "version": "1.6.0",
+      "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. Adds prepared issue drafts, board management, project fields, labels, flow metrics, milestones, and rollout helpers via Python CLI.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"

--- a/.codex/plans/2026-05-29-delegate-agent-feasibility.md
+++ b/.codex/plans/2026-05-29-delegate-agent-feasibility.md
@@ -1,0 +1,49 @@
+# Delegate Agent Plugin Feasibility
+
+## Goal
+
+Research whether this repository can add a Claude Code plugin that delegates agent work to
+local Codex and Antigravity CLI surfaces without using API keys, then write a reviewable
+ideation document.
+
+## Scope
+
+- Inspect existing plugin and `team-execution` conventions.
+- Verify local CLI behavior where available.
+- Research current public docs for Claude Code plugins, Codex CLI, and Antigravity CLI.
+- Identify feasible delegation models, risks, and recommended next exploration path.
+- Save the output in `docs/ideation/`.
+
+## Current Phase
+
+Follow-up complete. Ideation document now includes MCP, Codex App Server/Desktop, and Antigravity
+2.0 app/SDK route analysis.
+
+## Checks Run
+
+- `find docs -maxdepth 3 -type f | sort`
+- `rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g 'README.md' -g 'STRATEGY.md' -g 'pyproject.toml' -g 'package.json'`
+- `find plugins/team-execution -maxdepth 4 -type f | sort`
+- `codex --version`
+- `codex exec --help`
+- `codex exec --ephemeral --sandbox read-only --output-last-message /tmp/compound-engineering-codex-probe.txt 'Reply with exactly: CODEX_OK'`
+- `agy --version`
+- `agy --help`
+- `agy --print-timeout 10s --print 'Reply with exactly: AGY_OK'`
+- `agy plugin --help`
+- `agy changelog`
+- `git diff --check`
+- `git diff --no-index --check /dev/null docs/ideation/2026-05-30-delegate-agent-plugin-ideation.md`
+- `git diff --no-index --check /dev/null .codex/plans/2026-05-29-delegate-agent-feasibility.md`
+- `rg -n "[^\\x00-\\x7F]" docs/ideation/2026-05-30-delegate-agent-plugin-ideation.md .codex/plans/2026-05-29-delegate-agent-feasibility.md docs/engineering-journal/QUEUED.md`
+- `codex app-server --help`
+- `codex mcp-server --help`
+- `codex mcp --help`
+- `find /Applications -maxdepth 2 -iname '*codex*' -o -iname '*antigravity*' -o -iname '*gemini*'`
+- `sed -n '120,165p' /Applications/Codex.app/Contents/Info.plist`
+- `sed -n '1,160p' /Applications/Antigravity.app/Contents/Info.plist`
+
+## Output
+
+- `docs/ideation/2026-05-30-delegate-agent-plugin-ideation.md`
+- `docs/engineering-journal/QUEUED.md` entry `delegate-agents-plugin`

--- a/.codex/plans/2026-05-30-sdlc-manager-alignment.md
+++ b/.codex/plans/2026-05-30-sdlc-manager-alignment.md
@@ -1,0 +1,51 @@
+# SDLC Manager Alignment Checkpoint
+
+## Goal
+
+Document whether `plugins/sdlc-manager` matches the current `infiquetra-sdlc`
+operating model and decide whether to continue with a docs/prompt alignment pass.
+
+## Current Phase
+
+Implementation complete in the working tree. Awaiting user decision on commit/PR handling.
+
+## Completed
+
+- Compared the vendored plugin schema with `../infiquetra-sdlc/config/sdlc-schema.json`.
+- Ran `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`.
+- Ran `uv run pytest plugins/sdlc-manager/tests -q` with 93 passing tests.
+- Identified prompt/reference drift in:
+  - `plugins/sdlc-manager/skills/sdlc-issues/references/issue-types.md`
+  - `plugins/sdlc-manager/agents/sdlc-operator.md`
+  - `plugins/sdlc-manager/commands/sdlc-triage.md`
+  - `plugins/sdlc-manager/skills/sdlc-labels/SKILL.md`
+- Identified release metadata drift:
+  - `plugins/sdlc-manager/.claude-plugin/plugin.json` remains `1.4.0`.
+  - `.claude-plugin/marketplace.json` lists `sdlc-manager` as `1.0.0`.
+  - current schema/template work remains under `Unreleased`.
+- Wrote `docs/ideation/2026-05-30-sdlc-manager-alignment-pass.md`.
+- Updated prompt/reference docs to use current Hermes-actionability and label contracts.
+- Marked `needs-analysis` / `needs-triage` as legacy auto-label fallback labels, not current
+  template defaults.
+- Bumped `sdlc-manager` plugin and marketplace metadata to `1.5.0`.
+- Added `plugins/sdlc-manager/tests/test_prompt_alignment.py`.
+- Moved the SDLC-manager alignment queue item to `ARCHIVE.md` as shipped.
+
+## Next Steps
+
+1. Review the diff.
+2. Decide whether to commit these changes from `main` or move them to a branch/worktree first.
+3. Separately decide whether `infiquetra-sdlc/config/labels.json` should migrate legacy
+   title-pattern auto-label rules from `needs-analysis` / `needs-triage` to `needs-plan`.
+
+## Blockers
+
+None for this repo. Cross-repo label-config migration remains a separate `infiquetra-sdlc`
+decision.
+
+## Checks Run
+
+- `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`
+- `uv run ruff check plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- `uv run pytest plugins/sdlc-manager/tests tests/test_sdlc_manager.py -q`
+- `git diff --check`

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Thumbs.db
 
 # Claude Code (per-user settings and session state)
 .claude/
+
+# Antigravity CLI (per-user settings and session state)
+.antigravitycli/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# Codex Configuration for Infiquetra Claude Plugins
+
+## 📓 Engineering journal — AUTO-MAINTAIN
+
+Living documentation at [`docs/engineering-journal/`](docs/engineering-journal/) — pattern adopted from `infiquetra/home-lab/docs/engineering-journal/`. The directory IS the engineering journal; the files inside are its sections.
+
+| File | Purpose |
+|------|---------|
+| [LEARNINGS.md](docs/engineering-journal/LEARNINGS.md) | Empirical findings + mechanisms + fixes + validations |
+| [DECISIONS.md](docs/engineering-journal/DECISIONS.md) | ADR-style records of plugin-pattern / convention / tooling choices, with rationale + revisit conditions |
+| [QUEUED.md](docs/engineering-journal/QUEUED.md) | Future-work items by priority with "worth it when" triggers |
+| [ARCHIVE.md](docs/engineering-journal/ARCHIVE.md) | Shipped + rejected + superseded items |
+| [narratives/](docs/engineering-journal/narratives/) | Self-contained, longer-form companion docs (plugin design walkthroughs, multi-PR post-mortems, migration write-ups) — readable cold by an outside reader |
+
+**Maintenance rules (Codex: follow these without being asked):**
+
+1. **After fixing a plugin bug or shipping a feature where the mechanism wasn't obvious** (marketplace registry drift, hook timing race, skill activation gotcha, MCP env propagation, build-tool surprise) → add a dated entry to `LEARNINGS.md`. Include the **evidence** (PR / commit / file:line) and the **mechanism** (why it happened, not just what), and a **Generalizable rule** line stripping the lesson from the specific incident.
+
+2. **After committing a plugin-pattern decision** (skills-based vs CLI-based, line length, lockfile choice, marketplace category, version bump strategy, hook event choice, naming convention) → add an entry to `DECISIONS.md` with rationale + rejected alternatives + "revisit when" condition. Include the commit hash.
+
+3. **Whenever a promising idea surfaces but we don't build it right now** (new plugin idea, CI guard, refactor, test improvement) → add to `QUEUED.md` with priority (P0/P1/P2/P3/Maybe), concrete "worth it when" trigger, and rough effort estimate. Don't skip this step — undocumented good ideas decay into forgotten good ideas.
+
+4. **When a QUEUED item ships** → move its entry to `ARCHIVE.md` as SHIPPED with the commit hash + date. Remove it from `QUEUED.md`.
+
+5. **When a QUEUED item is rejected** (we decide it's not worth doing) → move to `ARCHIVE.md` as REJECTED with the reason + revisit conditions. Remove from `QUEUED.md`.
+
+6. **When a prior LEARNING or DECISION is invalidated** (new evidence contradicts the old claim) → update the original entry inline with the correction AND move the pre-correction version to `ARCHIVE.md` as SUPERSEDED. Never silently overwrite history.
+
+7. **When something needs a longer write-up than fits in an entry** (full plugin design narrative, multi-PR post-mortem, migration write-up, rejected-design memo) → create `docs/engineering-journal/narratives/YYYY-MM-DD-short-slug.md` and link to it from the relevant LEARNINGS / DECISIONS entry. The four core files stay scannable; long-form companion lives next door.
+
+**Entry format.** Each of the four core files has a block-quote intro at the top spelling out its format. New entries use these subheaders where applicable: **Context / Evidence / Mechanism / Fix (or queued) / Validation / What surprised / Generalizable rule / Refs**. Not every entry needs every subheader, but the **Generalizable rule** line is the highest-value field — without it, future-Codex has to re-derive the lesson from the evidence each time.
+
+**Don't wait to be asked.** When any of these triggers fire in a session, update the files as part of the same commit that ships the change. The whole point of these files is that they maintain themselves.
+
+## Repository Information
+
+- **Repository**: infiquetra-claude-plugins
+- **Purpose**: Claude Code plugins for Infiquetra development workflows
+- **Organization**: Infiquetra
+
+## Plugin Types
+
+This repository contains two types of Claude Code plugins:
+
+### Skills-based Plugins
+Markdown-driven plugins that provide Codex with knowledge about Claude Code plugin structure,
+patterns, and agent definitions. No Python scripts required.
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   └── agent-name.md       # Agent system prompt + trigger conditions
+├── skills/
+│   └── skill-name/
+│       ├── SKILL.md        # Skill definition with frontmatter
+│       └── references/     # Supporting reference documents (.md)
+├── README.md
+└── CHANGELOG.md
+```
+
+**Examples**: `identity-toolkit`, `python-toolkit`, `sdk-lifecycle`, `docs-generator`, `test-suite`
+
+### CLI-based Plugins
+Python CLI scripts wrapped as Claude Code skills/commands for interacting with external services.
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   └── agent-name.md
+├── skills/
+│   └── skill-name/
+│       ├── SKILL.md
+│       └── scripts/
+│           └── service_client.py   # CLI implementation
+├── commands/
+│   └── command.md
+├── README.md
+└── CHANGELOG.md
+```
+
+**Examples**: `pagerduty`, `slack`, `splunk`, `todoist-manager`
+
+## Plugin Development Guidelines
+
+### Naming Conventions
+- Plugin directories: `kebab-case` (e.g., `python-toolkit`)
+- Python files: `snake_case` (e.g., `splunk_client.py`)
+- Classes: `PascalCase` (e.g., `SplunkClient`)
+- Skill names in frontmatter: `kebab-case` (e.g., `splunk-search`)
+
+### Code Quality Standards
+- Python 3.12+ required
+- Type hints enforced with mypy
+- Ruff linting with 100-character line limit
+- Minimum 80% test coverage
+- Security scanning with bandit
+
+### Testing Requirements
+- Unit tests for all CLI-based plugins (in `tests/` at repo root)
+- Test files named `test_<plugin_client>.py`
+- Use pytest as the test framework
+- Add shared fixtures to `tests/conftest.py`
+
+### plugin.json Required Fields
+```json
+{
+  "name": "plugin-name",
+  "version": "1.0.0",
+  "description": "Clear description of what the plugin does",
+  "author": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
+  "keywords": ["relevant", "tags"]
+}
+```
+
+## Development Workflow
+
+1. Scaffold plugin: `./tools/create-plugin.sh my-plugin`
+2. Implement in appropriate structure (skills-based or CLI-based)
+3. Write tests in `tests/` for CLI plugins
+4. Document in README.md
+5. Add entry to `.claude-plugin/marketplace.json`
+6. Submit PR for review
+
+## Running Quality Checks
+
+```bash
+# Run all checks
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/test_pagerduty_client.py -v
+
+# Run linting
+uv run ruff check .
+
+# Run type checking
+uv run mypy plugins/
+
+# Run security scan
+uv run bandit -r plugins/
+```
+
+## Scaffold New Plugin
+
+```bash
+./tools/create-plugin.sh my-new-plugin
+```

--- a/docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md
+++ b/docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md
@@ -1,0 +1,286 @@
+---
+date: 2026-05-30
+topic: sdlc-manager-issue-prepare
+title: SDLC Manager Issue Prepare Requirements
+source_idea: docs/ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md
+---
+
+# Requirements: SDLC Manager Issue Prepare
+
+## Summary
+
+Add a team-aware issue preparation workflow to `sdlc-manager`. The workflow turns source text into
+reviewable issue drafts for Asgard or Mount Olympus, then creates the issue through a separate
+confirmed command that can repair missing repo prerequisites and record the result back onto the
+draft.
+
+---
+
+## Problem Frame
+
+`sdlc-manager` can create template-guided issues, deploy labels/templates, add issues to project
+boards, and validate the strict actionable body shape. It does not yet provide one reliable path
+from rough source text to an issue that is ready for the intended team.
+
+The current gap is not only issue body generation. Asgard and Mount Olympus have different
+readiness expectations. Asgard can accept shaping, incubation, and mission-mode work that is not
+yet a strict execution contract. Mount Olympus needs dispatch-ready issue structure: concrete
+objective, acceptance criteria, scoped file paths, test expectations, verification commands,
+labels, board placement, and safe default status.
+
+Without a team-aware prepare/create workflow, agents and operators can create issues that look
+valid but are routed too early, lack required labels/templates, miss project mappings, or require
+manual repair before any team can use them.
+
+---
+
+## Key Decisions
+
+- **Prepare and create are separate commands.** `issue prepare` writes a draft artifact and
+  readiness sidecar. `issue create-prepared` performs GitHub mutations only after showing a final
+  confirmation plan.
+- **V1 includes creation.** Creation is not deferred to a later project, but it is separated from
+  drafting so the operator can review before mutation.
+- **Team and project are both required.** The deterministic command/API should know both target
+  team and project. Natural-language skills may infer them when obvious, but must ask when the
+  prompt is ambiguous.
+- **The skill/model drafts; the CLI validates and mutates.** Rough-source interpretation belongs in
+  the skill layer. `sdlc_manager.py` owns deterministic parsing, readiness checks, mutation-plan
+  construction, and GitHub operations.
+- **Repo readiness is self-healing by explicit confirmation.** Missing labels/templates are
+  deployed directly. Missing project mappings trigger a branch-and-PR mapping update flow before
+  issue creation proceeds by default.
+
+---
+
+## Actors
+
+- A1. Operator — the human asking for issue preparation or creation.
+- A2. Agent skill — interprets natural-language prompts, shapes rough source text, and writes draft
+  artifacts for the CLI to validate.
+- A3. `sdlc-manager` CLI — deterministic tool that parses drafts, validates readiness, builds
+  mutation plans, and performs confirmed GitHub operations.
+- A4. GitHub repository and project surfaces — target repo labels/templates/issues plus Asgard or
+  Mount Olympus project board state.
+- A5. SDLC mapping owner — the canonical source for repo-to-project mappings, normally the SDLC
+  config repo; the plugin vendored mapping is a fallback.
+
+---
+
+## Requirements
+
+**Draft Preparation**
+
+- R1. `issue prepare` accepts source text from a prompt argument, stdin, or `--source-file`, and
+  produces the same draft artifact shape regardless of input source.
+- R2. `issue prepare` requires or infers the target repo, issue type, target team, and target
+  project; if any cannot be inferred safely, it must ask rather than guess.
+- R3. Prepared drafts are stored as repo files under `docs/sdlc-issue-drafts/` so they are easy to
+  review, edit, commit, and pass to the create command.
+- R4. Each prepared draft has a JSON sidecar containing structured readiness results and metadata
+  needed by `issue create-prepared`.
+- R5. Incomplete source text still produces a draft, but missing required fields are marked as
+  blocking gaps.
+- R6. A draft with blocking gaps cannot be created until the required gaps are resolved in the
+  draft and sidecar.
+
+**Team Readiness**
+
+- R7. Asgard drafts use the existing SDLC issue types and a relaxed readiness profile focused on
+  shaping quality: intent, target repo/surface, mode, constraints, risk, and promotion gaps.
+- R8. Olympus drafts use the existing actionable issue templates and strict readiness profile:
+  required H3 sections, checklist acceptance criteria, path-like expected files, fenced
+  verification commands, actionable labels, author risk visibility, project presence, and safe
+  status.
+- R9. The workflow must not treat an Asgard-shaped draft as Olympus-ready unless the Olympus
+  readiness profile passes.
+- R10. The workflow must never auto-move a new issue to `Ready`.
+- R11. `issue create-prepared` sets safe default statuses only: Asgard issues start in `Shaping`;
+  Mount Olympus issues start in `Backlog`.
+
+**Creation And Mutation**
+
+- R12. `issue create-prepared <draft>` consumes the markdown draft and JSON sidecar, then presents a
+  final mutation plan before any GitHub or mapping mutation.
+- R13. The final mutation plan includes every planned side effect: label/template deployment,
+  mapping branch/PR work, issue creation, board add, status setting, and draft update.
+- R14. Missing labels/templates are deployed directly to the target repo after confirmation.
+- R15. If the target repo is not mapped to the requested project, the create flow updates the
+  canonical SDLC mapping when available; otherwise it may update the vendored plugin mapping with a
+  clear warning.
+- R16. Mapping updates are committed on a branch, pushed, and surfaced as a PR before issue
+  creation continues by default.
+- R17. If mapping is missing, creation stops after opening/reporting the mapping PR unless the
+  operator explicitly chooses an override to create before the mapping PR merges.
+- R18. The explicit override creates the issue using the requested project directly and records
+  that canonical mapping is still pending.
+- R19. After successful issue creation, the draft file is retained and marked with issue URL,
+  issue number, creation timestamp, and mutation summary.
+
+**Natural-Language Use**
+
+- R20. Skills/docs treat natural-language usage as first-class. Prompts such as "create an
+  Olympus issue from this text" route to prepare plus create-prepared, not to ad hoc issue
+  creation.
+- R21. Natural-language flows may infer team/project from explicit phrases such as "Asgard issue"
+  or "Olympus issue"; ambiguous prompts must ask for the missing target.
+- R22. Natural-language creation still uses the same draft artifact, JSON sidecar, readiness
+  checks, and final mutation confirmation as direct CLI usage.
+
+**Validation And Tests**
+
+- R23. The feature includes parser and readiness unit tests for draft parsing, sidecar parsing,
+  Asgard readiness, Olympus readiness, blocked creation, and sidecar/draft state transitions.
+- R24. The feature includes mocked GitHub mutation tests for mutation-plan construction,
+  label/template deployment, mapping PR flow, issue creation, board add, and status setting.
+- R25. Tests must cover the override path that creates an issue before a mapping PR merges.
+
+---
+
+## Key Flows
+
+- F1. Prepare from rough source text
+  - **Trigger:** Operator or agent provides source text plus target repo/team/project.
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Shape source text into an issue draft, write the markdown draft, write the JSON
+    sidecar, and report readiness gaps.
+  - **Outcome:** A reviewable draft exists without GitHub mutation.
+  - **Covers:** R1-R8, R20-R22.
+
+- F2. Prepare with incomplete source
+  - **Trigger:** Source text lacks fields required by the selected team profile.
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Write a draft with blocking gaps and sidecar failures.
+  - **Outcome:** The operator can edit the draft, but `create-prepared` refuses to create until
+    required gaps are resolved.
+  - **Covers:** R5, R6, R9.
+
+- F3. Create when prerequisites are present
+  - **Trigger:** Operator runs `issue create-prepared <draft>` on a passing draft.
+  - **Actors:** A1, A3, A4.
+  - **Steps:** Present the mutation plan, receive confirmation, create the issue, add it to the
+    selected project, set safe default status, and mark the draft created.
+  - **Outcome:** The issue exists in the target repo and starts in the safe status for the chosen
+    team.
+  - **Covers:** R10-R13, R19.
+
+- F4. Create with missing labels/templates
+  - **Trigger:** Target repo lacks required SDLC labels or issue templates.
+  - **Actors:** A1, A3, A4.
+  - **Steps:** Include direct label/template deployment in the mutation plan, deploy after
+    confirmation, then continue issue creation.
+  - **Outcome:** Repo prerequisites are repaired and issue creation proceeds.
+  - **Covers:** R13, R14.
+
+- F5. Create with missing project mapping
+  - **Trigger:** Target repo is not mapped to the requested project.
+  - **Actors:** A1, A3, A5.
+  - **Steps:** Include mapping branch/PR work in the mutation plan, create the mapping branch and
+    PR after confirmation, then stop by default.
+  - **Outcome:** Mapping repair is in flight; issue creation waits for merge unless explicitly
+    overridden.
+  - **Covers:** R15-R18.
+
+---
+
+## Acceptance Examples
+
+- AE1. Olympus draft blocks on missing verification
+  - **Covers R5, R6, R8.**
+  - **Given:** Source text describes a router enhancement but does not include a verification
+    command.
+  - **When:** The agent prepares an Olympus issue draft.
+  - **Then:** The draft is written with a blocking verification gap, and `create-prepared` refuses
+    to create it.
+
+- AE2. Asgard draft accepts shaping-quality input
+  - **Covers R7, R9.**
+  - **Given:** Source text describes mission-mode work with intent, repo, mode, constraints, and
+    risk, but not expected file paths.
+  - **When:** The agent prepares an Asgard issue draft.
+  - **Then:** The Asgard readiness profile can pass, and the draft still reports Olympus promotion
+    gaps separately.
+
+- AE3. Create deploys missing labels/templates after confirmation
+  - **Covers R12-R14.**
+  - **Given:** A passing draft targets a repo missing SDLC templates.
+  - **When:** The operator runs `issue create-prepared`.
+  - **Then:** The confirmation plan lists template/label deployment before issue creation, and
+    creation proceeds only after confirmation.
+
+- AE4. Missing mapping opens PR and stops
+  - **Covers R15-R17.**
+  - **Given:** A passing Olympus draft targets an unmapped repo.
+  - **When:** The operator confirms the mutation plan without an override.
+  - **Then:** The command creates a mapping branch and PR, reports it, and stops before issue
+    creation.
+
+- AE5. Mapping override creates before merge
+  - **Covers R17, R18.**
+  - **Given:** A mapping PR was opened for the target repo.
+  - **When:** The operator explicitly chooses to create before mapping merge.
+  - **Then:** The command creates the issue using the requested project directly and records the
+    pending mapping state in the draft.
+
+- AE6. Natural-language creation uses the same path
+  - **Covers R20-R22.**
+  - **Given:** The operator says, "Create an Asgard issue from this text for the router repo."
+  - **When:** An agent acts on the prompt.
+  - **Then:** The agent prepares the draft artifact and invokes the create-prepared flow rather
+    than bypassing readiness checks.
+
+---
+
+## Success Criteria
+
+- The operator can review a prepared issue draft before any GitHub mutation.
+- Asgard and Olympus readiness are visibly different and cannot be confused by accident.
+- A prepared draft with missing required fields cannot be created.
+- Creation presents one complete mutation plan before side effects occur.
+- Missing labels/templates are fixed in the confirmed create flow.
+- Missing project mappings result in a branch and PR, not an invisible local edit or default-branch
+  push.
+- Natural-language and direct CLI usage converge on the same artifacts and checks.
+- Unit and mocked mutation tests cover blocked create, prerequisite repair, mapping PR flow, and
+  successful issue creation.
+
+---
+
+## Scope Boundaries
+
+- Dedicated `QUEUED.md` parsing is out of scope for v1. Queued entries are source text, not a
+  separate workflow.
+- Auto-moving issues to `Ready` is out of scope.
+- Hidden repo setup or hidden mapping edits are out of scope; all mutations appear in the final
+  confirmation plan.
+- Direct default-branch mapping pushes are out of scope.
+- Direct LLM calls from `sdlc_manager.py` are out of scope. Rough-source interpretation belongs in
+  the skill/model layer.
+- Replacing the existing six SDLC issue types is out of scope.
+
+---
+
+## Dependencies And Assumptions
+
+- The target repo has or can receive canonical SDLC labels and templates.
+- The create flow has GitHub permissions to create labels/templates/issues and add project items.
+- Mapping update PRs require an authenticated GitHub flow and a writable checkout of the canonical
+  SDLC config or plugin fallback mapping.
+- The skill layer can generate a draft from source text before invoking deterministic CLI
+  validation.
+- Asgard and Mount Olympus remain the stable public target surfaces for this workflow.
+
+---
+
+## Sources
+
+- `docs/ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md`
+- `plugins/sdlc-manager/scripts/sdlc_manager.py`
+- `plugins/sdlc-manager/config/sdlc-schema.json`
+- `plugins/sdlc-manager/config/project-mappings.json`
+- `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+- `plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md`
+- `plugins/sdlc-manager/skills/sdlc-rollout/SKILL.md`
+- `infiquetra-sdlc: config/sdlc-schema.json`
+- `home-lab: ansible/roles/hermes_orchestrator/files/card_validator.py`
+- `home-lab: ansible/roles/hermes_agent_listener/files/prompts/assign_work.md`

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -10,6 +10,30 @@
 
 ## Shipped
 
+### Asgard/Olympus issue readiness workflow for `sdlc-manager`  {#asgard-olympus-issue-readiness}
+
+**SHIPPED 2026-05-30** (commit pending).
+
+**Summary.** Added a prepared issue workflow that turns source text into reviewable Asgard or
+Mount Olympus drafts, then creates issues only after readiness checks and a confirmed mutation
+plan.
+
+**What shipped.**
+- `issue prepare` writes markdown drafts and JSON sidecars under `docs/sdlc-issue-drafts/`.
+- `issue create-prepared` re-runs readiness, shows a mutation plan, repairs missing
+  labels/templates, handles missing project mappings through PR flow, and records created issue
+  state back onto drafts.
+- Asgard and Mount Olympus readiness profiles with safe starting statuses.
+- Natural-language skill/command/operator guidance for Asgard/Olympus issue creation from text.
+- Plugin and marketplace metadata bumped to `1.6.0`.
+- Unit, mocked mutation, and prompt alignment tests.
+
+**Refs.**
+- Ideation doc: [SDLC Manager Asgard/Olympus issue readiness](../ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md).
+- Requirements: [SDLC Manager Issue Prepare Requirements](../brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md).
+- Plan: [Add SDLC issue prepare workflow](../plans/2026-05-30-001-feat-sdlc-issue-prepare-workflow-plan.md).
+- Learning: [Prepared issue creation needs an artifact boundary before mutation](LEARNINGS.md#prepared-issue-artifact-boundary).
+
 ### Align sdlc-manager prompts with current SDLC schema and release metadata  {#sdlc-manager-prompt-alignment}
 
 **SHIPPED 2026-05-30** (commit pending).

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -10,6 +10,26 @@
 
 ## Shipped
 
+### Align sdlc-manager prompts with current SDLC schema and release metadata  {#sdlc-manager-prompt-alignment}
+
+**SHIPPED 2026-05-30** (commit pending).
+
+**Summary.** Aligned `sdlc-manager` operator prompts, command docs, issue/label references,
+release metadata, and marketplace registration with the current Jeff Intent, Asgard, and Mount
+Olympus operating model.
+
+**What shipped.**
+- Updated handwritten prompt/reference docs to use current actionable labels:
+  `hermes-task`, `needs-plan`, and the type label.
+- Kept `needs-analysis` and `needs-triage` documented only as legacy auto-label fallback labels.
+- Fixed `sdlc-operator` Hermes-actionability wording and output examples.
+- Bumped `sdlc-manager` plugin and marketplace metadata to `1.5.0`.
+- Added prompt/reference drift guards for metadata, labels, and actionability claims.
+
+**Refs.**
+- Ideation doc: [2026-05-30-sdlc-manager-alignment-pass.md](../ideation/2026-05-30-sdlc-manager-alignment-pass.md).
+- Learning: [Prompt docs need their own drift guards](LEARNINGS.md#prompt-docs-need-drift-guards).
+
 ### Add Infiquetra loop `/doc-review` command  {#infiquetra-loop-doc-review}
 
 **SHIPPED 2026-05-29** (commit pending).

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,34 @@
 
 ---
 
+## 2026-05-30
+
+### Prepared issue workflow uses draft/sidecar boundary plus confirmed mutation (commit pending)  {#prepared-issue-workflow-boundary}
+
+**Decision.** Add `sdlc-manager issue prepare` and `issue create-prepared` as separate steps.
+`issue prepare` writes a markdown draft and JSON sidecar; `issue create-prepared` re-runs
+readiness, renders a mutation plan, asks for confirmation, repairs repo prerequisites, handles
+mapping PRs, creates the issue, and records the result back onto the draft.
+
+**Rejected alternatives.**
+- *Direct source-text to `gh issue create`.* Rejected: bypasses review and makes readiness failures
+  visible only after the external issue exists.
+- *Put LLM interpretation inside `sdlc_manager.py`.* Rejected: the CLI should stay deterministic;
+  skills and agents own rough-source interpretation.
+- *Create new issue types for Asgard/Olympus.* Rejected: the six SDLC issue types remain
+  canonical; team differences belong in readiness profiles and board/status routing.
+
+**Rationale.** The split gives operators a durable review point before GitHub mutation while still
+letting the final create flow perform repo repair and board placement as one visible plan.
+Sidecars keep deterministic metadata and lifecycle state out of prose-only markdown, and
+re-validation prevents stale edited drafts from bypassing team readiness.
+
+**Revisit when.** Multiple non-agent callers need deterministic text-to-body generation inside the
+CLI, or when prepared drafts become common enough to justify a richer review UI or batch create
+surface.
+
+**Refs.** LEARNINGS [prepared issue artifact boundary](LEARNINGS.md#prepared-issue-artifact-boundary).
+
 ## 2026-05-29
 
 ### Split Infiquetra lifecycle orchestration from deployment mutation (commit pending)  {#infiquetra-loop-deploy-boundary}

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,43 @@
 
 ---
 
+## 2026-05-30
+
+### Prompt docs need their own drift guards  {#prompt-docs-need-drift-guards}
+
+**Context.** `sdlc-manager` had already learned to consume the current `infiquetra-sdlc`
+board schema and generated template reference, but handwritten prompts and references still taught
+old label behavior.
+
+**Evidence.** `plugins/sdlc-manager/config/sdlc-schema.json` matched
+`../infiquetra-sdlc/config/sdlc-schema.json`, and
+`uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check` passed. The remaining
+drift was in handwritten files such as
+`plugins/sdlc-manager/agents/sdlc-operator.md`,
+`plugins/sdlc-manager/commands/sdlc-triage.md`, and
+`plugins/sdlc-manager/skills/sdlc-issues/references/issue-types.md`.
+
+**Mechanism.** Generated docs can stay correct while nearby prompt text keeps stale duplicated
+facts. Agents read both surfaces, so a correct generated reference is insufficient if the operator
+prompt still says exploration/context-update are `hermes-task` or examples still apply
+`needs-analysis` as a current template label.
+
+**Fix.** Aligned the handwritten prompts/references with the generated template contract and added
+`plugins/sdlc-manager/tests/test_prompt_alignment.py` to pin the current metadata,
+Hermes-actionability, and label wording.
+
+**Validation.** `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`,
+`uv run ruff check plugins/sdlc-manager/tests/test_prompt_alignment.py`, and
+`uv run pytest plugins/sdlc-manager/tests tests/test_sdlc_manager.py -q` pass.
+
+**Generalizable rule.** When a plugin mixes generated references with human-authored prompts, add
+drift guards for the human-authored prompts too; otherwise agents can keep following stale
+instructions even while generated docs are correct.
+
+**Refs.** ARCHIVE [sdlc-manager prompt alignment](ARCHIVE.md#sdlc-manager-prompt-alignment).
+
+---
+
 ## 2026-05-29
 
 ### Schema migrations need legacy fallback contract tests  {#schema-migration-legacy-fallbacks}

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,36 @@
 
 ## 2026-05-30
 
+### Prepared issue creation needs an artifact boundary before mutation  {#prepared-issue-artifact-boundary}
+
+**Context.** `sdlc-manager` needed to turn rough source text into Asgard or Mount Olympus issues
+without creating cards that fail team readiness checks or require hidden board/label repair.
+
+**Evidence.** The new workflow in `plugins/sdlc-manager/scripts/sdlc_manager.py` writes markdown
+drafts plus JSON sidecars, re-runs readiness in `issue create-prepared`, and records created issue
+state back onto the draft. Tests in `plugins/sdlc-manager/tests/test_issue_prepare.py` and
+`plugins/sdlc-manager/tests/test_issue_create_prepared.py` cover blocked drafts, safe statuses,
+mapping PR stop, override creation, and draft-created state.
+
+**Mechanism.** A direct "source text -> GitHub issue" command mixes interpretation, validation,
+and side effects. Splitting the workflow into a durable draft/sidecar artifact and a confirmed
+mutation step lets agents shape prose while deterministic code owns readiness, repair ordering,
+and idempotent recovery.
+
+**Fix.** Added prepared drafts, readiness profiles, mutation planning, repo prerequisite repair,
+mapping PR handling, natural-language prompt guidance, and plugin metadata for `sdlc-manager`
+1.6.0.
+
+**Validation.** `uv run pytest -q`, `uv run ruff check .`, `uv run python
+marketplace/validator/validate.py`, `uv run python
+plugins/sdlc-manager/scripts/sync_template_docs.py --check`, and `git diff --check` pass.
+
+**Generalizable rule.** When a plugin command turns ambiguous human or agent text into external
+side effects, make a reviewable artifact the boundary and re-validate it at mutation time.
+
+**Refs.** DECISIONS [prepared issue workflow boundary](DECISIONS.md#prepared-issue-workflow-boundary);
+ARCHIVE [Asgard/Olympus issue readiness workflow](ARCHIVE.md#asgard-olympus-issue-readiness).
+
 ### Prompt docs need their own drift guards  {#prompt-docs-need-drift-guards}
 
 **Context.** `sdlc-manager` had already learned to consume the current `infiquetra-sdlc`

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -93,26 +93,6 @@ independent read-only review, exploration, or implementation-plan critique.
 - Do not start with write-capable coder agents. Coder delegation should wait for worktree or strict
   file-ownership mechanics plus explicit consent.
 
-### Asgard/Olympus issue readiness workflow for `sdlc-manager`  {#asgard-olympus-issue-readiness}
-
-**Priority.** P2.
-
-**Effort.** Spike: half-day. Minimal dry-run workflow: 1 day. Mutation-capable creation flow:
-1-2 additional days.
-
-**Worth it when.** We want to turn source text, including copied engineering-journal entries or
-repo notes, into GitHub issue drafts that match either Asgard shaping expectations or Mount
-Olympus dispatch expectations without manual board/label repair.
-
-**Context.**
-- Ideation doc: [SDLC Manager Asgard/Olympus issue readiness](../ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md).
-- Current `sdlc-manager` covers the strict actionable issue-body shape partially, but not a full
-  team-aware label/author/project/status readiness check.
-- Recommended path: add a dry-run `issue prepare` or equivalent first, then layer
-  mutation-capable creation once the draft/readiness shape is trusted.
-- Keep shared issue templates human-facing. Put team-specific risk, authority, promotion, and
-  definition-of-done details in generated body sections or readiness output.
-
 ### Phase 5 spawn primitive: tmux-wrapped foreground sessions (replaces `--bg` from current plan)  {#phase5-spawn-via-tmux}
 
 **Priority.** P2. Blocks Phase 5 implementation but Phase 5 hasn't started yet.

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -93,6 +93,26 @@ independent read-only review, exploration, or implementation-plan critique.
 - Do not start with write-capable coder agents. Coder delegation should wait for worktree or strict
   file-ownership mechanics plus explicit consent.
 
+### Asgard/Olympus issue readiness workflow for `sdlc-manager`  {#asgard-olympus-issue-readiness}
+
+**Priority.** P2.
+
+**Effort.** Spike: half-day. Minimal dry-run workflow: 1 day. Mutation-capable creation flow:
+1-2 additional days.
+
+**Worth it when.** We want to turn source text, including copied engineering-journal entries or
+repo notes, into GitHub issue drafts that match either Asgard shaping expectations or Mount
+Olympus dispatch expectations without manual board/label repair.
+
+**Context.**
+- Ideation doc: [SDLC Manager Asgard/Olympus issue readiness](../ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md).
+- Current `sdlc-manager` covers the strict actionable issue-body shape partially, but not a full
+  team-aware label/author/project/status readiness check.
+- Recommended path: add a dry-run `issue prepare` or equivalent first, then layer
+  mutation-capable creation once the draft/readiness shape is trusted.
+- Keep shared issue templates human-facing. Put team-specific risk, authority, promotion, and
+  definition-of-done details in generated body sections or readiness output.
+
 ### Phase 5 spawn primitive: tmux-wrapped foreground sessions (replaces `--bg` from current plan)  {#phase5-spawn-via-tmux}
 
 **Priority.** P2. Blocks Phase 5 implementation but Phase 5 hasn't started yet.

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -73,6 +73,26 @@ classification is too variable.
 - A future helper could return `blueprint`, `spec`, `issue`, `plan`, `requirements`, or
   `strategy-scope` from path and content-shape signals.
 
+### Delegate agents plugin for Codex and Antigravity  {#delegate-agents-plugin}
+
+**Priority.** P2.
+
+**Effort.** Spike: half-day. Minimal plugin v1: 1-2 days.
+
+**Worth it when.** We want `team-execution` reviewers/explorers, or other parallel agents, to run
+through local Codex or Antigravity accounts instead of Claude Code subagents, especially for
+independent read-only review, exploration, or implementation-plan critique.
+
+**Context.**
+- Ideation doc: [delegate-agent plugin feasibility](../ideation/2026-05-30-delegate-agent-plugin-ideation.md).
+- Recommended path: create a separate `delegate-agents` plugin first, prove read-only Codex and
+  Antigravity delegates with structured results, then add optional `team-execution` routing.
+- Follow-up route analysis changed the spike shape: compare Codex `exec`, Codex App Server, and
+  `codex mcp-server`; compare Antigravity CLI, SDK, and any documented Antigravity 2.0 app control
+  surface.
+- Do not start with write-capable coder agents. Coder delegation should wait for worktree or strict
+  file-ownership mechanics plus explicit consent.
+
 ### Phase 5 spawn primitive: tmux-wrapped foreground sessions (replaces `--bg` from current plan)  {#phase5-spawn-via-tmux}
 
 **Priority.** P2. Blocks Phase 5 implementation but Phase 5 hasn't started yet.

--- a/docs/ideation/2026-05-30-delegate-agent-plugin-ideation.md
+++ b/docs/ideation/2026-05-30-delegate-agent-plugin-ideation.md
@@ -1,0 +1,582 @@
+---
+date: 2026-05-30
+topic: delegate-agent-plugin
+focus: Codex and Antigravity delegation from Claude Code
+status: ideation
+---
+
+# Ideation: Delegate Agent Plugin For Codex And Antigravity
+
+## Executive Summary
+
+Building a Claude Code plugin that delegates work to local Codex and Antigravity runtimes is
+feasible, but the two backends are not equally mature.
+
+Codex is the stronger first backend. This machine already has `codex-cli 0.135.0`, and
+`codex exec` successfully completed a non-interactive probe using the local Codex login, with no
+API key passed by the plugin or shell. The installed official OpenAI Claude Code plugin also proves
+the shape: Claude Code command -> thin subagent -> Node companion script -> local `codex app-server`
+thread or `codex exec`-style turn.
+
+Antigravity is plausible for prompt-based read-only delegation today. The local `agy 1.0.3` CLI has
+`--print`, conversation resume, workspace directory, sandbox, timeout, and plugin commands, and a
+non-interactive prompt probe succeeded using local Antigravity auth/config. The risk is that the CLI
+surface is not yet as clearly structured as Codex for job state, output schema, touched files, and
+write-mode safety. Rich Antigravity delegation probably needs a focused SDK spike rather than only a
+CLI shim.
+
+The best first product is a separate `delegate-agents` plugin, not a direct rewrite of
+`team-execution`. It should expose a provider-neutral agent contract:
+
+```text
+delegate-agent run --provider codex|antigravity --agent <agent.md> --prompt <task>
+```
+
+Then `team-execution` can opt into that runtime per worker, reviewer, or validator. Reviewer and
+explorer agents are the right first use cases because they are read-only, evidence-oriented, and do
+not require external CLIs to own file mutation. Coder agents should come later, ideally with isolated
+worktrees or strict write ownership.
+
+Follow-up note after reviewing MCP and app surfaces: the original recommendation was directionally
+right but underweighted three paths. Codex App Server should be the preferred rich Codex integration,
+not merely an optional later upgrade. MCP should be considered a compatibility/control-plane route,
+especially for invoking Codex from MCP-native systems, but not the primary route when the plugin
+needs Codex-specific session events, approvals, diff telemetry, and thread control. Antigravity 2.0
+should be treated as more than `agy --print`: the installed desktop app and public SDK position it
+as an agent platform with MCP and skills, so the Antigravity spike should explicitly compare CLI,
+SDK, and any documented app/deep-link surface rather than only prompt mode.
+
+## Grounding
+
+### Local Repository
+
+This repository already packages Claude Code plugins with:
+
+- `plugins/<plugin>/.claude-plugin/plugin.json`
+- `agents/*.md`
+- `skills/<skill>/SKILL.md`
+- `commands/*.md`
+- `README.md`
+- `CHANGELOG.md`
+- root marketplace registration in `.claude-plugin/marketplace.json`
+- contract tests under `tests/`
+
+`team-execution` is a good integration target but not the right first implementation surface.
+Its workers are plan rows orchestrated by the main agent. Its reviewers and validators are packaged
+Claude Code agents selected by registry references. That means external delegates should be an
+optional execution mode attached to selected roles, not an assumption baked into all team planning.
+
+### Local Runtime Evidence
+
+Codex:
+
+- `which codex` resolved to `/opt/homebrew/bin/codex`.
+- `codex --version` returned `codex-cli 0.135.0`.
+- `codex exec --help` exposes non-interactive prompt/stdin mode, `--sandbox`, `--ephemeral`,
+  `--json`, `--output-schema`, `--output-last-message`, `--model`, `--profile`, `--cd`, and
+  `--add-dir`.
+- `codex exec --ephemeral --sandbox read-only --output-last-message ... 'Reply with exactly:
+  CODEX_OK'` succeeded when run with normal process permissions.
+- In the Codex harness sandbox, nested `codex exec` initially failed with
+  `failed to initialize in-process app-server client: Operation not permitted`. That is an
+  environment constraint, not a product blocker, but the plugin must surface this class of failure.
+
+Antigravity:
+
+- `which agy` resolved to `/Users/jefcox/.local/bin/agy`.
+- `agy --version` returned `1.0.3`.
+- `agy --help` exposes `--print`, `--prompt`, `--prompt-interactive`, `--continue`,
+  `--conversation`, `--sandbox`, `--add-dir`, `--print-timeout`, `--log-file`, and plugin
+  management commands.
+- `agy --print-timeout 10s --print 'Reply with exactly: AGY_OK'` succeeded.
+- The first Antigravity probe emitted local config/log permission noise and created a repo-local
+  `.antigravitycli/<uuid>.json` file. The plugin should treat Antigravity as a CLI that may create
+  local project metadata and should document or redirect that state explicitly.
+- `/Applications/Antigravity.app` is installed. Its `Info.plist` reports bundle identifier
+  `com.google.antigravity`, version `2.0.10`, and URL scheme `antigravity`.
+
+Desktop apps:
+
+- `/Applications/Codex.app` is installed. Its `Info.plist` reports bundle identifier
+  `com.openai.codex`, version `26.527.31326`, and URL scheme `codex`.
+- `/Applications/Antigravity.app` is installed as noted above.
+- Neither desktop app should be treated as the first automation target without a documented control
+  API. The better route is to use the same lower-level surfaces the apps use or expose: Codex App
+  Server for Codex, and Antigravity CLI/SDK/MCP configuration for Antigravity.
+
+### Existing Delegation Patterns
+
+The installed OpenAI Claude Code plugin is the closest reference implementation. Its manifest
+describes the plugin as using Codex from Claude Code to review code or delegate tasks. Its
+`/rescue` command invokes a `codex:codex-rescue` subagent, and that subagent is deliberately thin:
+it forwards exactly one Bash call to `scripts/codex-companion.mjs`.
+
+Key architectural details worth copying conceptually:
+
+- Claude Code keeps orchestration and command UX.
+- The subagent is a wrapper, not an independent problem solver.
+- A companion script owns runtime flags, foreground/background mode, resume, output handling, and
+  state.
+- Codex app-server turns can run read-only or workspace-write based on the task.
+- Background jobs and result retrieval are explicit commands, not hidden chat state.
+
+The Compound Engineering `ce-work-beta` skill already has a simpler Codex delegation model:
+Claude plans and orchestrates; implementation units can be delegated to `codex exec`; consent and
+sandbox mode live in repo-local config. That is a good safety model for this repo to borrow.
+
+### Additional Route Analysis: MCP, App Server, And Desktop Apps
+
+#### Codex App Server
+
+Codex App Server is the strongest rich Codex route. OpenAI's public App Server material says Codex
+surfaces share the same harness, and the App Server is the first-class integration method for rich
+clients. The local CLI confirms this surface exists:
+
+```text
+codex app-server [--listen stdio://|unix://|ws://IP:PORT|off]
+codex app-server generate-ts --out DIR
+codex app-server generate-json-schema --out DIR
+```
+
+This matters because a delegate plugin needs more than a final string. It needs thread creation,
+turn start, streaming events, approvals, sandbox mode, model choice, cwd, interrupt, resume, and
+evidence. App Server is built around those primitives.
+
+Recommendation: use `codex exec` for the first minimal read-only spike, but design the Codex adapter
+interface so App Server is the default rich implementation once the wrapper grows job state,
+background mode, or write-capable delegates.
+
+#### Codex MCP Server
+
+Codex also exposes `codex mcp-server`. OpenAI documents it as an experimental MCP server interface
+over stdio that can manage Codex threads, turns, accounts, config, models, and approvals. The local
+CLI confirms the command exists:
+
+```text
+codex mcp-server
+```
+
+This route is worth considering, but its role is narrower:
+
+- Best fit: an MCP-native orchestrator wants to call Codex as a tool.
+- Good for: interoperability with systems that already load MCP servers.
+- Poor fit as primary route: MCP tends to flatten provider-specific session semantics, and OpenAI's
+  own App Server guidance says richer interactions such as diff updates may not map cleanly through
+  MCP endpoints.
+
+Recommendation: keep MCP as a secondary adapter candidate. It may be useful if `delegate-agents`
+itself becomes an MCP server or if another Infiquetra orchestrator wants to call Codex through a
+standard tool interface. Do not make MCP the first Codex implementation unless the target integration
+is specifically MCP-native.
+
+#### Codex Desktop App
+
+The installed Codex desktop app is evidence that this machine has the richer Codex surface, but it
+is probably not the right automation target. The app has a `codex://` URL scheme, but a URL scheme is
+not the same as a stable agent-control API. Treat the desktop app as a user-facing client over Codex
+harness/App Server, not as the delegate runtime.
+
+Possible exception: a later UX command could open a Codex thread or result in the desktop app if
+Codex documents a deep-link format. That is review/display UX, not the core delegation mechanism.
+
+#### Antigravity 2.0 Desktop App
+
+The original doc treated Antigravity mostly as `agy --print` plus a possible SDK. That is too narrow.
+Antigravity 2.0 is installed locally, and public Google material describes it as a standalone
+desktop app for managing agents, with skills and MCP server integration. The app also has an
+`antigravity://` URL scheme.
+
+The practical reading:
+
+- `agy --print` is still the easiest probe path.
+- The Antigravity SDK is likely the right route for rich nested-agent control, traces, and
+  structured orchestration.
+- MCP is important on the Antigravity side too, but likely as "tools available to Antigravity
+  agents" rather than "Claude Code controls Antigravity agents through MCP" unless Google exposes an
+  MCP server equivalent to Codex's.
+- The desktop app may become useful for monitoring delegated work, but should not be assumed to
+  provide a stable control API just because the app exists.
+
+Recommendation: rename the Antigravity spike from "CLI adapter" to "Antigravity control-surface
+spike" and compare three routes: CLI prompt mode, SDK runner, and any documented app/deep-link or MCP
+control surface.
+
+## Feasibility Matrix
+
+| Capability | Codex | Antigravity |
+|------------|-------|-------------|
+| Local auth without plugin API keys | High | High |
+| Non-interactive prompt execution | High | High |
+| Read-only reviewer/explorer delegate | High | Medium-high |
+| Structured final output | High via `--output-schema` or app-server handling | Medium, needs confirmation |
+| Background/resume/job model | High via app-server or companion state | Medium, CLI has conversations but job control needs wrapper |
+| Write-capable coder delegate | Medium-high with sandbox/worktree discipline | Medium-low until write semantics are proven |
+| Touched-file/event telemetry | High through app-server path | Unknown through CLI; likely SDK needed |
+| MCP-native control | Medium, experimental `codex mcp-server` exists | Unknown as control surface; MCP support appears stronger as tool integration |
+| Desktop-app control | Low-medium; app exists but App Server is the better control API | Unknown; app exists, SDK likely better |
+| Clean plugin packaging | High | Medium-high |
+| Maintenance risk | Medium because app-server protocol can drift | Medium because CLI/SDK is young |
+
+## Recommended Shape
+
+Build a new `delegate-agents` plugin first. It should package:
+
+- A slash command, for example `/delegate-agent`.
+- One or more thin subagents, for example `delegate-runner`, `delegate-reviewer`,
+  `delegate-explorer`.
+- A skill documenting when to delegate and how to interpret results.
+- A small runtime wrapper script that normalizes Codex and Antigravity invocation.
+- A state directory for jobs, transcripts, result summaries, and evidence paths.
+- Contract tests for manifest, command references, and wrapper prompt construction.
+
+Do not copy the OpenAI plugin source wholesale. Use it as a local architecture reference. A source
+copy would create avoidable upstream drift and licensing/maintenance questions. The safer route is
+to implement a thin Infiquetra-specific adapter with explicit provider interfaces.
+
+Suggested runtime contract:
+
+```json
+{
+  "provider": "codex",
+  "role": "reviewer",
+  "agent_file": "plugins/delegate-agents/agents/security-reviewer.md",
+  "workspace": "/path/to/repo",
+  "mode": "read-only",
+  "prompt": "Review this diff for auth regressions.",
+  "output_schema": "review-finding-list-v1",
+  "timeout_seconds": 900,
+  "resume": false
+}
+```
+
+The wrapper should render the actual delegate prompt from:
+
+- the selected `agent.md` contents
+- task prompt
+- workspace path and repository summary
+- allowed tools/mode
+- expected output schema
+- evidence requirements
+- explicit instruction to avoid secrets and production data
+
+Passing only `agent.md + prompt` is not enough. The wrapper also needs mode, timeout, output
+contract, state path, resume behavior, and a safety policy.
+
+## Ranked Ideas
+
+### 1. Provider-Neutral `delegate-agents` Plugin
+
+**Description.** Add a new plugin that exposes one common delegation contract and provider adapters
+for Codex and Antigravity.
+
+**Basis.** Codex and Antigravity both support local non-interactive prompt execution. Existing repo
+conventions support plugins with commands, agents, skills, README, CHANGELOG, and tests.
+
+**Why it is promising.** Keeps provider-specific volatility out of `team-execution`. Gives the team
+a small surface to test before making delegation part of larger workflows.
+
+**Downside.** Adds a new plugin and wrapper surface before the team-execution UX is fully known.
+
+**Confidence.** High.
+
+**Complexity.** Medium.
+
+### 2. Read-Only Reviewer And Explorer Delegates First
+
+**Description.** Start with roles that inspect, summarize, and produce evidence: reviewer,
+explorer, issue-triage, spec-review, architecture-risk, dependency-risk.
+
+**Basis.** These roles map well to both `codex exec --sandbox read-only` and `agy --print` with
+workspace context.
+
+**Why it is promising.** Read-only delegation gives useful signal while avoiding cross-agent file
+ownership problems.
+
+**Downside.** It does not immediately solve parallel implementation throughput.
+
+**Confidence.** High.
+
+**Complexity.** Low-medium.
+
+### 3. Codex Adapter With Three Modes
+
+**Description.** Support a simple `codex exec` adapter first, then add App Server as the preferred
+rich adapter, with `codex mcp-server` as a secondary MCP-native option.
+
+**Basis.** `codex exec` is documented and already provides output files, JSONL events, schemas,
+sandbox selection, and cwd control. The installed OpenAI plugin proves the app-server path for
+background/resume/touched-file tracking. OpenAI also documents `codex mcp-server` as an
+experimental MCP route.
+
+**Why it is promising.** The simple adapter is easy to test. App Server matches the eventual needs
+of delegate agents: thread state, turn events, approvals, cwd, sandbox, interrupts, and structured
+runtime state. MCP gives a standards-based fallback for MCP-native orchestrators.
+
+**Downside.** `codex exec` alone may not provide the same polished job lifecycle as the official
+plugin. App Server integration takes more client code. MCP is experimental and may lose
+Codex-specific detail.
+
+**Confidence.** High for `exec`; high for App Server feasibility; medium for MCP as primary route.
+
+**Complexity.** Low for `exec`; medium-high for App Server; medium for MCP.
+
+### 3a. MCP Bridge As Compatibility Layer
+
+**Description.** Let `delegate-agents` optionally expose or consume MCP: expose a local MCP server so
+Claude Code or other orchestrators can invoke `delegate.run`, and/or consume Codex through
+`codex mcp-server`.
+
+**Basis.** This repo already has MCP plugin patterns through `redis-channel`; Codex has an
+experimental MCP server; Antigravity 2.0 material emphasizes MCP server integration.
+
+**Why it is promising.** MCP gives a common control surface across tools and could make delegation
+usable outside Claude Code. It also aligns with Antigravity's plugin/tool ecosystem.
+
+**Downside.** MCP is a lowest-common-denominator shape for agents. It is good at tool calls, weaker
+at rich agent session semantics unless the MCP surface explicitly models threads, approvals,
+interrupts, and streaming events.
+
+**Confidence.** Medium.
+
+**Complexity.** Medium.
+
+### 4. Antigravity Control-Surface Spike
+
+**Description.** Compare three Antigravity routes: `agy --print`, Antigravity SDK, and any
+documented desktop app/deep-link or MCP control surface.
+
+**Basis.** Local `agy --print` worked. The CLI supports conversation IDs and workspace dirs. The
+installed desktop app is Antigravity 2.0.10, and public Google material describes Antigravity 2.0,
+the CLI, SDK, skills, and MCP server integration as parts of one agent platform.
+
+**Why it is promising.** It gives immediate access to Antigravity as a second independent reviewer
+or explorer, while keeping the door open to the richer SDK/app route if prompt mode is too thin.
+
+**Downside.** Structured output, file mutation, job telemetry, SDK packaging, and desktop-app control
+need proof. Antigravity may write project metadata such as `.antigravitycli/`.
+
+**Confidence.** Medium.
+
+**Complexity.** Low-medium for CLI; medium-high for SDK/app integration.
+
+### 5. Antigravity SDK Spike For Rich Agent Control
+
+**Description.** Prototype a tiny SDK-backed runner only after the CLI adapter proves useful.
+
+**Basis.** Public Antigravity material describes async agents, sub-agent delegation, and nested run
+trees in the SDK. That sounds closer to the desired reviewer/coder/explorer agent model than bare
+CLI print mode.
+
+**Why it is promising.** The SDK is likely the right path for nested agents, structured traces, and
+multi-agent delegation.
+
+**Downside.** It may require a separate TypeScript or Python runtime, more dependencies, and a
+different packaging story from current simple plugins.
+
+**Confidence.** Medium.
+
+**Complexity.** Medium-high.
+
+### 6. Team-Execution Optional Delegation Roster
+
+**Description.** Extend `team-execution` later with a role-level runtime choice:
+
+```markdown
+| Role | Agent | Runtime | Mode | Provider |
+|------|-------|---------|------|----------|
+| reviewer | security-reviewer | delegate | read-only | codex |
+| explorer | api-contract-explorer | delegate | read-only | antigravity |
+| worker | docs-worker | local | workspace-write | claude |
+```
+
+**Basis.** `team-execution` already selects reviewers, validators, workers, and gates by context.
+
+**Why it is promising.** It preserves current consensus and validator gates while allowing selected
+roles to run outside Claude Code's backend.
+
+**Downside.** It must not obscure who changed files or which gate produced which evidence.
+
+**Confidence.** Medium-high.
+
+**Complexity.** Medium.
+
+### 7. Coder Delegates In Isolated Worktrees
+
+**Description.** Allow write-capable delegates only in separate git worktrees or tightly scoped
+file ownership batches.
+
+**Basis.** External CLIs can mutate the same working tree. Parallel write agents can step on each
+other unless each owns a workspace or a disjoint file set.
+
+**Why it is promising.** This is the path to real parallel implementation throughput.
+
+**Downside.** Worktree lifecycle, patch import, conflict handling, and test attribution are
+nontrivial.
+
+**Confidence.** Medium.
+
+**Complexity.** High.
+
+## Proposed Phase Plan
+
+### Phase 0: Spike And Contracts
+
+- Define `delegate-run-v1` JSON request and result shapes.
+- Probe `codex exec` with `--output-schema`, `--json`, read-only, and workspace-write.
+- Probe Codex App Server with generated JSON schema and one `thread/start` plus `turn/start`
+  read-only run.
+- Probe `codex mcp-server` with an MCP inspector or minimal MCP client to verify which thread/turn
+  controls are actually available through MCP.
+- Probe `agy --print` with required JSON output, `--conversation`, `--sandbox`, `--add-dir`, and
+  `--log-file`.
+- Probe Antigravity SDK basics against one read-only reviewer task.
+- Check whether Antigravity 2.0 documents a stable deep-link, local app API, or MCP control surface
+  for starting or monitoring agent tasks.
+- Decide where provider state lives and how to keep it ignored.
+- Write a short security/consent note.
+
+Exit criteria:
+
+- Both providers can run a read-only reviewer prompt and return parseable results.
+- Codex route choice is explicit: `exec` for minimal v1, App Server for rich v1, or MCP only if the
+  target caller is MCP-native.
+- Antigravity route choice is explicit: CLI-only, SDK-backed, or app-mediated.
+- Failure modes are captured as structured errors.
+- The Antigravity metadata behavior is understood.
+
+### Phase 1: New Plugin
+
+- Add `plugins/delegate-agents/`.
+- Add manifests, README, CHANGELOG, command, skill, and thin subagent.
+- Implement a minimal wrapper script with `codex` and `antigravity` provider adapters.
+- Add tests for manifest, marketplace entry, prompt rendering, and command references.
+
+Exit criteria:
+
+- `/delegate-agent --provider codex --agent reviewer --prompt ...` works.
+- `/delegate-agent --provider antigravity --agent explorer --prompt ...` works in read-only mode.
+- Results are written to predictable state paths.
+
+### Phase 2: Team-Execution Integration
+
+- Add optional `.team-execution.json` keys for delegate preferences.
+- Add delegation columns to generated team plans only when configured or explicitly requested.
+- Route selected reviewers/explorers through `delegate-agents`.
+- Keep validators and gates unchanged.
+
+Exit criteria:
+
+- Existing team-execution plans are unchanged by default.
+- Explicit delegation requests produce role-level delegate assignments.
+- Reviewer consensus can include delegated reviewer evidence.
+
+### Phase 3: Coder Delegates
+
+- Add worktree-per-coder support or strict file-set ownership.
+- Require explicit consent for write-capable delegates.
+- Require post-delegate diff review by Claude Code before tests or commit.
+
+Exit criteria:
+
+- A delegated coder can produce a patch without overwriting unrelated user work.
+- The orchestrator can attribute files, tests, and remediation loops.
+
+## Rejected Or Deferred Ideas
+
+### Copy The OpenAI Codex Plugin Source Wholesale
+
+Reject for now. It proves the design, but copying it would import upstream implementation details
+and create drift. Prefer a small adapter that uses stable CLI surfaces first.
+
+### Drive Codex Through The Desktop App UI
+
+Reject for core delegation. Codex Desktop is installed and likely useful to inspect or resume work,
+but the stable automation target is App Server, not GUI automation or an undocumented `codex://`
+deep link.
+
+### Replace Claude Code Subagents Entirely
+
+Reject. Claude Code's Agent tool and plugin model are still useful for routing, UX, orchestration,
+and local policy. Delegates should supplement the current system.
+
+### Make Delegation The Default In Team-Execution
+
+Reject for now. Delegation sends prompts and repository context through other local agent accounts.
+It needs explicit opt-in, local consent, and clear state paths before becoming a default.
+
+### Use Antigravity As A Write-Capable Coder Backend Immediately
+
+Defer. The prompt mode works, but write behavior, structured output, and state management need a
+separate proof.
+
+### Treat MCP As The Only Abstraction
+
+Reject for now. MCP should be supported where it helps interoperability, but making it the only
+abstraction would hide provider-specific strengths such as Codex App Server event streams,
+approvals, diff telemetry, and thread control.
+
+### One Universal Prompt Shim With No State
+
+Reject. It is tempting, but insufficient. Useful delegation needs job IDs, transcripts, result
+files, resume or rerun behavior, timeouts, and evidence paths.
+
+## Open Questions
+
+1. Does `agy --print` reliably honor strict JSON instructions across realistic review prompts?
+2. Can Antigravity redirect or suppress `.antigravitycli/` project metadata, or should the plugin
+   document and ignore it?
+3. Which Antigravity SDK language/runtime fits this repository if richer agent control is needed?
+4. Does Antigravity 2.0 expose a documented control surface for starting or monitoring tasks outside
+   the app UI, or is the SDK the only supported rich route?
+5. Should Codex app-server integration depend on the user's installed `codex` plugin, or should this
+   repo implement only `codex exec` at first?
+6. Should `delegate-agents` expose its own MCP server so non-Claude orchestrators can call the same
+   provider-neutral delegation contract?
+7. What consent model should apply when a delegate can see proprietary code, issue context, or
+   secrets in config files?
+8. How should delegated findings participate in `team-execution` consensus: equal reviewer vote,
+   supporting evidence, or advisory signal?
+
+## Recommendation
+
+Proceed with a two-step feasibility build:
+
+1. Create a small `delegate-agents` spike that supports read-only Codex and Antigravity delegates
+   with structured results.
+2. In that spike, treat Codex App Server as the likely rich Codex backend, Codex MCP as a secondary
+   MCP-native backend, and Antigravity SDK/app-surface research as a first-class branch alongside
+   `agy --print`.
+3. After that works, update `team-execution` to optionally route reviewer/explorer roles through
+   the new plugin.
+
+Do not start with coder delegates and do not start by editing the main `team-execution` protocol.
+That would couple a still-uncertain runtime layer to the most operationally sensitive plugin in this
+repo. The right sequence is provider adapter first, read-only value second, team-execution
+integration third, write-capable delegation last.
+
+## References
+
+Local:
+
+- `plugins/team-execution/README.md`
+- `plugins/team-execution/skills/team-execution/SKILL.md`
+- `docs/PLUGIN_SPEC.md`
+- `/Users/jefcox/.claude/plugins/cache/openai-codex/codex/1.0.4/`
+- `/Users/jefcox/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.9.3/skills/ce-work-beta/`
+- `/Users/jefcox/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.9.3/skills/ce-optimize/`
+
+External:
+
+- Claude Code plugins: <https://code.claude.com/docs/en/plugins>
+- Claude Code subagents: <https://docs.anthropic.com/en/docs/claude-code/sub-agents>
+- Codex CLI: <https://developers.openai.com/codex/cli>
+- Codex non-interactive mode: <https://developers.openai.com/codex/noninteractive>
+- Codex app-server: <https://developers.openai.com/codex/app-server>
+- Codex App Server source README: <https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md>
+- Codex MCP interface: <https://github.com/openai/codex/blob/main/codex-rs/docs/codex_mcp_interface.md>
+- OpenAI App Server architecture: <https://openai.com/index/unlocking-the-codex-harness/>
+- Antigravity CLI getting started: <https://antigravity.google/docs/cli-getting-started>
+- Antigravity CLI plugins: <https://antigravity.google/docs/cli-plugins>
+- Antigravity 2.0 overview: <https://www.antigravity.google/docs/overview>
+- Antigravity SDK announcement: <https://antigravity.google/blog/introducing-google-antigravity-sdk>
+- Antigravity SDK product page: <https://antigravity.google/product/antigravity-sdk?app=antigravity>

--- a/docs/ideation/2026-05-30-sdlc-manager-alignment-pass.md
+++ b/docs/ideation/2026-05-30-sdlc-manager-alignment-pass.md
@@ -1,0 +1,191 @@
+# SDLC Manager Alignment Pass Ideation
+
+**Date:** 2026-05-30
+
+**Focus:** Determine whether `sdlc-manager` matches the current `infiquetra-sdlc`
+operating model, and whether to continue with a docs/prompt alignment pass.
+
+**Status:** Implemented in the working tree after pulling `origin/main` to `f5ffbaa`.
+
+## Executive Summary
+
+Yes, continue the docs/prompt alignment pass. This recommendation was implemented in the working
+tree after the initial ideation pass.
+
+The core operational update is partially present: the vendored
+`config/sdlc-schema.json` matches the current `infiquetra-sdlc` schema, the
+generated issue-template reference is in sync, and the `sdlc-manager` test suite
+passes locally. The remaining risk is guidance drift. Several operator-facing
+prompts, command docs, and reference docs still teach old label behavior or
+contradict the current Hermes-actionability model.
+
+There is also release metadata drift. The plugin manifest still says `1.4.0`,
+the marketplace entry still says `1.0.0`, and the recent schema/template work is
+recorded only under `Unreleased`. If the alignment pass ships, it should include
+a plugin version bump, marketplace update, and changelog release section.
+
+Implementation outcome: `sdlc-manager` is now bumped to `1.5.0` in the working tree, prompt and
+reference drift has been corrected, and a prompt/reference drift guard has been added.
+
+## Grounding
+
+Local checks performed before this write-up:
+
+- Fetched `infiquetra-claude-plugins` and sibling `infiquetra-sdlc`.
+- Confirmed sibling `infiquetra-sdlc` is at `74da244` on `main`.
+- Confirmed plugin schema matches canonical schema:
+  - `plugins/sdlc-manager/config/sdlc-schema.json`
+  - `../infiquetra-sdlc/config/sdlc-schema.json`
+- Ran template drift guard:
+  - `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`
+- Ran plugin tests:
+  - `uv run pytest plugins/sdlc-manager/tests -q`
+  - Result: 93 passed.
+- Checked release metadata:
+  - `plugins/sdlc-manager/.claude-plugin/plugin.json` still has `version: 1.4.0`.
+  - `.claude-plugin/marketplace.json` still lists `sdlc-manager` as `version: 1.0.0`.
+  - `plugins/sdlc-manager/CHANGELOG.md` has current work under `Unreleased`.
+
+## Alignment Status
+
+| Area | Status | Evidence | Action |
+|---|---|---|---|
+| Vendored board schema | Aligned | Plugin schema matches `infiquetra-sdlc/config/sdlc-schema.json`. | Keep. |
+| Template reference generation | Aligned | `sync_template_docs.py --check` passes. | Keep generator and guard test. |
+| Board, metrics, rollout references | Mostly aligned | The references are condensed, not verbatim copies. They use current Jeff Intent, Asgard, and Mount Olympus concepts. | Do not regenerate wholesale. Spot-check during prompt pass. |
+| Issue type reference | Drifted | `issue-types.md` still says capability/enhancement use `needs-analysis`, defect uses `needs-triage`, and objectives use `objective:*` / `initiative:*` labels. | Rewrite label sections to point at generated template reference and project fields. |
+| `sdlc-operator` prompt | Drifted | Early identity section says only capability/enhancement/defect are Hermes-actionable, but later section says exploration/context-update also get `hermes-task`. Output example uses `needs-analysis`. | Fix contradiction and examples. |
+| `/sdlc-triage` command | Drifted | Manual label example applies `capability,needs-analysis`; command also says it recommends initiative/objective labels. | Replace with template/current labels and project-field wording. |
+| Label auto-label docs | Needs decision | `labels.json` in `infiquetra-sdlc` still contains auto-label fallback rules for `needs-analysis` and `needs-triage`; issue templates now use `needs-plan`. | Distinguish "template defaults" from "legacy/fallback auto-label rules" before changing. |
+| Release metadata | Drifted | Manifest stayed `1.4.0`; marketplace entry stayed `1.0.0`; changelog is `Unreleased`. | Include version, marketplace, and changelog release cleanup in the pass. |
+
+## Strongest Ideas
+
+### 1. Make Generated Template Reference the Canonical Label Source
+
+Update handwritten issue-type guidance so it stops duplicating exact template
+labels. It should summarize when to use each issue type and link to
+`templates-reference.md` for current auto-applied labels and body requirements.
+
+Why this survives: duplication already drifted. The generated reference has a
+checkable sync path; handwritten references should not compete with it.
+
+### 2. Fix the `sdlc-operator` Hermes-Actionability Contract
+
+Make the prompt use one contract everywhere:
+
+- `hermes-task`: capability, enhancement, defect.
+- `hermes-not-actionable`: objective, exploration, context-update.
+- Initiative and Objective are project fields, not labels.
+
+Why this survives: this is the highest-risk prompt drift. It affects how agents
+classify work and whether Hermes should pick up a card.
+
+### 3. Separate Template Labels from Auto-Label Fallback Labels
+
+Do not blindly delete every `needs-analysis` or `needs-triage` reference. The
+canonical templates moved to `needs-plan`, but `infiquetra-sdlc/config/labels.json`
+still includes title/body auto-label rules that apply older labels. The pass
+should either preserve those as legacy fallback behavior or update the canonical
+label config in `infiquetra-sdlc` first.
+
+Why this survives: it avoids papering over a real source-of-truth conflict.
+
+### 4. Treat Release Metadata as Part of the Alignment Pass
+
+The schema/template update changed plugin behavior enough to need a release
+record. The pass should:
+
+- Move the `Unreleased` changelog entry into a dated release, likely `1.5.0`.
+- Bump `plugins/sdlc-manager/.claude-plugin/plugin.json`.
+- Update the `sdlc-manager` marketplace entry version and stale description.
+- Check installed command examples that hard-code `1.0.0` cache paths.
+
+Why this survives: without this, users can install or reason about the wrong
+plugin version even if the docs are corrected.
+
+### 5. Add a Narrow Prompt Drift Guard
+
+Add a small test or script that checks the most expensive stale vocabulary in
+operator-facing docs:
+
+- No `objective:*` or `initiative:*` as recommended current labels.
+- No claim that exploration/context-update are `hermes-task`.
+- No default example applying `needs-analysis` to capability/enhancement.
+- No default example applying `needs-triage` to defects unless clearly marked as
+  legacy or fallback.
+
+Why this survives: the template docs already have a guard. The remaining drift is
+in prompts and human-written references, so a narrow guard is the cheapest way to
+stop the same problem recurring.
+
+## Rejected or Deferred Ideas
+
+### Regenerate all SDLC manager references verbatim from `infiquetra-sdlc`
+
+Reject for now. The plugin docs are operationally condensed and agent-oriented;
+making them verbatim copies would add noise. The right move is to remove exact
+duplicated facts that drift, not remove all local summarization.
+
+### Remove every `needs-analysis` and `needs-triage` mention immediately
+
+Defer until label config intent is clarified. Current issue templates use
+`needs-plan`, but auto-label rules in `infiquetra-sdlc` still mention the older
+labels. The alignment pass should make that distinction explicit or update the
+source config first.
+
+### Treat schema sync as the main remaining problem
+
+Reject. The schema is already aligned. The problem is that prompts and reference
+docs still teach stale behavior around labels, project fields, and
+Hermes-actionability.
+
+## Recommended Pass
+
+Proceed with a focused docs/prompt alignment pass:
+
+1. Update `sdlc-issues` issue-type guidance to stop duplicating auto-applied
+   labels and to point at generated template reference for exact current labels.
+2. Fix `sdlc-operator` Hermes-actionability wording and output examples.
+3. Fix `/sdlc-triage` command wording and examples around labels and project
+   fields.
+4. Clarify `sdlc-labels` docs around template labels versus auto-label fallback
+   labels.
+5. Bump release metadata and marketplace entry if behavior/docs are shipped.
+6. Add a narrow stale-vocabulary guard for operator prompts and references.
+7. Re-run:
+   - `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`
+   - `uv run pytest plugins/sdlc-manager/tests -q`
+   - `git diff --check`
+
+## Implementation Outcome
+
+Implemented in the current working tree:
+
+- Pulled latest `origin/main` first. The pulled commit already restored the legacy rollout
+  WIP-limit fallback in `plugins/sdlc-manager/scripts/sdlc_manager.py`, so this pass did not
+  duplicate that runtime fix.
+- Updated `sdlc-operator`, `/sdlc-triage`, issue-type docs, label docs, command examples, and
+  README cache paths.
+- Bumped `plugins/sdlc-manager/.claude-plugin/plugin.json` and the marketplace entry to `1.5.0`.
+- Cut the `CHANGELOG.md` `Unreleased` content as `1.5.0`.
+- Added `plugins/sdlc-manager/tests/test_prompt_alignment.py`.
+- Added journal coverage:
+  - `docs/engineering-journal/LEARNINGS.md`
+  - `docs/engineering-journal/ARCHIVE.md`
+  - `docs/engineering-journal/QUEUED.md`
+
+Validation after implementation:
+
+- `uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check`
+- `uv run ruff check plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- `uv run pytest plugins/sdlc-manager/tests tests/test_sdlc_manager.py -q` -> 108 passed
+- `git diff --check`
+
+## Follow-Up Questions and Decisions
+
+- Decided for this repo: document `needs-analysis` / `needs-triage` as legacy/fallback labels
+  rather than silently changing `infiquetra-sdlc/config/labels.json` from this repository.
+- Decided for this repo: release the plugin as `sdlc-manager` `1.5.0`.
+- Still open cross-repo follow-up: decide in `infiquetra-sdlc` whether title-pattern auto-label
+  rules should migrate from `needs-analysis` / `needs-triage` to `needs-plan`.

--- a/docs/ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md
+++ b/docs/ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md
@@ -1,0 +1,402 @@
+# SDLC Manager Asgard/Olympus Issue Readiness Ideation
+
+**Date:** 2026-05-30
+
+**Focus:** Determine whether `sdlc-manager` can create issues that match the current Asgard and
+Mount Olympus board expectations, and identify the strongest follow-up ideas for making issue
+preparation reliable.
+
+**Status:** Ideation only. No remote rollout, issue creation, or project-board mutation was
+performed.
+
+## Framing Update
+
+This should be framed in board/team terms, not around a named runtime owner or orchestrator. The
+useful product framing is **Asgard vs. Olympus issue readiness**.
+
+The systems may converge later, and home-lab runtime files are useful evidence for today's stricter
+Olympus-style checks, but the plugin should speak in board/team terms:
+
+- **Asgard** expects work to be shaped enough for rapid action, incubation, or mission-mode
+  coordination.
+- **Mount Olympus** expects work to be dispatch-ready for the autonomous engineering pipeline.
+- A source like `QUEUED.md` should be treated as prompt/source text, not as a special first-class
+  workflow target.
+
+## Executive Summary
+
+The answer is conditional, not a clean yes.
+
+1. **Does `sdlc-manager` account for the agentic teams and boards in `infiquetra-sdlc`?**
+   Mostly yes for the canonical SDLC boards: Jeff Intent, Asgard, and Mount Olympus. The plugin's
+   vendored schema and board commands know those boards and workflows.
+
+2. **Can `sdlc-manager` create issues that pass the stricter Olympus-style readiness checks?**
+   It can help, but it cannot guarantee that today. It understands the shared actionable issue
+   shape and has a body validator mirror, but the current issue-create flow is still
+   browser/manual, does not validate labels or author allow-list, and relies on target repos having
+   the canonical issue templates deployed.
+
+3. **Can we use it to shape `hermes-claude-code-router` work into board-ready issues?**
+   Yes with manual care; no as a reliable one-command path. The missing piece is a team-aware issue
+   preparation workflow that can produce either Asgard-ready shaping issues or Olympus-ready
+   dispatch issues from ordinary source text.
+
+The strongest survivor is a dry-run-first `sdlc-manager` workflow tentatively named
+`issue prepare` or `issue prepare-team-card`. It should take a target repo, a target team/board,
+and free-form source text, then produce a complete issue draft plus a readiness report. Issue
+creation can come later once the dry-run shape is trusted.
+
+## Grounding
+
+Checked local repositories and files:
+
+- Current repo: `infiquetra-claude-plugins`
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/config/sdlc-schema.json`
+  - `plugins/sdlc-manager/config/project-mappings.json`
+  - `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+  - `plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md`
+  - `plugins/sdlc-manager/skills/sdlc-rollout/SKILL.md`
+- SDLC repo:
+  - `../infiquetra-sdlc/config/sdlc-schema.json`
+  - `../infiquetra-sdlc/.github/ISSUE_TEMPLATE/capability.yml`
+  - `../infiquetra-sdlc/AGENTS.md`
+- Runtime/readiness evidence from home-lab:
+  - `../home-lab/ansible/roles/hermes_orchestrator/files/card_validator.py`
+  - `../home-lab/ansible/roles/hermes_orchestrator/files/config.py`
+  - `../home-lab/ansible/roles/hermes_orchestrator/files/handlers.py`
+  - `../home-lab/ansible/roles/hermes_agent_listener/files/prompts/assign_work.md`
+  - `../home-lab/ansible/roles/hermes/files/skills/mimir-orchestration/SKILL.md`
+  - `../home-lab/ansible/roles/hermes/files/skills/mimir-orchestration/references/issue-intake.md`
+  - `../home-lab/ansible/roles/hermes/files/skills/mimir-orchestration/references/card-grammar.md`
+  - `../home-lab/ansible/roles/hermes/files/skills/mimir-orchestration/references/selection-and-gates.md`
+- Target repo:
+  - `../hermes-claude-code-router/docs/engineering-journal/QUEUED.md`
+  - `../hermes-claude-code-router/AGENTS.md`
+  - local `.github/` contains `workflows/ci.yml` only; no `.github/ISSUE_TEMPLATE/` files.
+
+Remote sanity check:
+
+- `gh repo view infiquetra/hermes-claude-code-router` reports default branch `main`, last pushed
+  `2026-05-27T03:45:47Z`.
+- Local `hermes-claude-code-router` is on `main` at `d8711cf`, tracking `origin/main`.
+
+## What `infiquetra-sdlc` Defines
+
+The current SDLC schema defines these teams and boards:
+
+| Team or role | Kind | Board |
+|---|---|---|
+| `jeff` | human operator | `jeff_intent` |
+| `asgard` | agent team | `asgard` |
+| `olympus` | agent team | `olympus` |
+| `hermes` | system role | none |
+| `themis` | retired historical role | none |
+
+The board workflows are:
+
+- Jeff Intent and Asgard: `Idea -> Shaping -> Ready -> Active -> Verify -> Done`
+- Mount Olympus: `Backlog -> Ready -> Planning -> Assigned -> In Review -> Done -> Closed`
+
+The Olympus Ready gate is the strict one:
+
+- Actionable issue schema passes.
+- Work is labeled for Olympus dispatch.
+- Acceptance criteria and verification are present.
+
+`sdlc-manager` has caught up to this board topology at the schema and board-tooling level. It has
+`PROJECT_CHOICES = ("mount-olympus", "asgard", "jeff-intent")`, board references for all three,
+and WIP/status behavior backed by the vendored schema.
+
+## Asgard vs. Olympus Expectations
+
+### Asgard Readiness
+
+Asgard is for rapid action, incubation, and mission-mode work close to Jeff. An Asgard issue or
+card can be useful before it is fully dispatch-ready. The shape should emphasize:
+
+- Clear intent or problem statement.
+- Target repository or surface.
+- Mode: Rapid Action, Incubator, or Mission.
+- Known constraints and risk.
+- What would make the work promotable to Olympus, if promotion is expected.
+- Jeff-needed or decision-needed state when the work crosses an approval boundary.
+
+Asgard should be allowed to hold issue drafts that are not yet strict implementation contracts.
+The plugin should not force every Asgard card through the Olympus issue schema.
+
+### Olympus Readiness
+
+Olympus is the autonomous engineering execution pipeline. An Olympus-ready issue needs the stricter
+shape currently enforced by the runtime validator and assignment prompt:
+
+- Actionable labels are present: type label, `hermes-task`, and `needs-plan`.
+- Required H3 sections exist:
+  - `Objective`
+  - `Acceptance criteria`
+  - `Out-of-scope / non-goals`
+  - `Files expected to change`
+  - `Tests to add or update`
+  - `Verification`
+- Acceptance criteria include at least one checklist item.
+- Files expected to change include at least one plausible path.
+- Verification includes a fenced command block.
+- Placeholder-only sections fail.
+- The issue author is allowed by the runtime configuration.
+- The issue is on the intended project/status.
+
+The stricter issue body matters because the assignment prompt treats the structured fields as the
+execution contract: the worker only touches files in `Files expected to change`, and the exact
+command in `Verification` is the acceptance signal.
+
+## Current `sdlc-manager` Capability
+
+What works today:
+
+- Knows the six SDLC issue types.
+- Documents actionable templates as `capability`, `enhancement`, and `defect`.
+- Documents actionable template labels as type label + `hermes-task` + `needs-plan`.
+- Can deploy canonical labels and issue templates to a repo using rollout commands.
+- Can add issues to a GitHub Projects v2 board.
+- Can set project fields via live field discovery.
+- Can validate an issue body against the stricter body-shape checks.
+- Can target Jeff Intent, Asgard, or Mount Olympus for board commands.
+
+Important gaps:
+
+- `issue create` has no `--project` override. It only discovers projects from repo mappings.
+- `hermes-claude-code-router` is not in the vendored `project-mappings.json`.
+- The sibling `infiquetra-sdlc` checkout currently has no local `config/project-mappings.json`, so
+  the vendored mapping is the practical local source.
+- Post-create metadata applies `hermes-task` or `hermes-not-actionable`, but relies on the selected
+  issue template for `needs-plan` and the type label.
+- The `--web` flow has a documented caveat: GitHub CLI may open a blank issue form even when a
+  template was requested.
+- If the template labels do not apply, the tool does not currently guarantee `needs-plan` or the
+  type label.
+- `flow validate-card` is a body validator, not a full label/author/project/status readiness check.
+- The router repo lacks local issue templates, so template-driven issue creation will not work
+  cleanly until templates are deployed.
+
+## Source Text, Not Queue-Specific Automation
+
+The router backlog is in `../hermes-claude-code-router/docs/engineering-journal/QUEUED.md`, and it
+contains useful source material such as voice transcript routing, voice playback, button approvals,
+tmux spawning, and hybrid tool dispatch.
+
+That file does not need a special command. The better abstraction is:
+
+- Take any source text: pasted prompt, copied queued entry, roadmap excerpt, blueprint section, or
+  free-form note.
+- Ask the operator for target team/board and issue type when not inferable.
+- Produce a board-specific issue draft and readiness report.
+
+This keeps `QUEUED.md` useful without making the plugin depend on one journal file format.
+
+## Feasibility Answer
+
+### Manual path today: feasible with care
+
+For a single router item, a safe manual workflow today would be:
+
+1. Deploy or confirm SDLC labels and templates on `hermes-claude-code-router`.
+2. Decide board routing:
+   - Use Asgard if the work is still shaping, incubating, or mission-mode near Jeff.
+   - Use Mount Olympus if the card should be dispatch-ready for autonomous engineering execution.
+3. If using `sdlc-manager` without mapping changes, create the issue with the template, then add it
+   explicitly with `board add --project mount-olympus` or `board add --project asgard`.
+4. Fill every required issue-form field with concrete content for Olympus-directed work.
+5. Confirm labels include the type label, `hermes-task`, and `needs-plan` for Olympus-directed work.
+6. Run `flow validate-card` for Olympus-directed work.
+7. Keep the issue in Backlog/Shaping until it passes the appropriate team readiness expectations.
+
+### One-command path today: not feasible
+
+There is no current command that takes arbitrary source text, emits a team-specific issue draft,
+proves labels/templates/author/project/readiness, and routes the card without manual steps.
+
+### Risk if we use today's flow naively
+
+The likely failure modes are:
+
+- The router repo has no issue templates, so the issue body is blank or ad hoc.
+- The issue has `hermes-task` but not `needs-plan` or the type label.
+- The body passes the six-heading validator but lacks risk, authority, or definition-of-done detail
+  that the team needs to execute safely.
+- The repo is unmapped, so issue-create does not add it to the intended project.
+- An Asgard-shaped issue is treated as Olympus-ready too early.
+- An Olympus card is moved to Ready before it satisfies the stricter execution checks.
+
+## Strongest Ideas
+
+### 1. Add Dry-Run `issue prepare`
+
+Create a dry-run-first command that turns source text into a board-ready issue draft.
+
+Inputs:
+
+- Target repo.
+- Source text, from stdin, file path, or prompt argument.
+- Issue type.
+- Target team or project: Asgard or Mount Olympus first, Jeff Intent later if useful.
+- Optional risk, affected repos, authority boundaries, validation expectations, and parent issue.
+
+Outputs:
+
+- Issue title.
+- Complete issue body appropriate to the chosen team.
+- Label set.
+- Target project/status recommendation.
+- Readiness report with pass/fail/warn results.
+
+Why this survives: it gives the operator the high-leverage part without mutating GitHub first.
+Issue authoring is the brittle step, and Asgard/Olympus need different levels of strictness.
+
+### 2. Add `issue create` Support On Top Of Prepared Drafts
+
+After the draft command is trusted, add a mutation-capable path that creates the issue and applies
+metadata.
+
+Required behavior:
+
+- Refuse to create Olympus-directed actionable issues if target repo lacks canonical templates or
+  labels unless `--allow-missing-rollout` is explicit.
+- Add type label, `hermes-task`, and `needs-plan` explicitly after creation, not only via template.
+- Support `--project mount-olympus|asgard|jeff-intent`.
+- Add to the selected board explicitly.
+- Set status to Backlog/Shaping by default, not Ready.
+- Print the exact reason the card is or is not ready for the selected board.
+
+Why this survives: direct creation becomes safe only after dry-run shape is deterministic.
+
+### 3. Add Team-Aware Readiness Profiles
+
+Extend `flow validate-card` into a broader checker:
+
+```bash
+sdlc_manager.py issue readiness --team olympus --repo <repo> --number <n>
+sdlc_manager.py issue readiness --team asgard --repo <repo> --number <n>
+```
+
+Olympus checks:
+
+- Body-shape validation.
+- Required actionable labels.
+- Author allow-list risk, or at least report issue author and configured/default allowed authors.
+- Target repo template deployment.
+- Target repo label deployment.
+- Project mapping or explicit project presence.
+- Project status.
+- Verification block and expected file path sanity.
+
+Asgard checks:
+
+- Intent/problem is stated.
+- Target repo/surface is present.
+- Mode or promotion target is clear.
+- Known constraints and risk are present.
+- Jeff-needed state is clear when relevant.
+- If marked for promotion to Olympus, the Olympus readiness gaps are listed.
+
+Why this survives: the current body validator is necessary but too narrow.
+
+### 4. Update Project Mappings And Routing Semantics
+
+Add or generate a mapping for `hermes-claude-code-router`, but do not hide the routing decision.
+
+Recommended default:
+
+- `hermes-claude-code-router` should map to Mount Olympus if the goal is autonomous engineering
+  dispatch.
+- Asgard should stay available as an explicit target for shaping, incubation, and mission-mode work.
+
+Why this survives: an unmapped repo is the reason the current issue-create flow cannot route router
+issues automatically.
+
+### 5. Keep Shared Templates Stable; Generate Team-Specific Additions In The Body
+
+Do not add team-internal machinery as required shared template fields. Use generated body sections
+or comments for team-specific details.
+
+Why this survives: shared issue templates should remain human-facing and cross-team. The
+team-specific details belong in generated drafts and readiness checks.
+
+### 6. Add Drift Tests Against Asgard/Olympus Readiness Expectations
+
+Add tests that keep `sdlc-manager` aligned with selected source facts:
+
+- Board names and workflow statuses from `infiquetra-sdlc/config/sdlc-schema.json`.
+- Required Olympus H3 headings.
+- Actionable label names.
+- Asgard mode/routing terms.
+- Body-shape semantics.
+
+Why this survives: there are now multiple moving sources. The costly drift is between issue
+authoring guidance and runtime/team readiness.
+
+## Rejected Or Deferred Ideas
+
+### Add A Dedicated Source-File-To-Issues Command
+
+Reject for now. A queued entry is just one possible source text. The stronger abstraction is
+source-text-in, team-ready issue draft out.
+
+### Auto-Move Created Issues Directly To Ready
+
+Reject. Ready is a dispatch signal. A newly created issue should be Backlog/Shaping until the
+appropriate readiness checks pass and the operator intends dispatch.
+
+### Treat Every Unmapped Repo As Mount Olympus
+
+Reject. It would make new repos easy to route incorrectly. The tool should require mapping or an
+explicit `--project`.
+
+### Add Team-Specific Required Fields To Shared Issue Templates
+
+Reject for now. The shared templates should stay human-facing and cross-team. Team-specific
+readiness detail belongs in generated issue bodies, comments, or project fields.
+
+### Depend On GitHub's Browser Issue Form To Apply Everything
+
+Reject. The current `gh issue create --web` caveat makes this too fragile. The plugin should
+explicitly verify and, for labels, explicitly apply the required machine labels.
+
+### Hardcode A Separate Runtime Board Into `sdlc-manager`
+
+Defer. The stable public surfaces in `infiquetra-sdlc` are Asgard and Mount Olympus. If another
+board or runtime API becomes canonical later, model it then.
+
+## Recommended Next Brainstorm Topic
+
+Use `ce-brainstorm` for:
+
+> Define the `sdlc-manager` team-ready issue preparation workflow for turning source text into
+> validated GitHub issue drafts that can be routed to Asgard or Mount Olympus without confusing
+> shaping readiness with dispatch readiness.
+
+Decisions that brainstorming should settle:
+
+- Command name: `issue prepare`, `issue draft`, or `issue prepare-team-card`.
+- Whether v1 is dry-run only.
+- How target team is represented: `--team asgard|olympus`, `--project`, or both.
+- Exact required inputs versus inferred fields.
+- How source text is supplied: stdin, file path, prompt argument, or all three.
+- The Asgard readiness checklist.
+- The Olympus readiness checklist.
+- The readiness output schema.
+- The minimum change needed before creating router issues from copied queued entries or prompts.
+
+## Practical Next Step For The Router Repo
+
+Before creating real router issues:
+
+1. Deploy or confirm canonical SDLC labels/templates on `hermes-claude-code-router`.
+2. Add `hermes-claude-code-router` to project mappings or use explicit `board add --project`.
+3. Pick one router work item and draft it twice:
+   - Asgard version: shaping/mission-ready.
+   - Olympus version: dispatch-ready.
+4. Compare what fields differ.
+5. Use that comparison as the input to `ce-brainstorm` for `issue prepare`.
+
+This gives one concrete calibration issue before automating the workflow.

--- a/docs/plans/2026-05-30-001-feat-sdlc-issue-prepare-workflow-plan.md
+++ b/docs/plans/2026-05-30-001-feat-sdlc-issue-prepare-workflow-plan.md
@@ -1,0 +1,505 @@
+---
+title: "feat: Add SDLC issue prepare workflow"
+type: "feat"
+status: "completed"
+date: "2026-05-30"
+origin: "docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md"
+---
+
+# feat: Add SDLC issue prepare workflow
+
+## Summary
+
+Add a team-aware prepared-issue workflow to `sdlc-manager` so source text can become
+reviewable Asgard or Mount Olympus issue drafts before any GitHub mutation. The workflow adds
+`issue prepare` for draft/readiness artifacts and `issue create-prepared` for confirmed creation,
+repo prerequisite repair, board placement, safe status assignment, and draft state recording.
+
+---
+
+## Problem Frame
+
+`sdlc-manager` already knows about the current Jeff Intent, Asgard, and Mount Olympus boards,
+template labels, repo mappings, project fields, and the strict actionable body validator. The
+missing path is the one operators actually need before pointing agent teams at work: take rough
+source text, make the target team and project explicit, produce a draft that can be reviewed, and
+only then create an issue that will not fail the intended team's pre-checks.
+
+The plan is sourced from
+`docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md`. It covers the full v1
+brainstorm scope, including creation and self-healing repo prerequisites, while keeping rough-source
+interpretation in skills/docs and deterministic validation/mutation in the CLI.
+
+---
+
+## Requirements
+
+**Prepared draft artifacts**
+
+- R1. `issue prepare` accepts source from a prompt argument, stdin, or `--source-file`, and writes a
+  markdown draft under `docs/sdlc-issue-drafts/`.
+- R2. Each prepared draft has a JSON sidecar with repo, issue type, team, project, readiness
+  profile, blocking gaps, warnings, and draft lifecycle state.
+- R3. Incomplete source still writes a draft and sidecar, but marks blocking readiness gaps.
+- R4. Drafts with blocking gaps cannot be created until the markdown and sidecar pass validation.
+
+**Team readiness**
+
+- R5. Asgard readiness accepts shaping-quality issue drafts that state intent, target
+  repo/surface, mode, constraints, risk, and promotion gaps.
+- R6. Mount Olympus readiness requires the strict actionable issue body shape: required H3
+  sections, checklist acceptance criteria, path-like expected files, fenced verification,
+  actionable labels, project presence, author risk visibility, and safe status.
+- R7. An Asgard-shaped draft is not treated as Olympus-ready unless the Olympus profile passes.
+- R8. The workflow never auto-moves a newly created issue to `Ready`; safe defaults are
+  `Shaping` for Asgard and `Backlog` for Mount Olympus.
+
+**Confirmed creation and repair**
+
+- R9. `issue create-prepared <draft>` parses the markdown draft and JSON sidecar, then shows a
+  complete mutation plan before any GitHub or mapping mutation.
+- R10. The mutation plan includes label/template deployment, mapping repair, issue creation, board
+  add, status setting, and draft update steps when applicable.
+- R11. Missing labels/templates are deployed directly to the target repo after confirmation.
+- R12. Missing project mappings trigger a branch-and-PR mapping update flow before issue creation
+  continues by default.
+- R13. An explicit override can create the issue before the mapping PR merges, using the requested
+  project and recording the pending mapping state on the draft.
+- R14. Successful creation retains the draft and records issue URL, number, timestamp, and mutation
+  summary.
+
+**Natural-language and documentation**
+
+- R15. Natural-language skill guidance routes prompts like "create an Olympus issue from this" to
+  prepare plus create-prepared, not directly to the existing browser-backed create flow.
+- R16. Team and project are first-class inputs. Skills may infer them from clear language but must
+  ask when ambiguous.
+- R17. Documentation distinguishes the existing interactive `issue create` flow from the prepared
+  draft workflow.
+
+**Validation**
+
+- R18. Parser/readiness tests cover draft parsing, sidecar parsing, Asgard readiness, Olympus
+  readiness, blocked create, safe status defaults, and draft lifecycle transitions.
+- R19. Mocked mutation tests cover mutation-plan construction, label/template deployment, mapping
+  PR flow, issue creation, board add, status setting, override, and draft-created updates.
+- R20. Prompt/reference drift tests cover natural-language routing and the new command
+  documentation.
+
+---
+
+## Key Technical Decisions
+
+- **Extend the existing `issue` command group instead of adding a separate plugin command group:**
+  The current CLI already owns issue creation, project routing, field setting, labels, templates,
+  and validation. Adding `issue prepare` and `issue create-prepared` keeps the public surface
+  discoverable without disturbing the existing interactive `issue create` flow.
+- **Use draft artifacts as the handoff boundary:** The markdown draft is human-editable review
+  material. The JSON sidecar is the deterministic contract consumed by `create-prepared`. This
+  keeps model-shaped prose out of mutation code while giving the CLI enough structure to block bad
+  creates.
+- **Treat Asgard and Mount Olympus as readiness profiles, not issue types:** The six existing SDLC
+  issue types stay canonical. Team-specific differences live in readiness checks, default status,
+  board/project targeting, and draft guidance.
+- **Keep source interpretation out of `sdlc_manager.py`:** `issue prepare` accepts already-shaped
+  fields and source text, but the skill layer is responsible for turning vague prompts into draft
+  content. The CLI validates, serializes, builds mutation plans, and performs confirmed mutations.
+- **Centralize mutation planning before side effects:** `create-prepared` should build one
+  structured mutation plan and render it for confirmation before running any GitHub or mapping
+  operation. This makes direct repo repair, mapping PR work, issue creation, and draft updates
+  reviewable as one decision.
+- **Repair labels/templates directly, but repair mappings through a PR:** Label and template
+  deployment already has direct repo helpers. Project mapping changes affect canonical routing, so
+  default behavior should branch, commit, push, and open a PR before issue creation proceeds.
+- **Prefer live project field discovery for status setting:** Existing `flow set-field` behavior
+  resolves fields/options live. `create-prepared` should reuse that posture for safe status
+  assignment rather than caching option IDs.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Source text or shaped fields"] --> B["Skill/model prepares issue body"]
+  B --> C["issue prepare"]
+  C --> D["Markdown draft"]
+  C --> E["JSON readiness sidecar"]
+  D --> F["Operator review/edit"]
+  E --> F
+  F --> G["issue create-prepared"]
+  G --> H{"Readiness passes?"}
+  H -->|no| I["Report blocking gaps; no mutation"]
+  H -->|yes| J["Build mutation plan"]
+  J --> K{"Operator confirms?"}
+  K -->|no| L["No mutation; draft retained"]
+  K -->|yes| M["Repair prerequisites"]
+  M --> N["Create issue"]
+  N --> O["Add to project and set safe status"]
+  O --> P["Mark draft created"]
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft
+  draft --> blocked: readiness gaps
+  blocked --> draft: operator edits draft or sidecar
+  draft --> ready_to_create: readiness passes
+  ready_to_create --> mutation_planned: create-prepared parses artifacts
+  mutation_planned --> draft: operator declines confirmation
+  mutation_planned --> mapping_pending: mapping PR opened without override
+  mapping_pending --> ready_to_create: mapping merged or override selected
+  mutation_planned --> created: confirmed mutations complete
+  created --> [*]
+```
+
+---
+
+## Output Structure
+
+```text
+docs/
+  sdlc-issue-drafts/
+    <generated issue drafts and JSON sidecars>
+
+plugins/sdlc-manager/
+  scripts/
+    sdlc_manager.py
+  commands/
+    sdlc-create.md
+  skills/
+    sdlc-issues/
+      SKILL.md
+      references/
+        issue-types.md
+  tests/
+    test_issue_prepare.py
+    test_issue_create_prepared.py
+    test_prompt_alignment.py
+```
+
+---
+
+## Implementation Units
+
+### U1. Define prepared draft data contracts
+
+- **Goal:** Add deterministic draft, sidecar, readiness result, and mutation plan structures that
+  can be used by parser, readiness, and create-prepared code without mixing in GitHub side effects.
+- **Requirements:** R1, R2, R3, R4, R9, R10, R14, R18.
+- **Dependencies:** None.
+- **Files:**
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/tests/test_issue_prepare.py`
+- **Approach:** Introduce small typed structures near the existing issue helpers for prepared
+  draft metadata, readiness gaps, lifecycle state, and mutation plan steps. Keep the structures
+  serializable with stdlib JSON and compatible with existing zero-extra-dependency CLI style.
+  Define lifecycle states such as draft, blocked, ready_to_create, mapping_pending, and created.
+  Store only stable data in the sidecar: repo, type, team, project, draft path, readiness profile,
+  expected labels, author-visible risk fields, gap lists, timestamps, planned side-effect
+  summaries, and created issue result fields.
+- **Patterns to follow:** Existing typed exception/data helper style in
+  `plugins/sdlc-manager/scripts/sdlc_manager.py`; existing test import pattern in
+  `plugins/sdlc-manager/tests/test_issue_create_interactive.py`.
+- **Test scenarios:**
+  - Serialize and parse a sidecar for an Asgard draft with no blocking gaps.
+  - Serialize and parse a sidecar for an Olympus draft with blocking verification and files gaps.
+  - Reject sidecar content whose draft path, repo, team, project, or issue type conflicts with the
+    markdown draft metadata.
+  - Preserve created issue URL, number, timestamp, and mutation summary when marking a draft
+    created.
+  - Treat missing or malformed sidecar JSON as a blocking create-prepared error with no mutation.
+- **Verification:** Unit tests prove the artifact contract round-trips, rejects inconsistent
+  state, and can record created-state metadata without GitHub calls.
+
+### U2. Implement draft parsing and team readiness profiles
+
+- **Goal:** Parse prepared markdown drafts and evaluate them against Asgard or Mount Olympus
+  readiness without performing mutations.
+- **Requirements:** R3, R4, R5, R6, R7, R8, R18.
+- **Dependencies:** U1.
+- **Files:**
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/tests/test_issue_prepare.py`
+  - `plugins/sdlc-manager/tests/test_card_validator.py`
+- **Approach:** Reuse `validate_card_body` for the strict Olympus actionable body checks rather
+  than duplicating the H3/checklist/path/code-block rules. Add a separate Asgard profile focused on
+  shaping readiness fields and promotion gaps. The readiness result should distinguish blocking
+  gaps from warnings and should report Olympus promotion gaps for Asgard drafts without blocking
+  Asgard creation. Olympus readiness should also validate expected actionable labels, project
+  presence, and author-visible risk fields from the sidecar or draft metadata before treating the
+  draft as dispatch-ready. Status validation should enforce safe defaults only and reject `Ready`.
+- **Patterns to follow:** Existing card validator shim and tests in
+  `plugins/sdlc-manager/tests/test_card_validator.py`; schema-backed status helpers such as
+  `_project_workflow` and `_status_order`.
+- **Test scenarios:**
+  - Covers AE1. Olympus draft without fenced verification fails readiness and cannot create.
+  - Covers AE2. Asgard shaping draft with intent, repo, mode, constraints, and risk passes Asgard
+    readiness while reporting Olympus promotion gaps.
+  - Olympus draft with all required H3 sections, checklist acceptance criteria, path-like files,
+    and fenced verification passes readiness.
+  - Asgard-shaped draft targeting Mount Olympus fails the Olympus profile.
+  - Draft or sidecar requesting `Ready` status fails for both Asgard and Mount Olympus.
+  - Olympus sidecar missing expected actionable labels, project, or author-visible risk metadata
+    fails readiness before creation.
+  - Non-actionable issue types are not accidentally treated as dispatch-ready actionable tasks.
+- **Verification:** Readiness unit tests prove the two profiles are visibly different and that
+  Olympus checks keep parity with the existing card validator.
+
+### U3. Add `issue prepare` command
+
+- **Goal:** Add the dry-run preparation command that writes markdown and JSON artifacts under
+  `docs/sdlc-issue-drafts/`.
+- **Requirements:** R1, R2, R3, R4, R5, R6, R15, R16, R18.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/tests/test_issue_prepare.py`
+  - `plugins/sdlc-manager/README.md`
+  - `plugins/sdlc-manager/CHANGELOG.md`
+- **Approach:** Add an `issue prepare` argparse branch with explicit `--repo`, `--type`, `--team`,
+  and `--project` inputs plus source text from an argument, stdin, or `--source-file`. The command
+  should normalize inputs, write a stable filename, write the sidecar next to the markdown draft,
+  run readiness, and print the draft path plus blocking gaps. Ambiguous team/project inference
+  belongs in the skill layer, so the deterministic CLI should require explicit values unless a
+  direct flag supplies them.
+- **Execution note:** Implement the parser and readiness behavior test-first before adding the CLI
+  branch.
+- **Patterns to follow:** Existing argparse grouping for `issue create`; README command reference
+  style under `plugins/sdlc-manager/README.md`.
+- **Test scenarios:**
+  - Source text supplied as a positional prompt creates markdown and JSON sidecar with equivalent
+    readiness output.
+  - Source text supplied through `--source-file` creates the same artifact shape.
+  - Stdin source creates the same artifact shape when no prompt or source file is provided.
+  - Missing required repo/type/team/project inputs fail before artifact creation in CLI mode.
+  - Existing draft filenames are not overwritten accidentally; a unique suffix or timestamp is
+    used.
+  - Blocking gaps are printed and persisted in the sidecar for incomplete input.
+- **Verification:** CLI-level tests and direct helper tests prove preparation is mutation-free,
+  writes both artifacts, and reports readiness consistently across input sources.
+
+### U4. Build mutation planning and confirmed `issue create-prepared`
+
+- **Goal:** Add the create command that consumes a prepared draft, blocks invalid drafts, renders a
+  full mutation plan, and only mutates after explicit confirmation.
+- **Requirements:** R4, R8, R9, R10, R14, R19.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/tests/test_issue_create_prepared.py`
+- **Approach:** Add an `issue create-prepared` argparse branch that loads the markdown and sidecar,
+  re-runs readiness, constructs a mutation plan, renders every side effect, and asks for final
+  confirmation. The mutation executor should call composable helpers for each step so tests can
+  mock GitHub operations. Successful creation should update the sidecar and annotate the markdown
+  draft with the created issue result. Project placement and status setting should use the
+  requested project from the prepared draft directly, including mapping-override cases, instead of
+  falling back to repo-based project discovery after issue creation. A declined confirmation leaves
+  the draft unchanged except for any explicit non-mutating validation output.
+- **Execution note:** Start with blocked-create and declined-confirmation tests before wiring real
+  mutation helpers.
+- **Patterns to follow:** Existing `_apply_post_create_metadata` sequencing and isolation; existing
+  `flow_set_field`, `board_add`, and label/template deployment helpers.
+- **Test scenarios:**
+  - Covers AE1. Draft with blocking readiness gaps refuses to create and calls no GitHub helpers.
+  - Passing draft renders a mutation plan containing issue creation, board add, safe status, and
+    draft update.
+  - Operator declines confirmation and no mutation helper is called.
+  - Successful Mount Olympus create sets safe status `Backlog`, not `Ready`.
+  - Successful Asgard create sets safe status `Shaping`, not `Ready`.
+  - Board add and status setting use the prepared draft's requested project even when repo mapping
+    is missing or still pending.
+  - Issue creation failure does not mark the draft created.
+  - Draft update failure is reported after issue creation without hiding the created issue URL.
+- **Verification:** Mocked mutation tests prove side effects happen only after confirmation and that
+  draft lifecycle updates reflect the actual mutation result.
+
+### U5. Add repo prerequisite repair and mapping PR flow
+
+- **Goal:** Teach create-prepared to repair missing labels/templates directly and handle missing
+  project mappings through branch-and-PR work with an explicit override.
+- **Requirements:** R10, R11, R12, R13, R19.
+- **Dependencies:** U4.
+- **Files:**
+  - `plugins/sdlc-manager/scripts/sdlc_manager.py`
+  - `plugins/sdlc-manager/tests/test_issue_create_prepared.py`
+  - `plugins/sdlc-manager/tests/test_project_mappings_resolution.py`
+- **Approach:** Factor existing gap-analysis logic into reusable checks for labels, templates, and
+  project mapping. Use the existing label/template deployment helpers for direct repo repair. Add
+  mapping-repair helpers that prefer the external `infiquetra-sdlc` checkout when available and
+  otherwise update the vendored mapping with a warning. Mapping repair should create a branch,
+  commit, push, and open a PR before stopping by default. The override path creates the issue using
+  the requested project directly and records the pending mapping state.
+- **Execution note:** Treat this as high-risk relative to the rest of the feature; keep GitHub and
+  git operations behind mocked helper boundaries first.
+- **Patterns to follow:** `_resolve_project_mappings`, `_VENDORED_PROJECT_MAPPINGS_PATH`,
+  `rollout_gap_analysis`, `rollout_deploy_labels`, `rollout_deploy_templates`, and existing
+  `board add --project` support.
+- **Test scenarios:**
+  - Covers AE3. Missing labels/templates appear in the mutation plan and are deployed after
+    confirmation before issue creation.
+  - Covers AE4. Missing mapping creates a mapping branch/PR and stops before issue creation when no
+    override is selected.
+  - Covers AE5. Override creates the issue with the requested project and records pending mapping
+    state in the sidecar.
+  - External mapping checkout wins over vendored mapping for repair when present.
+  - Vendored mapping repair warns clearly when no external checkout is available.
+  - Mapping PR creation failure stops issue creation and preserves draft state.
+- **Verification:** Mocked tests prove prerequisite repair ordering, mapping stop/override behavior,
+  and no hidden default-branch mapping writes.
+
+### U6. Update skill, command, and agent guidance for natural-language routing
+
+- **Goal:** Make natural-language use first-class and prevent agents from bypassing prepared-draft
+  readiness checks when the user asks to create Asgard or Olympus issues from text.
+- **Requirements:** R15, R16, R17, R20.
+- **Dependencies:** U3, U4, U5.
+- **Files:**
+  - `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+  - `plugins/sdlc-manager/commands/sdlc-create.md`
+  - `plugins/sdlc-manager/agents/sdlc-operator.md`
+  - `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- **Approach:** Update prompt guidance to describe two issue-creation paths: existing interactive
+  browser-backed creation for already-known work, and prepared-draft creation for source-text or
+  team-readiness-driven work. Add examples for "create an Asgard issue from this text" and "create
+  an Olympus issue from this text" that route through prepare plus create-prepared. Make team and
+  project inference rules explicit and require an ask when ambiguous.
+- **Patterns to follow:** Existing prompt/reference drift guards in
+  `plugins/sdlc-manager/tests/test_prompt_alignment.py`.
+- **Test scenarios:**
+  - Prompt alignment test asserts natural-language Asgard/Olympus issue creation routes through
+    prepared draft workflow.
+  - Prompt alignment test asserts existing `issue create` remains documented for interactive
+    template creation.
+  - Prompt alignment test asserts ambiguous team/project prompts must ask rather than guess.
+  - Command documentation includes both `issue prepare` and `issue create-prepared` examples.
+- **Verification:** Drift guard tests prove docs and prompts teach the new route without erasing
+  the old route.
+
+### U7. Update release metadata and operator docs
+
+- **Goal:** Make the new workflow discoverable after plugin installation and keep release metadata
+  consistent.
+- **Requirements:** R17, R20.
+- **Dependencies:** U3, U4, U5, U6.
+- **Files:**
+  - `plugins/sdlc-manager/README.md`
+  - `plugins/sdlc-manager/CHANGELOG.md`
+  - `plugins/sdlc-manager/.claude-plugin/plugin.json`
+  - `.claude-plugin/marketplace.json`
+  - `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- **Approach:** Add README examples for prepare and create-prepared, document the draft directory,
+  summarize safe statuses and mapping-repair behavior, and add a changelog entry. If this ships as
+  a plugin release, bump the plugin manifest and marketplace entry together and update the metadata
+  drift guard to the new version.
+- **Patterns to follow:** The `1.5.0` changelog/metadata bump pattern and existing marketplace
+  drift guard in `plugins/sdlc-manager/tests/test_prompt_alignment.py`.
+- **Test scenarios:**
+  - Metadata test asserts plugin manifest and marketplace versions match after any bump.
+  - README contains prepare/create-prepared usage and draft directory guidance.
+  - Changelog documents the new workflow, safe defaults, and mapping PR behavior.
+  - Marketplace description remains under validator limits and mentions prepared issue workflow
+    only if the description still reads cleanly.
+- **Verification:** Prompt alignment and metadata tests prove installed plugin docs, manifest, and
+  marketplace registration stay in sync.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Olympus draft blocks on missing verification:** A draft with no fenced verification command
+  is written with blocking gaps, and `issue create-prepared` refuses to mutate.
+- AE2. **Asgard draft accepts shaping-quality input:** A draft with intent, repo, mode,
+  constraints, and risk can pass Asgard readiness while listing Olympus promotion gaps.
+- AE3. **Create deploys missing labels/templates after confirmation:** The mutation plan lists
+  prerequisite repair and runs it only after confirmation.
+- AE4. **Missing mapping opens PR and stops:** Mapping repair is opened as a PR and issue creation
+  waits by default.
+- AE5. **Mapping override creates before merge:** Explicit override creates the issue and records
+  pending mapping state.
+- AE6. **Natural-language creation uses the same path:** Agent guidance routes Asgard/Olympus issue
+  creation from source text through prepare plus create-prepared.
+
+---
+
+## System-Wide Impact
+
+- **Public CLI surface:** Adds new subcommands under `issue`, so command docs, README examples, and
+  prompt alignment tests need to change with the CLI.
+- **GitHub side effects:** `create-prepared` can create issues, deploy labels/templates, add cards
+  to projects, set fields, push mapping branches, and open PRs. The mutation plan and confirmation
+  gate are the safety boundary.
+- **Project routing:** Missing mapping behavior changes from "warn and manual repair" to a
+  first-class repair plan. Default behavior still avoids hidden direct default-branch edits.
+- **Team workflow semantics:** Asgard and Mount Olympus get explicit readiness profiles and safe
+  starting statuses, which reduces accidental early routing to `Ready`.
+
+---
+
+## Scope Boundaries
+
+- Dedicated `QUEUED.md` parsing is out of scope; queued entries are source text.
+- Auto-moving issues to `Ready` is out of scope.
+- Direct LLM calls from `sdlc_manager.py` are out of scope.
+- Replacing the six SDLC issue types is out of scope.
+- Hidden repo setup, hidden mapping edits, and direct default-branch mapping pushes are out of
+  scope.
+- Joining Asgard and Mount Olympus into one issue-readiness profile is out of scope.
+
+### Deferred to Follow-Up Work
+
+- Batch creation from multiple prepared drafts.
+- A richer review UI for prepared drafts.
+- A deterministic source-text-to-body generator inside the CLI if a future non-model use case
+  requires it.
+- End-to-end tests against a fixture GitHub project; v1 relies on unit and mocked mutation tests.
+
+---
+
+## Risks & Dependencies
+
+- **GitHub auth and scopes:** Project writes, issue creation, content updates, and PR creation may
+  require different `gh` scopes. Mitigate by surfacing failures per mutation step and leaving draft
+  state uncreated when critical operations fail.
+- **Canonical mapping location drift:** The external `infiquetra-sdlc` checkout may or may not
+  contain `config/project-mappings.json`. Keep resolution order explicit and warn when falling back
+  to vendored mapping repair.
+- **Template drift:** Olympus readiness should reuse `validate_card_body` and existing template
+  drift guards so body validation does not fork silently.
+- **Partially successful mutation:** Issue creation may succeed while draft annotation fails.
+  Preserve and print the issue URL/number so the operator can recover.
+- **Prompt overreach:** Natural-language docs must not imply the CLI can infer vague user intent
+  without the skill/model layer. Keep deterministic CLI requirements explicit.
+
+---
+
+## Documentation And Operational Notes
+
+- Update `sdlc-issues` guidance to describe when to use existing interactive creation versus
+  prepared-draft creation.
+- Update `/sdlc-create` docs so natural-language issue creation from source text routes through the
+  prepared workflow.
+- Document that prepared drafts are durable repo files and may be edited before creation.
+- Document that `create-prepared` asks for final confirmation before GitHub or mapping mutations.
+- Document the safe default statuses: Asgard `Shaping`, Mount Olympus `Backlog`.
+
+---
+
+## Sources & Research
+
+- `docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md` is the origin and source
+  of product scope.
+- `docs/ideation/2026-05-30-sdlc-manager-asgard-olympus-issue-readiness.md` records the earlier
+  feasibility and design rationale.
+- `plugins/sdlc-manager/scripts/sdlc_manager.py` contains the existing issue, board, field, label,
+  template, project mapping, and card validator helpers this plan extends.
+- `plugins/sdlc-manager/config/sdlc-schema.json` defines current teams, boards, workflows, fields,
+  gates, and safe target statuses.
+- `plugins/sdlc-manager/config/project-mappings.json` is the current vendored mapping fallback.
+- `plugins/sdlc-manager/tests/test_issue_create_interactive.py`,
+  `plugins/sdlc-manager/tests/test_card_validator.py`,
+  `plugins/sdlc-manager/tests/test_flow_subcommands.py`, and
+  `plugins/sdlc-manager/tests/test_project_mappings_resolution.py` show the local test style and
+  helper seams to extend.
+- `docs/engineering-journal/LEARNINGS.md` records prior prompt/template drift lessons for
+  `sdlc-manager`, including the rule that generated/template-backed contracts need drift guards.

--- a/plugins/sdlc-manager/.claude-plugin/plugin.json
+++ b/plugins/sdlc-manager/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "sdlc-manager",
-  "version": "1.4.0",
-  "description": "SDLC management for Mount Olympus: Kanban boards, issues, labels, flow metrics, milestones, project fields, sub-issues, and card validation.",
+  "version": "1.5.0",
+  "description": "SDLC management for Jeff Intent, Asgard, and Mount Olympus: board schemas, issues, labels, flow metrics, milestones, project fields, sub-issues, and card validation.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "milestones", "sub-issues", "card-validator", "mount-olympus"]
+  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "milestones", "sub-issues", "card-validator", "mount-olympus", "asgard", "jeff-intent"]
 }

--- a/plugins/sdlc-manager/.claude-plugin/plugin.json
+++ b/plugins/sdlc-manager/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "sdlc-manager",
-  "version": "1.5.0",
-  "description": "SDLC management for Jeff Intent, Asgard, and Mount Olympus: board schemas, issues, labels, flow metrics, milestones, project fields, sub-issues, and card validation.",
+  "version": "1.6.0",
+  "description": "SDLC management for Jeff Intent, Asgard, and Mount Olympus: prepared issue drafts, board schemas, labels, project fields, sub-issues, metrics, and card validation.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "milestones", "sub-issues", "card-validator", "mount-olympus", "asgard", "jeff-intent"]
+  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "sub-issues", "mount-olympus", "asgard", "jeff-intent"]
 }

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## [1.6.0] — 2026-05-30
+
+### Added
+- Added `issue prepare` to write team-aware Asgard or Mount Olympus issue drafts under
+  `docs/sdlc-issue-drafts/` with JSON readiness sidecars.
+- Added `issue create-prepared` to re-run readiness, render a full mutation plan, ask for final
+  confirmation, repair missing labels/templates, add issues to the requested project, set safe
+  starting status, and record the created issue back onto the draft.
+- Added Asgard and Olympus readiness profiles. Asgard accepts shaping-quality drafts with mode,
+  constraints, risk, and promotion gaps; Olympus requires the strict actionable card body,
+  expected labels, project presence, author-visible risk, and safe `Backlog` status.
+- Added mocked tests for blocked create, declined confirmation, direct create, missing
+  labels/templates, missing mapping PR stop, and mapping override creation.
+
+### Changed
+- Updated `sdlc-issues`, `/sdlc-create`, `sdlc-operator`, README, and release metadata so
+  natural-language requests like "create an Olympus issue from this text" route through prepared
+  drafts instead of bypassing readiness checks.
+- Bumped plugin and marketplace metadata to `1.6.0`.
+
 ## [1.5.0] — 2026-05-30
 
 ### Migration notes

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [1.5.0] — 2026-05-30
+
+### Migration notes
+- **No breaking CLI changes.** Existing commands continue to work. Operators should update
+  installed cache paths from `sdlc-manager/1.0.0` or `1.4.0` to `sdlc-manager/1.5.0` after
+  installing this release.
+- Current actionable issue templates use `hermes-task`, `needs-plan`, and the type label.
+  `needs-analysis` and `needs-triage` remain documented only as legacy auto-label fallback
+  labels from `labels.json`.
+
 ### Changed
 - Added vendored `config/sdlc-schema.json` and taught board/metric helpers to consume schema-backed boards, workflows, WIP limits, and terminal statuses.
 - Added live Jeff Intent (#3) and Asgard (#2) project mappings plus explicit `--project` targeting for board add/move.
@@ -9,6 +19,10 @@
 - Preserved read compatibility for live/legacy Olympus statuses such as `In Progress`, `In Development`, and `Deployed` while guiding new movement to the current schema.
 - Synced `sdlc-issues` template guidance with canonical issue forms in `infiquetra-sdlc`, including current Hermes actionable labels and required card sections.
 - Added a deterministic template documentation generator plus drift guard tests for `templates-reference.md`.
+- Restored legacy rollout WIP-limit fallback when schema-backed limits are absent.
+- Aligned `sdlc-operator`, `/sdlc-triage`, and issue/label references so prompts no longer teach
+  stale actionable labels or initiative/objective labels as current practice.
+- Bumped plugin and marketplace metadata to `1.5.0`.
 
 ## [1.4.0] — 2026-05-04
 

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -7,7 +7,7 @@ SDLC management for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. 
 All operations run locally via the `gh` CLI, providing:
 
 - **Project board operations** — view, move, add, archive, WIP analysis, standup prep across Jeff Intent, Asgard, and Olympus
-- **Issue creation** — guided workflow with templates, auto-labeling, and project board integration
+- **Issue creation** — guided interactive creation plus prepared Asgard/Olympus issue drafts with readiness checks and confirmed creation
 - **Label management** — deploy, audit, sync initiative/objective fields, auto-label rules
 - **Flow metrics** — cycle time, throughput, WIP age using GitHub timeline events
 - **Rollout tracking** — gap analysis and full SDLC deployment to any Infiquetra repo
@@ -25,7 +25,7 @@ All operations run locally via the `gh` CLI, providing:
 ### Script Location (after plugin install)
 
 ```bash
-SCRIPT="$HOME/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py"
+SCRIPT="$HOME/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py"
 ```
 
 Or from source:
@@ -38,6 +38,29 @@ SCRIPT="$HOME/workspace/infiquetra/infiquetra-claude-plugins/plugins/sdlc-manage
 ```bash
 python3 $SCRIPT config show
 ```
+
+### Prepare an Issue Draft
+
+Use prepared drafts when starting from rough source text, notes, or an agent prompt that must be
+reviewed before GitHub mutation:
+
+```bash
+python3 $SCRIPT issue prepare \
+  --repo hermes-claude-code-router \
+  --type capability \
+  --team olympus \
+  --project mount-olympus \
+  --risk medium \
+  --title "Router prepared issue workflow" \
+  "Add the prepared issue workflow described in the design notes."
+
+python3 $SCRIPT issue create-prepared docs/sdlc-issue-drafts/<draft>.md
+```
+
+Prepared drafts are written under `docs/sdlc-issue-drafts/` with a JSON sidecar. Creation renders a
+mutation plan before side effects, repairs missing labels/templates after confirmation, opens a
+mapping PR when the repo is not mapped to the requested project, and starts issues in safe statuses:
+Asgard `Shaping`, Mount Olympus `Backlog`.
 
 ## Slash Commands
 
@@ -216,6 +239,26 @@ python3 $SCRIPT flow verify-label --repo campps-mvp \
 
 # Pre-flight card body against the card_validator schema
 python3 $SCRIPT flow validate-card --repo campps-mvp --number 42
+```
+
+### Prepared Issue Workflow
+
+```bash
+# Draft from source text without GitHub mutation
+python3 $SCRIPT issue prepare \
+    --repo hermes-claude-code-router \
+    --type capability \
+    --team olympus \
+    --project mount-olympus \
+    --risk medium \
+    --title "Prepared issue workflow" \
+    "Create issue drafts that pass Olympus readiness before mutation."
+
+# Create after reviewing the markdown draft and sidecar
+python3 $SCRIPT issue create-prepared docs/sdlc-issue-drafts/<draft>.md
+
+# Explicit override when a mapping PR was opened but creation must continue
+python3 $SCRIPT issue create-prepared docs/sdlc-issue-drafts/<draft>.md --override-mapping
 ```
 
 ## Configuration

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -25,7 +25,7 @@ All operations run locally via the `gh` CLI, providing:
 ### Script Location (after plugin install)
 
 ```bash
-SCRIPT="$HOME/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py"
+SCRIPT="$HOME/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py"
 ```
 
 Or from source:

--- a/plugins/sdlc-manager/agents/sdlc-operator.md
+++ b/plugins/sdlc-manager/agents/sdlc-operator.md
@@ -160,8 +160,8 @@ interactive flow:
 # 1. Create the issue (use --web or non-interactive form)
 gh issue create --repo infiquetra/<repo> --template <type>.yml --title "..." --body "..."
 
-# 2. Apply hermes-task / hermes-not-actionable label
-gh issue edit <N> --repo infiquetra/<repo> --add-label hermes-task
+# 2. Apply template labels if the issue form did not apply them
+gh issue edit <N> --repo infiquetra/<repo> --add-label "hermes-task,needs-plan,<type-label>"
 
 # 3. Add to the default repo-mapped board, or pass --project for Jeff Intent / Asgard
 python3 "$SCRIPT" board add --repo <repo> --number <N>
@@ -283,7 +283,8 @@ python "$SCRIPT" milestones progress --repo <repo> --milestone <N>
 3. Map each item to the appropriate consumer repo
 4. For each item:
    a. Create the issue with the right template + sub-issue parent
-   b. Apply hermes-task label
+   b. Apply template labels: `hermes-task` + `needs-plan` + type label for actionable cards,
+      or `hermes-not-actionable` + context labels for non-actionable cards
    c. Add to the target board
    d. Set Initiative + Objective + Status fields
    e. Link as sub-issue of the Objective
@@ -295,9 +296,10 @@ flow — the interactive flow is one-at-a-time by design.
 
 ### Triage Batch
 
-"Triage" here means assigning a priority label + ensuring the card is on the Mount Olympus
-board, for issues filed without one. The `needs-triage` label is added when an issue is
-created without a priority. To find them:
+"Triage" here means assigning a priority label when needed, ensuring the card is on the
+right board, and filling project fields. Current actionable issue templates use `needs-plan`.
+The older `needs-triage` label can still appear from legacy auto-label fallback rules; treat it
+as a compatibility queue signal, not a current template default. To find legacy triage items:
 
 ```bash
 gh issue list --label needs-triage --state open --repo infiquetra/<repo>
@@ -305,7 +307,7 @@ gh issue list --label needs-triage --state open --repo infiquetra/<repo>
 gh search issues "label:needs-triage state:open org:infiquetra"
 ```
 
-For each `needs-triage` issue:
+For each issue that needs triage:
 
 ```bash
 # 1. Read issue content
@@ -358,8 +360,9 @@ targeting Jeff Intent or Asgard.
 
 ### How to handle Hermes-actionability?
 - Auto-applied by issue templates: `hermes-task` for actionable types
-  (capability/enhancement/defect/exploration/context-update); `hermes-not-actionable` for
-  objective
+  (capability/enhancement/defect); `hermes-not-actionable` for non-actionable types
+  (objective/exploration/context-update)
+- Current actionable templates also apply `needs-plan` and the type label
 - The orchestrator silently skips cards without `hermes-task`
 
 ### Initiative + Objective: NEVER use labels
@@ -390,7 +393,7 @@ For multi-step operations, report progress clearly:
 
 ```
 Step 1: Created capability issue #142 in athena-service
-Step 2: Applied labels (hermes-task, capability, needs-analysis)
+Step 2: Applied labels (hermes-task, capability, needs-plan)
 Step 3: Added to Mount Olympus board
 Step 4: Set Initiative=olympus-quality on #142 (project field, not label)
 Step 5: Set Objective=Auth Pilot on #142

--- a/plugins/sdlc-manager/agents/sdlc-operator.md
+++ b/plugins/sdlc-manager/agents/sdlc-operator.md
@@ -96,6 +96,8 @@ You are deeply familiar with the Infiquetra SDLC process as documented in the
 **Subcommand groups** (full list: `sdlc_manager.py --help`):
 - `board {view,add,move,archive,wip,standup,discover-fields}` — project board operations
 - `issue create` — sub-issue-first interactive issue creation (Phase C; see "Issue creation flow" below)
+- `issue prepare` / `issue create-prepared` — source-text to reviewed Asgard/Olympus issue draft,
+  then confirmed creation with readiness checks and repo prerequisite repair
 - `flow {set-field,field-options,discover-project,link-sub-issue,verify-label,validate-card}` —
   operator-facing GraphQL/REST helpers (Phase C minimum-viable). **`flow set-field` failure modes**:
   if the field doesn't exist on the project, raises `RuntimeError` with the available field list +
@@ -152,6 +154,32 @@ The flow's per-project schema discovery silently skips prompts for missing field
 see only the prompts the selected board actually exposes. When fields get created via the
 runbook in `infiquetra-sdlc/docs/operations/operational-reference.md`, the additional prompts
 light up automatically.
+
+### Prepared Asgard/Olympus Issue Creation
+
+Use this path when the user says "create an Olympus issue from this text", "create an Asgard issue
+from these notes", or provides rough queue/source text that should become an issue only after
+review.
+
+```bash
+python3 "$SCRIPT" issue prepare \
+    --repo <repo> \
+    --type <capability|enhancement|defect|exploration|context-update|objective> \
+    --team <asgard|olympus> \
+    --project <asgard|mount-olympus> \
+    --risk <low|medium|high> \
+    --mode "Rapid Action" \
+    --title "..." \
+    "source text..."
+
+python3 "$SCRIPT" issue create-prepared docs/sdlc-issue-drafts/<draft>.md
+```
+
+Prepared drafts are durable markdown files with JSON sidecars under `docs/sdlc-issue-drafts/`.
+`issue create-prepared` re-runs readiness, renders every side effect before mutation, repairs
+missing labels/templates after confirmation, opens a mapping PR for unmapped repos, and starts new
+cards in safe statuses: Asgard `Shaping`, Olympus `Backlog`. If team or project is ambiguous,
+ask the operator; do not guess or bypass this path with direct `gh issue create`.
 
 For batch issue creation from a blueprint, prefer the manual lifecycle below over the
 interactive flow:

--- a/plugins/sdlc-manager/commands/sdlc-board.md
+++ b/plugins/sdlc-manager/commands/sdlc-board.md
@@ -38,7 +38,7 @@ and blockers.
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
 
 python3 $SCRIPT board view --project mount-olympus
 python3 $SCRIPT board wip --project mount-olympus

--- a/plugins/sdlc-manager/commands/sdlc-board.md
+++ b/plugins/sdlc-manager/commands/sdlc-board.md
@@ -38,7 +38,7 @@ and blockers.
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py
 
 python3 $SCRIPT board view --project mount-olympus
 python3 $SCRIPT board wip --project mount-olympus

--- a/plugins/sdlc-manager/commands/sdlc-create.md
+++ b/plugins/sdlc-manager/commands/sdlc-create.md
@@ -4,7 +4,8 @@ description: Interactive SDLC issue creation with canonical template guidance, H
 ---
 
 Create a new SDLC issue in any Infiquetra repository with guided template selection, canonical
-field guidance, Hermes label verification, and project board integration.
+field guidance, Hermes label verification, project board integration, and prepared-draft readiness
+checks when starting from source text.
 
 ## Usage
 
@@ -22,11 +23,12 @@ field guidance, Hermes label verification, and project board integration.
 1. Guides issue type selection using the decision tree when type is not specified
 2. Asks for the target repository when repo is not specified
 3. Walks through canonical template fields for the selected type
-4. Creates the issue via `gh issue create`
-5. Verifies canonical Hermes labels
-6. Adds to project board when repo is mapped
-7. Sets project fields with flow helpers when requested
-8. Creates milestone for Objective type when the target workflow uses milestones
+4. For source-text requests, prepares a reviewable draft before mutation
+5. Creates the issue via `gh issue create` or `issue create-prepared`
+6. Verifies canonical Hermes labels
+7. Adds to project board when repo is mapped or explicitly targeted
+8. Sets project fields with flow helpers when requested
+9. Creates milestone for Objective type when the target workflow uses milestones
 
 ## Issue Type Decision Tree
 
@@ -82,20 +84,34 @@ has optional `Capability size (human planning hint)`.
 /sdlc-create defect --repo hermes-gateway
 /sdlc-create objective --repo olympus-blueprint
 /sdlc-create exploration
+/sdlc-create "create an Olympus issue from this text for hermes-claude-code-router"
+/sdlc-create "create an Asgard issue from these notes"
 ```
 
 ## Script Command
 
 ```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py \
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
   issue create --repo athena-service --type capability
 ```
 
 Then add to project:
 
 ```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py \
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
   board add --repo athena-service --number <new-issue-number>
+```
+
+Prepared-draft path:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
+  issue prepare --repo hermes-claude-code-router --type capability \
+  --team olympus --project mount-olympus --risk medium \
+  --title "Prepared issue workflow" "source text..."
+
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
+  issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 ```
 
 ## Instructions
@@ -105,14 +121,18 @@ When the user invokes `/sdlc-create`:
 1. If no type given, walk through the decision tree with the user.
 2. If no repo given, ask which Infiquetra repo this belongs to.
 3. Use the `sdlc-issues` skill to guide issue creation.
-4. For actionable types, confirm the body includes the exact required field headers and Hermes validator semantics.
-5. After creation, verify labels:
+4. If the user asks to create an Asgard or Olympus issue from text, notes, a queue entry, or other
+   rough source, use the prepared-draft path: `issue prepare`, review gaps with the user, then
+   `issue create-prepared` after final confirmation.
+5. For actionable Olympus types, confirm the body includes the exact required field headers and Hermes validator semantics.
+6. If team or project is ambiguous, ask. Do not guess between Asgard and Mount Olympus.
+7. After creation, verify labels:
    - Actionable: type label + `hermes-task` + `needs-plan`
    - Non-actionable: `hermes-not-actionable` plus the template-specific context labels
-6. Add to project board if repo is mapped.
-7. Set project fields with `flow set-field` when requested.
-8. For Objectives, create a GitHub Milestone when the target workflow still uses milestones.
-9. Show a concise summary of everything created or applied.
+8. Add to project board if repo is mapped or the prepared draft supplied an explicit project.
+9. Set project fields with `flow set-field` when requested.
+10. For Objectives, create a GitHub Milestone when the target workflow still uses milestones.
+11. Show a concise summary of everything created or applied.
 
 If user provides partial info, infer the likely type and ask for confirmation. Example: "create a
 defect about the auth timeout" implies `defect`, but still confirm target repo and required fields.

--- a/plugins/sdlc-manager/commands/sdlc-create.md
+++ b/plugins/sdlc-manager/commands/sdlc-create.md
@@ -87,14 +87,14 @@ has optional `Capability size (human planning hint)`.
 ## Script Command
 
 ```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py \
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py \
   issue create --repo athena-service --type capability
 ```
 
 Then add to project:
 
 ```bash
-python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py \
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py \
   board add --repo athena-service --number <new-issue-number>
 ```
 

--- a/plugins/sdlc-manager/commands/sdlc-metrics.md
+++ b/plugins/sdlc-manager/commands/sdlc-metrics.md
@@ -37,7 +37,7 @@ throughput, WIP age, and bottleneck hints.
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
 
 python3 $SCRIPT metrics cycle-time --project mount-olympus --days 30
 python3 $SCRIPT metrics throughput --project asgard --weeks 4

--- a/plugins/sdlc-manager/commands/sdlc-metrics.md
+++ b/plugins/sdlc-manager/commands/sdlc-metrics.md
@@ -37,7 +37,7 @@ throughput, WIP age, and bottleneck hints.
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py
 
 python3 $SCRIPT metrics cycle-time --project mount-olympus --days 30
 python3 $SCRIPT metrics throughput --project asgard --weeks 4

--- a/plugins/sdlc-manager/commands/sdlc-triage.md
+++ b/plugins/sdlc-manager/commands/sdlc-triage.md
@@ -20,7 +20,7 @@ Triage an existing issue by analyzing its content, recommending appropriate labe
 1. Reads the issue content (title, body, existing labels)
 2. Recommends issue type label if missing
 3. Recommends priority label for defects
-4. Recommends initiative/objective labels based on context
+4. Recommends Initiative/Objective project field values based on context
 5. Applies auto-label rules
 6. Adds to project board if not already there
 7. Sets project fields when the target board exposes them
@@ -37,7 +37,7 @@ Triage an existing issue by analyzing its content, recommending appropriate labe
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.0.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
 
 # Auto-label based on content
 python3 $SCRIPT labels auto-label --repo athena-service --number 42
@@ -63,8 +63,8 @@ When the user invokes `/sdlc-triage repo#number`:
    - Does title/body mention an initiative or objective? Suggest project field values
 4. Apply auto-label rules:
    - `python3 $SCRIPT labels auto-label --repo <repo> --number <N>`
-5. Manually apply recommended labels:
-   - `gh issue edit <N> --repo infiquetra/<repo> --add-label "capability,needs-analysis"`
+5. Manually apply recommended labels when the template did not apply them:
+   - `gh issue edit <N> --repo infiquetra/<repo> --add-label "capability,hermes-task,needs-plan"`
 6. Add to project board:
    - `python3 $SCRIPT board add --repo <repo> --number <N>`
 7. Set initiative/objective fields when applicable:
@@ -73,7 +73,8 @@ When the user invokes `/sdlc-triage repo#number`:
 8. Recommend status:
    - Defect (critical/high): Move directly to Assigned on Olympus, or Active on Asgard
    - Has complete context: Ready
-   - Needs more context: Add `needs-analysis` label, leave in Backlog or Shaping
+   - Needs more context: keep `needs-plan` on actionable cards, optionally add `needs-context`,
+     and leave in Backlog or Shaping
 9. Show summary of all actions taken
 
 If the issue is a defect with `critical` label, flag urgency: "This is a critical defect with a 4-hour SLA. Moving to active ownership now."

--- a/plugins/sdlc-manager/commands/sdlc-triage.md
+++ b/plugins/sdlc-manager/commands/sdlc-triage.md
@@ -37,7 +37,7 @@ Triage an existing issue by analyzing its content, recommending appropriate labe
 ## Script Commands
 
 ```bash
-SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.5.0/scripts/sdlc_manager.py
+SCRIPT=~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py
 
 # Auto-label based on content
 python3 $SCRIPT labels auto-label --repo athena-service --number 42

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -2801,7 +2801,7 @@ def _source_to_issue_body(source: str, team: str, repo: str, mode: str | None) -
 {repo}
 
 ### Mode
-{mode or 'TBD'}
+{mode or "TBD"}
 
 ### Constraints
 TBD
@@ -2964,7 +2964,9 @@ def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
     )
 
 
-def _sidecar_payload(issue: PreparedIssue, readiness: PreparedReadiness, state: str) -> dict[str, Any]:
+def _sidecar_payload(
+    issue: PreparedIssue, readiness: PreparedReadiness, state: str
+) -> dict[str, Any]:
     return {
         "schema_version": "1.0",
         "state": state,
@@ -3004,7 +3006,9 @@ def issue_prepare(
     if issue_type not in _ISSUE_TYPES:
         raise RuntimeError(f"Unknown issue type {issue_type!r}")
     if project not in PROJECT_CHOICES:
-        raise RuntimeError(f"Unknown project {project!r}; expected one of {', '.join(PROJECT_CHOICES)}")
+        raise RuntimeError(
+            f"Unknown project {project!r}; expected one of {', '.join(PROJECT_CHOICES)}"
+        )
 
     safe_status = status or _TEAM_SAFE_STATUSES[team]
     draft_title = title or f"{issue_type}: {repo} {team} work"
@@ -3037,7 +3041,14 @@ def issue_prepare(
     )
 
     if fmt == "json":
-        _out({"draft": str(draft_path), "sidecar": str(sidecar_path), "readiness": asdict(readiness)}, fmt)
+        _out(
+            {
+                "draft": str(draft_path),
+                "sidecar": str(sidecar_path),
+                "readiness": asdict(readiness),
+            },
+            fmt,
+        )
     else:
         print(f"Prepared draft: {draft_path}")
         print(f"Readiness: {'passed' if readiness.passed else 'blocked'}")
@@ -3143,7 +3154,9 @@ def _open_mapping_pr(repo: str, project_name: str) -> str:
             )
         finally:
             try:
-                _run_git_command(["git", "worktree", "remove", "--force", str(temp_worktree)], cwd=worktree_root)
+                _run_git_command(
+                    ["git", "worktree", "remove", "--force", str(temp_worktree)], cwd=worktree_root
+                )
             except RuntimeError as e:
                 _warn(f"Could not remove temporary mapping worktree {temp_worktree}: {e}")
 
@@ -3178,12 +3191,7 @@ def _append_created_issue_to_draft(draft_path: Path, url: str, number: int) -> N
     marker = "\n\n## Created Issue\n"
     if marker in text:
         text = text.split(marker, 1)[0].rstrip()
-    text += (
-        f"{marker}\n"
-        f"- URL: {url}\n"
-        f"- Number: {number}\n"
-        f"- Created at: {created_at}\n"
-    )
+    text += f"{marker}\n- URL: {url}\n- Number: {number}\n- Created at: {created_at}\n"
     draft_path.write_text(text + "\n", encoding="utf-8")
 
 
@@ -3204,10 +3212,14 @@ def _build_mutation_plan(issue: PreparedIssue, config: dict[str, Any]) -> Mutati
     mapping_missing = not _project_mapping_contains_repo(config, issue.repo, issue.project)
 
     if missing_labels:
-        steps.append(MutationStep("deploy-labels", f"Deploy missing labels: {', '.join(missing_labels)}"))
+        steps.append(
+            MutationStep("deploy-labels", f"Deploy missing labels: {', '.join(missing_labels)}")
+        )
     if missing_templates:
         steps.append(
-            MutationStep("deploy-templates", f"Deploy missing templates: {', '.join(missing_templates)}")
+            MutationStep(
+                "deploy-templates", f"Deploy missing templates: {', '.join(missing_templates)}"
+            )
         )
     if mapping_missing:
         steps.append(

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -17,6 +17,8 @@ Usage:
     sdlc_manager.py board discover-fields --project mount-olympus
 
     sdlc_manager.py issue create --repo athena-service --type capability
+    sdlc_manager.py issue prepare --repo athena-service --type capability --team olympus --project mount-olympus "source text"
+    sdlc_manager.py issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 
     sdlc_manager.py labels sync-fields --repo athena-service --number 42
     sdlc_manager.py labels audit --repo athena-service
@@ -61,6 +63,8 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -2646,13 +2650,24 @@ _ISSUE_TYPES = (
     "context-update",
     "objective",
 )
+_TEAM_CHOICES = ("asgard", "olympus")
+_TEAM_SAFE_STATUSES = {"asgard": "Shaping", "olympus": "Backlog"}
+_DISPATCH_ACTIONABLE_TYPES = frozenset({"capability", "enhancement", "defect"})
+_ISSUE_TYPE_LABELS = {
+    "capability": ["capability", "hermes-task", "needs-plan"],
+    "enhancement": ["enhancement", "hermes-task", "needs-plan"],
+    "defect": ["defect", "hermes-task", "needs-plan"],
+    "objective": ["objective", "hermes-not-actionable"],
+    "exploration": ["exploration", "research", "hermes-not-actionable"],
+    "context-update": ["context-update", "documentation", "hermes-not-actionable"],
+}
+_PREPARED_DRAFT_DIR = Path("docs") / "sdlc-issue-drafts"
+
 _HERMES_ACTIONABLE_TYPES = frozenset(
     {
         "capability",
         "enhancement",
         "defect",
-        "exploration",
-        "context-update",
     }
 )
 # Issue types where the capability-adaptive fields are relevant (size,
@@ -2671,6 +2686,653 @@ _HERMES_ACTIONABLE_TYPES = frozenset(
 # `infiquetra-sdlc/docs/operations/operational-reference.md`, the
 # additional prompts light up automatically.
 _CAPABILITY_ADAPTIVE_TYPES = frozenset({"capability", "objective"})
+
+
+@dataclass
+class PreparedReadiness:
+    profile: str
+    passed: bool
+    blocking_gaps: list[str]
+    warnings: list[str]
+
+
+@dataclass
+class PreparedIssue:
+    title: str
+    repo: str
+    issue_type: str
+    team: str
+    project: str
+    status: str
+    labels: list[str]
+    risk: str | None
+    mode: str | None
+    body: str
+    draft_path: str | None = None
+    sidecar_path: str | None = None
+
+
+@dataclass
+class MutationStep:
+    action: str
+    detail: str
+
+
+@dataclass
+class MutationPlan:
+    draft_path: str
+    repo: str
+    issue_type: str
+    team: str
+    project: str
+    status: str
+    steps: list[MutationStep]
+    mapping_missing: bool = False
+
+
+def _issue_expected_labels(issue_type: str) -> list[str]:
+    return list(_ISSUE_TYPE_LABELS.get(issue_type, [issue_type]))
+
+
+def _normalize_label_list(raw: Any) -> list[str]:
+    if isinstance(raw, list):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    if isinstance(raw, str):
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    return []
+
+
+def _parse_draft_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    metadata: dict[str, str] = {}
+    for line in text[4:end].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    return metadata, text[end + 5 :].lstrip()
+
+
+def _strip_draft_h1(body: str) -> tuple[str | None, str]:
+    lines = body.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            title = line[2:].strip()
+            remaining = "\n".join(lines[index + 1 :]).lstrip()
+            return title, remaining
+        if line.strip():
+            break
+    return None, body
+
+
+def _render_draft_markdown(issue: PreparedIssue) -> str:
+    labels = ", ".join(issue.labels)
+    frontmatter = [
+        "---",
+        f"title: {issue.title}",
+        f"repo: {issue.repo}",
+        f"type: {issue.issue_type}",
+        f"team: {issue.team}",
+        f"project: {issue.project}",
+        f"status: {issue.status}",
+        f"labels: {labels}",
+    ]
+    if issue.risk:
+        frontmatter.append(f"risk: {issue.risk}")
+    if issue.mode:
+        frontmatter.append(f"mode: {issue.mode}")
+    frontmatter.append("---")
+    return "\n".join(frontmatter) + f"\n\n# {issue.title}\n\n{issue.body.rstrip()}\n"
+
+
+def _source_to_issue_body(source: str, team: str, repo: str, mode: str | None) -> str:
+    stripped = source.strip()
+    if "### " in stripped:
+        return stripped
+    if team == "asgard":
+        return f"""### Intent
+{stripped}
+
+### Target repo / surface
+{repo}
+
+### Mode
+{mode or 'TBD'}
+
+### Constraints
+TBD
+
+### Risk
+TBD
+
+### Promotion gaps
+- [ ] Identify any Olympus promotion gaps
+"""
+    return f"""### Objective
+{stripped}
+
+### Acceptance criteria
+- [ ] TBD
+
+### Out-of-scope / non-goals
+TBD
+
+### Files expected to change
+TBD
+
+### Tests to add or update
+TBD
+
+### Verification
+TBD
+"""
+
+
+def _safe_slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:48].strip("-") or "issue"
+
+
+def _unique_draft_path(draft_dir: Path, title: str) -> Path:
+    date_prefix = datetime.now(UTC).strftime("%Y-%m-%d")
+    base = f"{date_prefix}-{_safe_slug(title)}"
+    candidate = draft_dir / f"{base}.md"
+    index = 2
+    while candidate.exists() or candidate.with_suffix(".json").exists():
+        candidate = draft_dir / f"{base}-{index}.md"
+        index += 1
+    return candidate
+
+
+def _read_prepared_issue(draft_path: Path) -> PreparedIssue:
+    text = draft_path.read_text(encoding="utf-8")
+    metadata, body_with_title = _parse_draft_frontmatter(text)
+    h1_title, body = _strip_draft_h1(body_with_title)
+    sidecar_path = draft_path.with_suffix(".json")
+    if not sidecar_path.exists():
+        raise RuntimeError(f"Missing prepared issue sidecar: {sidecar_path}")
+    try:
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Malformed prepared issue sidecar {sidecar_path}: {e}") from e
+    if not isinstance(sidecar, dict):
+        raise RuntimeError(f"Prepared issue sidecar {sidecar_path} is not a JSON object")
+
+    def field(name: str, sidecar_name: str | None = None) -> str:
+        value = metadata.get(name) or sidecar.get(sidecar_name or name)
+        return str(value).strip() if value is not None else ""
+
+    issue = PreparedIssue(
+        title=field("title") or h1_title or draft_path.stem,
+        repo=field("repo"),
+        issue_type=field("type", "issue_type"),
+        team=field("team"),
+        project=field("project"),
+        status=field("status"),
+        labels=_normalize_label_list(metadata.get("labels") or sidecar.get("labels")),
+        risk=field("risk") or None,
+        mode=field("mode") or None,
+        body=body.strip(),
+        draft_path=str(draft_path),
+        sidecar_path=str(sidecar_path),
+    )
+
+    for key, value in {
+        "repo": issue.repo,
+        "type": issue.issue_type,
+        "team": issue.team,
+        "project": issue.project,
+    }.items():
+        sidecar_key = "issue_type" if key == "type" else key
+        if metadata.get(key) and sidecar.get(sidecar_key) and metadata[key] != sidecar[sidecar_key]:
+            raise RuntimeError(
+                f"Draft metadata {key}={metadata[key]!r} conflicts with sidecar "
+                f"{sidecar_key}={sidecar[sidecar_key]!r}"
+            )
+        if not value:
+            raise RuntimeError(f"Prepared issue draft is missing required metadata: {key}")
+    if issue.issue_type not in _ISSUE_TYPES:
+        raise RuntimeError(f"Unknown issue type in prepared draft: {issue.issue_type}")
+    if issue.team not in _TEAM_CHOICES:
+        raise RuntimeError(f"Unknown team in prepared draft: {issue.team}")
+    return issue
+
+
+def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
+    blocking: list[str] = []
+    warnings: list[str] = []
+
+    expected_status = _TEAM_SAFE_STATUSES.get(issue.team)
+    if issue.status == "Ready":
+        blocking.append("Prepared issues must not start in Ready")
+    elif expected_status and issue.status != expected_status:
+        blocking.append(
+            f"Prepared {issue.team} issues must start in {expected_status!r}, not {issue.status!r}"
+        )
+
+    if issue.project not in PROJECT_CHOICES:
+        blocking.append(f"Unknown project {issue.project!r}")
+
+    expected_labels = set(_issue_expected_labels(issue.issue_type))
+    missing_labels = sorted(expected_labels - set(issue.labels))
+    if missing_labels:
+        blocking.append(f"Missing expected labels: {missing_labels}")
+
+    sections = _split_sections(issue.body)
+    if issue.team == "olympus":
+        if issue.issue_type not in _DISPATCH_ACTIONABLE_TYPES:
+            blocking.append(
+                f"Issue type {issue.issue_type!r} is not an Olympus dispatch-ready task type"
+            )
+        valid_body, body_errors = validate_card_body(issue.body)
+        if not valid_body:
+            blocking.extend(body_errors)
+        if not issue.project:
+            blocking.append("Missing target project")
+        if not issue.risk:
+            blocking.append("Missing author-visible risk metadata")
+    elif issue.team == "asgard":
+        required = {
+            "Intent": "intent",
+            "Target repo / surface": "target repo/surface",
+            "Mode": "mode",
+            "Constraints": "constraints",
+            "Risk": "risk",
+            "Promotion gaps": "promotion gaps",
+        }
+        for header, label in required.items():
+            text = sections.get(header, "").strip()
+            if not text or text.upper() == "TBD":
+                blocking.append(f"Missing Asgard {label}")
+        if not issue.mode:
+            blocking.append("Missing Asgard mode metadata")
+        if not issue.risk:
+            blocking.append("Missing Asgard risk metadata")
+        olympus_valid, olympus_errors = validate_card_body(issue.body)
+        if not olympus_valid:
+            warnings.append("Olympus promotion gaps: " + "; ".join(olympus_errors))
+
+    return PreparedReadiness(
+        profile=issue.team,
+        passed=not blocking,
+        blocking_gaps=blocking,
+        warnings=warnings,
+    )
+
+
+def _sidecar_payload(issue: PreparedIssue, readiness: PreparedReadiness, state: str) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "state": state,
+        "title": issue.title,
+        "repo": issue.repo,
+        "issue_type": issue.issue_type,
+        "team": issue.team,
+        "project": issue.project,
+        "status": issue.status,
+        "labels": issue.labels,
+        "risk": issue.risk,
+        "mode": issue.mode,
+        "draft_path": issue.draft_path,
+        "sidecar_path": issue.sidecar_path,
+        "readiness": asdict(readiness),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def issue_prepare(
+    repo: str,
+    issue_type: str,
+    team: str,
+    project: str,
+    source: str,
+    title: str | None,
+    status: str | None,
+    risk: str | None,
+    mode: str | None,
+    draft_dir: Path | None = None,
+    fmt: str = "text",
+) -> Path:
+    if not source.strip():
+        raise RuntimeError("issue prepare requires non-empty source text")
+    if team not in _TEAM_CHOICES:
+        raise RuntimeError(f"Unknown team {team!r}; expected one of {', '.join(_TEAM_CHOICES)}")
+    if issue_type not in _ISSUE_TYPES:
+        raise RuntimeError(f"Unknown issue type {issue_type!r}")
+    if project not in PROJECT_CHOICES:
+        raise RuntimeError(f"Unknown project {project!r}; expected one of {', '.join(PROJECT_CHOICES)}")
+
+    safe_status = status or _TEAM_SAFE_STATUSES[team]
+    draft_title = title or f"{issue_type}: {repo} {team} work"
+    issue = PreparedIssue(
+        title=draft_title,
+        repo=repo,
+        issue_type=issue_type,
+        team=team,
+        project=project,
+        status=safe_status,
+        labels=_issue_expected_labels(issue_type),
+        risk=risk,
+        mode=mode,
+        body=_source_to_issue_body(source, team, repo, mode),
+    )
+    readiness = _readiness_for_prepared_issue(issue)
+
+    target_dir = draft_dir or _PREPARED_DRAFT_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    draft_path = _unique_draft_path(target_dir, draft_title)
+    sidecar_path = draft_path.with_suffix(".json")
+    issue.draft_path = str(draft_path)
+    issue.sidecar_path = str(sidecar_path)
+
+    draft_path.write_text(_render_draft_markdown(issue), encoding="utf-8")
+    state = "ready_to_create" if readiness.passed else "blocked"
+    sidecar_path.write_text(
+        json.dumps(_sidecar_payload(issue, readiness, state), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    if fmt == "json":
+        _out({"draft": str(draft_path), "sidecar": str(sidecar_path), "readiness": asdict(readiness)}, fmt)
+    else:
+        print(f"Prepared draft: {draft_path}")
+        print(f"Readiness: {'passed' if readiness.passed else 'blocked'}")
+        for gap in readiness.blocking_gaps:
+            print(f"  - BLOCKING: {gap}")
+        for warning in readiness.warnings:
+            print(f"  - WARNING: {warning}")
+    return draft_path
+
+
+def _known_template_names() -> list[str]:
+    return [f"{issue_type}.yml" for issue_type in _ISSUE_TYPES]
+
+
+def _repo_missing_labels(repo: str, required_labels: list[str]) -> list[str]:
+    existing_raw = _rest_get(f"/repos/{ORG}/{repo}/labels?per_page=100")
+    existing = {label.get("name") for label in existing_raw if isinstance(label, dict)}
+    return [label for label in required_labels if label not in existing]
+
+
+def _repo_missing_templates(repo: str) -> list[str]:
+    template_names = _known_template_names()
+    try:
+        existing_raw = _rest_get(f"/repos/{ORG}/{repo}/contents/.github/ISSUE_TEMPLATE")
+    except ApiNotFoundError:
+        return template_names
+    existing = {template.get("name") for template in existing_raw if isinstance(template, dict)}
+    return [template for template in template_names if template not in existing]
+
+
+def _project_mapping_contains_repo(config: dict[str, Any], repo: str, project_name: str) -> bool:
+    projects = config.get("project_mappings", {}).get("projects", {})
+    project = projects.get(project_name, {})
+    return repo in project.get("repositories", [])
+
+
+def _mapping_update_target() -> tuple[Path, Path, str, str | None]:
+    sdlc_path = get_sdlc_path()
+    external = sdlc_path / "config" / "project-mappings.json"
+    if external.exists():
+        return external, sdlc_path, "infiquetra-sdlc", None
+    warning = (
+        "No external infiquetra-sdlc project-mappings.json found; updating vendored "
+        "sdlc-manager mapping instead."
+    )
+    repo_root = Path(__file__).resolve().parents[3]
+    return _VENDORED_PROJECT_MAPPINGS_PATH, repo_root, "infiquetra-claude-plugins", warning
+
+
+def _write_mapping_update(mapping_path: Path, repo: str, project_name: str) -> None:
+    data = json.loads(mapping_path.read_text(encoding="utf-8"))
+    projects = data.setdefault("projects", {})
+    if project_name not in projects:
+        raise RuntimeError(f"Project {project_name!r} not found in {mapping_path}")
+    repositories = projects[project_name].setdefault("repositories", [])
+    if repo not in repositories:
+        repositories.append(repo)
+        projects[project_name]["repositories"] = sorted(repositories)
+    mapping_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _run_git_command(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed")
+    return result.stdout.strip()
+
+
+def _open_mapping_pr(repo: str, project_name: str) -> str:
+    mapping_path, worktree_root, gh_repo, warning = _mapping_update_target()
+    if warning:
+        _warn(warning)
+    branch = (
+        f"sdlc-map-{_safe_slug(repo)}-{_safe_slug(project_name)}-"
+        f"{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}"
+    )
+    rel_mapping_path = mapping_path.relative_to(worktree_root)
+    with tempfile.TemporaryDirectory(prefix="sdlc-mapping-") as tmp_parent:
+        temp_worktree = Path(tmp_parent) / "repo"
+        _run_git_command(
+            ["git", "worktree", "add", "-b", branch, str(temp_worktree), "HEAD"],
+            cwd=worktree_root,
+        )
+        try:
+            _write_mapping_update(temp_worktree / rel_mapping_path, repo, project_name)
+            _run_git_command(["git", "add", str(rel_mapping_path)], cwd=temp_worktree)
+            _run_git_command(
+                ["git", "commit", "-m", f"chore(sdlc): map {repo} to {project_name}"],
+                cwd=temp_worktree,
+            )
+            _run_git_command(["git", "push", "-u", "origin", branch], cwd=temp_worktree)
+            return _gh(
+                [
+                    "pr",
+                    "create",
+                    "--repo",
+                    f"{ORG}/{gh_repo}",
+                    "--title",
+                    f"chore(sdlc): map {repo} to {project_name}",
+                    "--body",
+                    f"Adds `{repo}` to the `{project_name}` project mapping for sdlc-manager routing.",
+                ]
+            )
+        finally:
+            try:
+                _run_git_command(["git", "worktree", "remove", "--force", str(temp_worktree)], cwd=worktree_root)
+            except RuntimeError as e:
+                _warn(f"Could not remove temporary mapping worktree {temp_worktree}: {e}")
+
+
+def _issue_body_for_github(issue: PreparedIssue) -> str:
+    return issue.body.strip() + "\n"
+
+
+def _create_github_issue(issue: PreparedIssue) -> tuple[str, int]:
+    args = [
+        "issue",
+        "create",
+        "--repo",
+        f"{ORG}/{issue.repo}",
+        "--title",
+        issue.title,
+        "--body",
+        _issue_body_for_github(issue),
+    ]
+    if issue.labels:
+        args.extend(["--label", ",".join(issue.labels)])
+    url = _gh(args).strip()
+    match = re.search(r"/issues/(\d+)\b", url)
+    if not match:
+        raise RuntimeError(f"Could not parse created issue number from gh output: {url!r}")
+    return url, int(match.group(1))
+
+
+def _append_created_issue_to_draft(draft_path: Path, url: str, number: int) -> None:
+    text = draft_path.read_text(encoding="utf-8").rstrip()
+    created_at = datetime.now(UTC).isoformat()
+    marker = "\n\n## Created Issue\n"
+    if marker in text:
+        text = text.split(marker, 1)[0].rstrip()
+    text += (
+        f"{marker}\n"
+        f"- URL: {url}\n"
+        f"- Number: {number}\n"
+        f"- Created at: {created_at}\n"
+    )
+    draft_path.write_text(text + "\n", encoding="utf-8")
+
+
+def _update_sidecar_state(draft_path: Path, updates: dict[str, Any]) -> None:
+    sidecar_path = draft_path.with_suffix(".json")
+    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    payload.update(updates)
+    payload["updated_at"] = datetime.now(UTC).isoformat()
+    sidecar_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _build_mutation_plan(issue: PreparedIssue, config: dict[str, Any]) -> MutationPlan:
+    if not issue.draft_path:
+        raise RuntimeError("Prepared issue is missing draft_path")
+    steps: list[MutationStep] = []
+    missing_labels = _repo_missing_labels(issue.repo, issue.labels)
+    missing_templates = _repo_missing_templates(issue.repo)
+    mapping_missing = not _project_mapping_contains_repo(config, issue.repo, issue.project)
+
+    if missing_labels:
+        steps.append(MutationStep("deploy-labels", f"Deploy missing labels: {', '.join(missing_labels)}"))
+    if missing_templates:
+        steps.append(
+            MutationStep("deploy-templates", f"Deploy missing templates: {', '.join(missing_templates)}")
+        )
+    if mapping_missing:
+        steps.append(
+            MutationStep(
+                "mapping-pr",
+                f"Open mapping PR for {issue.repo} -> {issue.project}",
+            )
+        )
+    steps.extend(
+        [
+            MutationStep("create-issue", f"Create {issue.issue_type} in {ORG}/{issue.repo}"),
+            MutationStep("board-add", f"Add issue to {issue.project}"),
+            MutationStep("set-status", f"Set Status to {issue.status}"),
+            MutationStep("mark-draft", "Record created issue on draft and sidecar"),
+        ]
+    )
+    return MutationPlan(
+        draft_path=issue.draft_path,
+        repo=issue.repo,
+        issue_type=issue.issue_type,
+        team=issue.team,
+        project=issue.project,
+        status=issue.status,
+        steps=steps,
+        mapping_missing=mapping_missing,
+    )
+
+
+def _print_mutation_plan(plan: MutationPlan) -> None:
+    print("\nMutation plan:")
+    for step in plan.steps:
+        print(f"  - {step.action}: {step.detail}")
+
+
+def issue_create_prepared(
+    draft_path: Path,
+    fmt: str,
+    auto_confirm: bool = False,
+    override_mapping: bool = False,
+) -> dict[str, Any]:
+    issue = _read_prepared_issue(draft_path)
+    readiness = _readiness_for_prepared_issue(issue)
+    if not readiness.passed:
+        if fmt == "json":
+            _out({"created": False, "readiness": asdict(readiness)}, fmt)
+        else:
+            print("Prepared issue is blocked:")
+            for gap in readiness.blocking_gaps:
+                print(f"  - {gap}")
+        raise RuntimeError("Prepared issue has blocking readiness gaps")
+
+    config = load_config()
+    plan = _build_mutation_plan(issue, config)
+    plan_payload = asdict(plan)
+    if fmt != "json":
+        _print_mutation_plan(plan)
+
+    if not auto_confirm:
+        confirm = _safe_input("Apply this mutation plan? (y/N): ")
+        if confirm is None or confirm.lower() not in ("y", "yes"):
+            result = {"created": False, "reason": "declined"}
+            if fmt == "json":
+                _out({**result, "mutation_plan": plan_payload}, fmt)
+            else:
+                print("No mutations applied.")
+            return result
+
+    labels_missing = any(step.action == "deploy-labels" for step in plan.steps)
+    templates_missing = any(step.action == "deploy-templates" for step in plan.steps)
+    if labels_missing:
+        labels_deploy(issue.repo, fmt="text")
+    if templates_missing:
+        rollout_deploy_templates(issue.repo, fmt="text")
+
+    mapping_pr_url: str | None = None
+    if plan.mapping_missing:
+        mapping_pr_url = _open_mapping_pr(issue.repo, issue.project)
+        if not override_mapping:
+            _update_sidecar_state(
+                draft_path,
+                {
+                    "state": "mapping_pending",
+                    "mapping_pr_url": mapping_pr_url,
+                    "pending_mapping": {"repo": issue.repo, "project": issue.project},
+                },
+            )
+            if fmt != "json":
+                print(f"Mapping PR opened; issue creation stopped: {mapping_pr_url}")
+            result = {"created": False, "mapping_pr_url": mapping_pr_url}
+            if fmt == "json":
+                _out({**result, "mutation_plan": plan_payload}, fmt)
+            return result
+
+    url, number = _create_github_issue(issue)
+    board_add(issue.repo, number, fmt="text", config=config, project_name=issue.project)
+    flow_set_field(issue.project, issue.repo, number, "Status", issue.status, fmt="text")
+    _append_created_issue_to_draft(draft_path, url, number)
+    _update_sidecar_state(
+        draft_path,
+        {
+            "state": "created",
+            "created_issue_url": url,
+            "created_issue_number": number,
+            "created_at": datetime.now(UTC).isoformat(),
+            "mutation_summary": [asdict(step) for step in plan.steps],
+            "mapping_pr_url": mapping_pr_url,
+            "pending_mapping": bool(mapping_pr_url and override_mapping),
+        },
+    )
+    result = {"created": True, "url": url, "number": number, "mapping_pr_url": mapping_pr_url}
+    if fmt == "json":
+        _out({**result, "mutation_plan": plan_payload}, fmt)
+    else:
+        print(f"Created issue: {url}")
+    return result
+
+
+def _read_prepare_source(source_parts: list[str], source_file: str | None) -> str:
+    if source_file:
+        return Path(source_file).read_text(encoding="utf-8")
+    if source_parts:
+        return " ".join(source_parts)
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise RuntimeError("Provide source text as an argument, stdin, or --source-file")
 
 
 def _safe_input(prompt: str) -> str | None:
@@ -2884,7 +3546,7 @@ def _apply_post_create_metadata(
     cached_config = load_config()
 
     # 1. Hermes-actionability label (only types we want the orchestrator
-    # to act on — capability/enhancement/defect/exploration/context-update)
+    # to act on — capability/enhancement/defect)
     if issue_type in _HERMES_ACTIONABLE_TYPES:
         try:
             _gh(
@@ -3273,6 +3935,47 @@ def main() -> None:
         help="Skip post-create metadata (labels, project fields, sub-issue link, "
         "paired-card prompt). Useful for testing or scripted setup.",
     )
+    issue_prepare_p = issue_sp.add_parser(
+        "prepare",
+        help="Prepare a team-aware issue draft and readiness sidecar without GitHub mutation",
+    )
+    issue_prepare_p.add_argument("--repo", required=True)
+    issue_prepare_p.add_argument(
+        "--type",
+        required=True,
+        choices=[
+            "capability",
+            "enhancement",
+            "defect",
+            "exploration",
+            "context-update",
+            "objective",
+        ],
+    )
+    issue_prepare_p.add_argument("--team", required=True, choices=_TEAM_CHOICES)
+    issue_prepare_p.add_argument("--project", required=True, choices=PROJECT_CHOICES)
+    issue_prepare_p.add_argument("--title", default=None)
+    issue_prepare_p.add_argument("--status", default=None)
+    issue_prepare_p.add_argument("--risk", default=None)
+    issue_prepare_p.add_argument("--mode", default=None)
+    issue_prepare_p.add_argument("--source-file", default=None)
+    issue_prepare_p.add_argument("source", nargs="*")
+
+    issue_create_prepared_p = issue_sp.add_parser(
+        "create-prepared",
+        help="Create a prepared issue draft after readiness checks and final confirmation",
+    )
+    issue_create_prepared_p.add_argument("draft")
+    issue_create_prepared_p.add_argument(
+        "--yes",
+        action="store_true",
+        help="Apply the rendered mutation plan without an interactive prompt",
+    )
+    issue_create_prepared_p.add_argument(
+        "--override-mapping",
+        action="store_true",
+        help="Create the issue before a missing project-mapping PR merges",
+    )
 
     # ===========================
     # LABELS
@@ -3505,6 +4208,26 @@ def main() -> None:
                     fmt,
                     parent_ref=args.parent_ref,
                     skip_metadata=args.skip_metadata,
+                )
+            elif args.action == "prepare":
+                issue_prepare(
+                    repo=args.repo,
+                    issue_type=args.type,
+                    team=args.team,
+                    project=args.project,
+                    source=_read_prepare_source(args.source, args.source_file),
+                    title=args.title,
+                    status=args.status,
+                    risk=args.risk,
+                    mode=args.mode,
+                    fmt=fmt,
+                )
+            elif args.action == "create-prepared":
+                issue_create_prepared(
+                    Path(args.draft),
+                    fmt=fmt,
+                    auto_confirm=args.yes,
+                    override_mapping=args.override_mapping,
                 )
 
         elif args.resource == "labels":

--- a/plugins/sdlc-manager/skills/sdlc-issues/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-issues/SKILL.md
@@ -30,6 +30,11 @@ when_to_use: |
   Batch creation:
   - "create issues for all the capabilities in this objective"
   - "set up the issues for the platform launch objective"
+
+  Prepared issue creation:
+  - "create an Olympus issue from this text"
+  - "create an Asgard issue from these notes"
+  - "turn this queue entry into an issue for the router repo"
 ---
 
 # SDLC Issues
@@ -93,6 +98,45 @@ these as Hermes task cards or dispatch them directly to agents. Use them for coo
 research, or documentation context.
 
 ## Core Operations
+
+### Prepared Issue Draft from Source Text
+
+Use the prepared workflow when the user starts from rough text, notes, copied queue entries, or
+asks for an Asgard/Olympus issue that should be reviewed before mutation.
+
+```bash
+python3 sdlc_manager.py issue prepare \
+  --repo hermes-claude-code-router \
+  --type capability \
+  --team olympus \
+  --project mount-olympus \
+  --risk medium \
+  --title "Prepared issue workflow" \
+  "source text..."
+
+python3 sdlc_manager.py issue create-prepared docs/sdlc-issue-drafts/<draft>.md
+```
+
+The prepared workflow writes a markdown draft and JSON sidecar under
+`docs/sdlc-issue-drafts/`. `issue create-prepared` re-runs readiness checks, renders the mutation
+plan, asks for confirmation, repairs missing labels/templates after confirmation, opens a mapping
+PR when needed, and only then creates the issue.
+
+Natural-language routing rules:
+
+- "Create an Olympus issue from this text" -> prepare with `--team olympus --project mount-olympus`,
+  then create-prepared after review.
+- "Create an Asgard issue from this text" -> prepare with `--team asgard --project asgard`, then
+  create-prepared after review.
+- If team or project is ambiguous, ask. Do not guess.
+- Do not bypass prepared readiness checks with ad hoc `gh issue create` when the prompt asks to
+  create from source text.
+
+Safe starting statuses:
+
+- Asgard starts in `Shaping`.
+- Mount Olympus starts in `Backlog`.
+- Never auto-move a prepared issue to `Ready`.
 
 ### Create Issue with Template
 
@@ -249,6 +293,14 @@ still uses milestones for that repository.
 
 **"Create an exploration to research biometric SDK options"**
 -> `issue create --repo infiquetra-blueprint --type exploration`
+
+**"Create an Olympus issue from this text for the router repo"**
+-> Prepare an Olympus draft with `issue prepare --team olympus --project mount-olympus`, review
+readiness gaps, then use `issue create-prepared`.
+
+**"Create an Asgard issue from these notes"**
+-> Ask for the target repo if missing, prepare an Asgard draft with
+`issue prepare --team asgard --project asgard`, review gaps, then use `issue create-prepared`.
 
 **"Is this a capability or enhancement?"**
 -> Walk through decision tree: Is it new end-to-end deployable functionality? If yes -> capability.

--- a/plugins/sdlc-manager/skills/sdlc-issues/references/issue-types.md
+++ b/plugins/sdlc-manager/skills/sdlc-issues/references/issue-types.md
@@ -81,10 +81,12 @@ If > 10 Capabilities: consider breaking into multiple Objectives or extending th
 | **Release** | Versioned delivery requiring coordination | "Release: Olympus v1.0" |
 | **Program** | OKR milestone or initiative phase | "Program: Q1 KR1 - User Adoption" |
 
-### Required Labels
-- `objective` (auto-applied by template)
-- `objective:{short-name}` (applied after creation, e.g., `objective:platform-launch`)
-- `initiative:{name}` (if part of a strategic initiative)
+### Template Labels and Project Fields
+- Current template labels: `objective`, `hermes-not-actionable`
+- Use the board's `Initiative` and `Objective` project fields for strategic grouping.
+- Do not apply `initiative:*` or `objective:*` labels to new work; those are legacy convention
+  labels only.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Examples
 **Good**:
@@ -126,8 +128,11 @@ or technical value. The primary unit of work in AI-native development.
 | M | 1-2 weeks | Notification system with message queue + workers |
 | L | 2-4 weeks | Identity verification service with multiple providers |
 
-### Required Labels
-- `capability`, `needs-analysis` (auto-applied by template)
+### Template Labels
+- Current template labels: `capability`, `hermes-task`, `needs-plan`
+- Do not use `needs-analysis` as the current template default; it may still appear from legacy
+  auto-label fallback rules.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Examples
 **Good**:
@@ -170,8 +175,11 @@ For optimization, refinement, refactoring, and incremental improvements.
 | 2-3 days | Moderate | Add caching, improve error handling |
 | 4-5 days | Complex | Significant refactor, performance optimization |
 
-### Required Labels
-- `enhancement`, `needs-analysis` (auto-applied by template)
+### Template Labels
+- Current template labels: `enhancement`, `hermes-task`, `needs-plan`
+- Do not use `needs-analysis` as the current template default; it may still appear from legacy
+  auto-label fallback rules.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Examples
 **Good**:
@@ -212,9 +220,13 @@ Hours to 2 days. Priority determines SLA:
 | Medium | 3 days | Minor functionality broken | Validation too strict, UI glitch |
 | Low | When capacity | Cosmetic or rare edge case | Typo, rare race condition |
 
-### Required Labels
-- `defect`, `needs-triage` (auto-applied by template)
-- `critical` / `high-priority` / `medium-priority` / `low-priority` (add manually)
+### Template Labels
+- Current template labels: `defect`, `hermes-task`, `needs-plan`
+- Add exactly one priority label manually when the defect severity is known:
+  `critical`, `high-priority`, `medium-priority`, or `low-priority`.
+- Do not use `needs-triage` as the current template default; it may still appear from legacy
+  auto-label fallback rules.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Examples
 **Good**:
@@ -247,8 +259,10 @@ decisions. Produces knowledge, not production code.
 ### Size / Duration
 1-3 days maximum (timebox strictly).
 
-### Required Labels
-- `exploration`, `research` (auto-applied by template)
+### Template Labels
+- Current template labels: `exploration`, `research`, `hermes-not-actionable`
+- Exploration cards are context for research and decisions, not Hermes task cards.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Exploration Outcomes
 - **Clear Recommendation**: Document in Blueprint, create ADR, create follow-up Capability
@@ -286,8 +300,10 @@ AI effectiveness — Claude Code relies on up-to-date context in the blueprint r
 ### Size / Duration
 Hours to 1 day. Should accompany every Capability.
 
-### Required Labels
-- `context-update`, `documentation` (auto-applied by template)
+### Template Labels
+- Current template labels: `context-update`, `documentation`, `hermes-not-actionable`
+- Context Update cards are documentation/context work items, not Hermes task cards.
+- See `templates-reference.md` for the generated label and field contract.
 
 ### Where to Document
 | Content Type | Location |

--- a/plugins/sdlc-manager/skills/sdlc-labels/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-labels/SKILL.md
@@ -105,8 +105,10 @@ Apply labels based on pattern matching against the issue title and body:
 python3 sdlc_manager.py labels auto-label --repo infiquetra-core --number 42
 ```
 
-See auto-label rules in `references/labels-reference.md`. Common patterns: `[CAPABILITY]` in
-title adds `capability` + `needs-analysis`; `[DEFECT]` adds `defect` + `needs-triage`.
+See auto-label rules in `references/labels-reference.md`. Current GitHub issue templates apply
+`needs-plan` to actionable cards. The older title-pattern auto-label rules in `labels.json` are
+legacy fallback behavior and may still add `needs-analysis` or `needs-triage`.
+Treat those as legacy fallback labels, not current template defaults.
 
 ### Create a New Field Option
 
@@ -142,8 +144,9 @@ verifying that an initiative/objective option exists before trying to sync.
 - **AI usage labels**: Add when a PR is created — one per PR, tracks AI generation %
 - **Size labels**: Add during Analysis phase — one per capability/enhancement
 - **Risk labels**: Add during Analysis phase — one per capability
-- **Status labels** (`ready`, `blocked`, `needs-analysis`, `needs-triage`): may be
-  auto-managed as issues progress
+- **Planning/status labels**: current actionable templates use `needs-plan`; `ready` and
+  `blocked` may be managed as work progresses; `needs-analysis` and `needs-triage` are legacy
+  fallback labels from older auto-label rules
 
 ### Initiative and Objective Fields
 

--- a/plugins/sdlc-manager/skills/sdlc-labels/references/labels-reference.md
+++ b/plugins/sdlc-manager/skills/sdlc-labels/references/labels-reference.md
@@ -25,10 +25,15 @@ Applied automatically or manually as issues progress through the workflow.
 
 | Label | Color | Description |
 |-------|-------|-------------|
+| `needs-plan` | `#FBCA04` (yellow) | Current actionable-template planning label read by Hermes |
 | `needs-analysis` | `#FBCA04` (yellow) | Requires context gathering and specification |
 | `needs-triage` | `#FBCA04` (yellow) | Needs priority and impact assessment |
 | `ready` | `#0E8A16` (green) | Context complete, ready for development |
 | `blocked` | `#B60205` (dark red) | Work is blocked by external dependency |
+
+`needs-analysis` and `needs-triage` are legacy fallback labels. Current capability,
+enhancement, and defect templates apply `needs-plan`; the older labels may still appear when
+`labels auto-label` runs against title-pattern rules from `labels.json`.
 
 ---
 
@@ -147,6 +152,8 @@ Organizational and process labels.
 ## Auto-Label Rules
 
 Applied by `labels auto-label` command. Rules match patterns in issue title or body.
+These are legacy fallback rules, not the current GitHub Issue Form template defaults. For current
+template labels, use `../sdlc-issues/references/templates-reference.md`.
 
 | Rule | Pattern (regex) | Labels Applied |
 |------|----------------|----------------|
@@ -155,6 +162,7 @@ Applied by `labels auto-label` command. Rules match patterns in issue title or b
 | `title_contains_defect` | `\[DEFECT\]` in title | `defect`, `needs-triage` |
 | `title_contains_exploration` | `\[EXPLORATION\]` in title | `exploration` |
 | `title_contains_context` | `\[CONTEXT\]` in title | `context-update`, `documentation` |
+| `title_contains_objective` | `\[OBJECTIVE\]` in title | `objective` |
 | `mentions_security` | `security\|vulnerability\|CVE` in title/body | `security` |
 | `mentions_performance` | `performance\|latency\|slow\|timeout` in title/body | `performance` |
 | `mentions_breaking` | `breaking change\|breaking\|backwards incompatible` in title/body | `breaking-change` |
@@ -177,8 +185,9 @@ Applied by `labels auto-label` command. Rules match patterns in issue title or b
 
 6. **Risk labels**: Add during Analysis phase. One per capability.
 
-7. **Status labels** (`ready`, `blocked`, `needs-analysis`, `needs-triage`): May be
-   auto-managed by the system as issues progress through workflow columns.
+7. **Planning/status labels**: current actionable templates apply `needs-plan`; `ready` and
+   `blocked` may be managed as issues progress. `needs-analysis` and `needs-triage` are legacy
+   fallback labels from older auto-label rules.
 
 8. **Technical area, workflow, and meta labels**: Apply as many as relevant. Not exclusive.
 

--- a/plugins/sdlc-manager/tests/test_issue_create_interactive.py
+++ b/plugins/sdlc-manager/tests/test_issue_create_interactive.py
@@ -198,8 +198,7 @@ def test_paired_card_recursion_guard() -> None:
 
 
 def test_metadata_applies_hermes_task_for_actionable_types() -> None:
-    """Capability/enhancement/defect/exploration/context-update get
-    `hermes-task`; objective gets `hermes-not-actionable`."""
+    """Capability/enhancement/defect get `hermes-task`."""
     with (
         patch.object(sdlc_manager, "_gh") as mock_gh,
         patch.object(sdlc_manager, "board_add"),
@@ -251,6 +250,29 @@ def test_metadata_applies_hermes_not_actionable_for_objective() -> None:
     # Verify hermes-task is NOT applied to objective
     actionable_calls = [c for c in cmd_calls if "hermes-task" in str(c)]
     assert actionable_calls == []
+
+
+def test_metadata_applies_hermes_not_actionable_for_exploration() -> None:
+    """Exploration/context-update are non-actionable template types."""
+    with (
+        patch.object(sdlc_manager, "_gh") as mock_gh,
+        patch.object(sdlc_manager, "board_add"),
+        patch.object(sdlc_manager, "flow_set_field"),
+        patch.object(sdlc_manager, "flow_link_sub_issue"),
+        patch.object(sdlc_manager, "load_config", return_value={}),
+    ):
+        sdlc_manager._apply_post_create_metadata(
+            repo="campps-context-library",
+            issue_number=2,
+            issue_type="exploration",
+            project_name=None,
+            parent=None,
+            field_values={},
+            fmt="text",
+        )
+    cmd_calls = [c.args[0] for c in mock_gh.call_args_list]
+    assert any("hermes-not-actionable" in str(call) for call in cmd_calls)
+    assert not any("hermes-task" in str(call) for call in cmd_calls)
 
 
 def test_metadata_label_failure_does_not_abort_other_steps() -> None:

--- a/plugins/sdlc-manager/tests/test_issue_create_prepared.py
+++ b/plugins/sdlc-manager/tests/test_issue_create_prepared.py
@@ -253,7 +253,9 @@ def test_mapping_pr_uses_temporary_worktree(tmp_path) -> None:
         ),
         patch.object(sdlc_manager, "_run_git_command", return_value="ok") as mock_git,
         patch.object(sdlc_manager, "_write_mapping_update") as mock_write,
-        patch.object(sdlc_manager, "_gh", return_value="https://github.com/infiquetra/infiquetra-sdlc/pull/1"),
+        patch.object(
+            sdlc_manager, "_gh", return_value="https://github.com/infiquetra/infiquetra-sdlc/pull/1"
+        ),
     ):
         url = sdlc_manager._open_mapping_pr("hermes-claude-code-router", "mount-olympus")
 

--- a/plugins/sdlc-manager/tests/test_issue_create_prepared.py
+++ b/plugins/sdlc-manager/tests/test_issue_create_prepared.py
@@ -1,0 +1,268 @@
+"""Tests for confirmed prepared issue creation and mutation planning."""
+
+# ruff: noqa: E402,I001
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+OLYMPUS_BODY = """### Objective
+Add a prepared issue workflow.
+
+### Acceptance criteria
+- [ ] Drafts are written before GitHub mutation
+
+### Out-of-scope / non-goals
+- Do not auto-move issues to Ready
+
+### Files expected to change
+plugins/sdlc-manager/scripts/sdlc_manager.py
+
+### Tests to add or update
+plugins/sdlc-manager/tests/test_issue_create_prepared.py
+
+### Verification
+```bash
+uv run pytest plugins/sdlc-manager/tests/test_issue_create_prepared.py
+```
+"""
+
+
+def _ready_draft(tmp_path: Path) -> Path:
+    return sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Prepared issue workflow",
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+
+def _blocked_draft(tmp_path: Path) -> Path:
+    return sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source="Implement it.",
+        title="Blocked issue workflow",
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+
+def _mapped_config() -> dict:
+    return {
+        "project_mappings": {
+            "projects": {
+                "mount-olympus": {
+                    "number": 1,
+                    "name": "Olympus",
+                    "repositories": ["hermes-claude-code-router"],
+                }
+            }
+        }
+    }
+
+
+def _unmapped_config() -> dict:
+    return {
+        "project_mappings": {
+            "projects": {
+                "mount-olympus": {
+                    "number": 1,
+                    "name": "Olympus",
+                    "repositories": [],
+                }
+            }
+        }
+    }
+
+
+def test_blocked_draft_refuses_to_mutate(tmp_path) -> None:
+    draft = _blocked_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config") as mock_config,
+        patch.object(sdlc_manager, "_create_github_issue") as mock_create,
+        pytest.raises(RuntimeError, match="blocking readiness"),
+    ):
+        sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+
+    mock_config.assert_not_called()
+    mock_create.assert_not_called()
+
+
+def test_declined_confirmation_applies_no_mutation(tmp_path) -> None:
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(sdlc_manager, "_safe_input", return_value="n"),
+        patch.object(sdlc_manager, "_create_github_issue") as mock_create,
+    ):
+        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=False)
+
+    assert result == {"created": False, "reason": "declined"}
+    mock_create.assert_not_called()
+
+
+def test_create_prepared_creates_issue_and_marks_draft(tmp_path) -> None:
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(
+            sdlc_manager,
+            "_create_github_issue",
+            return_value=("https://github.com/infiquetra/hermes-claude-code-router/issues/42", 42),
+        ),
+        patch.object(sdlc_manager, "board_add") as mock_board,
+        patch.object(sdlc_manager, "flow_set_field") as mock_status,
+    ):
+        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+
+    assert result["created"] is True
+    mock_board.assert_called_once_with(
+        "hermes-claude-code-router",
+        42,
+        fmt="text",
+        config=_mapped_config(),
+        project_name="mount-olympus",
+    )
+    mock_status.assert_called_once_with(
+        "mount-olympus",
+        "hermes-claude-code-router",
+        42,
+        "Status",
+        "Backlog",
+        fmt="text",
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+    assert sidecar["state"] == "created"
+    assert sidecar["created_issue_number"] == 42
+    assert "## Created Issue" in draft.read_text()
+
+
+def test_missing_mapping_opens_pr_and_stops_without_override(tmp_path) -> None:
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_unmapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(sdlc_manager, "_open_mapping_pr", return_value="https://github.com/pr/1"),
+        patch.object(sdlc_manager, "_create_github_issue") as mock_create,
+    ):
+        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+
+    assert result == {"created": False, "mapping_pr_url": "https://github.com/pr/1"}
+    mock_create.assert_not_called()
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+    assert sidecar["state"] == "mapping_pending"
+    assert sidecar["pending_mapping"] == {
+        "repo": "hermes-claude-code-router",
+        "project": "mount-olympus",
+    }
+
+
+def test_override_mapping_creates_issue_and_records_pending_mapping(tmp_path) -> None:
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_unmapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(sdlc_manager, "_open_mapping_pr", return_value="https://github.com/pr/1"),
+        patch.object(
+            sdlc_manager,
+            "_create_github_issue",
+            return_value=("https://github.com/infiquetra/hermes-claude-code-router/issues/42", 42),
+        ),
+        patch.object(sdlc_manager, "board_add"),
+        patch.object(sdlc_manager, "flow_set_field"),
+    ):
+        result = sdlc_manager.issue_create_prepared(
+            draft,
+            fmt="text",
+            auto_confirm=True,
+            override_mapping=True,
+        )
+
+    assert result["created"] is True
+    assert result["mapping_pr_url"] == "https://github.com/pr/1"
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+    assert sidecar["state"] == "created"
+    assert sidecar["pending_mapping"] is True
+
+
+def test_missing_labels_and_templates_are_deployed_after_confirmation(tmp_path) -> None:
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=["hermes-task"]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=["capability.yml"]),
+        patch.object(sdlc_manager, "labels_deploy") as mock_labels,
+        patch.object(sdlc_manager, "rollout_deploy_templates") as mock_templates,
+        patch.object(
+            sdlc_manager,
+            "_create_github_issue",
+            return_value=("https://github.com/infiquetra/hermes-claude-code-router/issues/42", 42),
+        ),
+        patch.object(sdlc_manager, "board_add"),
+        patch.object(sdlc_manager, "flow_set_field"),
+    ):
+        sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+
+    mock_labels.assert_called_once_with("hermes-claude-code-router", fmt="text")
+    mock_templates.assert_called_once_with("hermes-claude-code-router", fmt="text")
+
+
+def test_mapping_pr_uses_temporary_worktree(tmp_path) -> None:
+    worktree_root = tmp_path / "infiquetra-sdlc"
+    mapping_path = worktree_root / "config" / "project-mappings.json"
+    mapping_path.parent.mkdir(parents=True)
+    mapping_path.write_text('{"projects": {"mount-olympus": {"repositories": []}}}\n')
+
+    with (
+        patch.object(
+            sdlc_manager,
+            "_mapping_update_target",
+            return_value=(mapping_path, worktree_root, "infiquetra-sdlc", None),
+        ),
+        patch.object(sdlc_manager, "_run_git_command", return_value="ok") as mock_git,
+        patch.object(sdlc_manager, "_write_mapping_update") as mock_write,
+        patch.object(sdlc_manager, "_gh", return_value="https://github.com/infiquetra/infiquetra-sdlc/pull/1"),
+    ):
+        url = sdlc_manager._open_mapping_pr("hermes-claude-code-router", "mount-olympus")
+
+    assert url == "https://github.com/infiquetra/infiquetra-sdlc/pull/1"
+    git_args = [call.args[0] for call in mock_git.call_args_list]
+    assert any(args[:3] == ["git", "worktree", "add"] for args in git_args)
+    assert any(args[:4] == ["git", "worktree", "remove", "--force"] for args in git_args)
+    assert not any(args[:2] == ["git", "checkout"] for args in git_args)
+
+    written_path = mock_write.call_args.args[0]
+    assert written_path != mapping_path
+    assert written_path.name == "project-mappings.json"

--- a/plugins/sdlc-manager/tests/test_issue_create_prepared.py
+++ b/plugins/sdlc-manager/tests/test_issue_create_prepared.py
@@ -5,6 +5,7 @@
 import json
 import sys
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -37,32 +38,38 @@ uv run pytest plugins/sdlc-manager/tests/test_issue_create_prepared.py
 
 
 def _ready_draft(tmp_path: Path) -> Path:
-    return sdlc_manager.issue_prepare(
-        repo="hermes-claude-code-router",
-        issue_type="capability",
-        team="olympus",
-        project="mount-olympus",
-        source=OLYMPUS_BODY,
-        title="Prepared issue workflow",
-        status=None,
-        risk="medium",
-        mode=None,
-        draft_dir=tmp_path,
+    return cast(
+        Path,
+        sdlc_manager.issue_prepare(
+            repo="hermes-claude-code-router",
+            issue_type="capability",
+            team="olympus",
+            project="mount-olympus",
+            source=OLYMPUS_BODY,
+            title="Prepared issue workflow",
+            status=None,
+            risk="medium",
+            mode=None,
+            draft_dir=tmp_path,
+        ),
     )
 
 
 def _blocked_draft(tmp_path: Path) -> Path:
-    return sdlc_manager.issue_prepare(
-        repo="hermes-claude-code-router",
-        issue_type="capability",
-        team="olympus",
-        project="mount-olympus",
-        source="Implement it.",
-        title="Blocked issue workflow",
-        status=None,
-        risk="medium",
-        mode=None,
-        draft_dir=tmp_path,
+    return cast(
+        Path,
+        sdlc_manager.issue_prepare(
+            repo="hermes-claude-code-router",
+            issue_type="capability",
+            team="olympus",
+            project="mount-olympus",
+            source="Implement it.",
+            title="Blocked issue workflow",
+            status=None,
+            risk="medium",
+            mode=None,
+            draft_dir=tmp_path,
+        ),
     )
 
 

--- a/plugins/sdlc-manager/tests/test_issue_prepare.py
+++ b/plugins/sdlc-manager/tests/test_issue_prepare.py
@@ -1,0 +1,214 @@
+"""Tests for prepared issue draft contracts and readiness profiles."""
+
+# ruff: noqa: E402,I001
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+OLYMPUS_BODY = """### Objective
+Add a prepared issue workflow.
+
+### Acceptance criteria
+- [ ] Drafts are written before GitHub mutation
+
+### Out-of-scope / non-goals
+- Do not auto-move issues to Ready
+
+### Files expected to change
+plugins/sdlc-manager/scripts/sdlc_manager.py
+
+### Tests to add or update
+plugins/sdlc-manager/tests/test_issue_prepare.py
+
+### Verification
+```bash
+uv run pytest plugins/sdlc-manager/tests/test_issue_prepare.py
+```
+"""
+
+
+ASGARD_BODY = """### Intent
+Shape a rapid-action issue preparation path.
+
+### Target repo / surface
+hermes-claude-code-router issue intake
+
+### Mode
+Rapid Action
+
+### Constraints
+Keep issue creation separate from draft review.
+
+### Risk
+Low operational risk.
+
+### Promotion gaps
+- [ ] Add strict verification before Olympus promotion.
+"""
+
+
+def test_prepare_olympus_writes_ready_draft_and_sidecar(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Prepared issue workflow",
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+
+    assert draft.exists()
+    assert sidecar["state"] == "ready_to_create"
+    assert sidecar["repo"] == "hermes-claude-code-router"
+    assert sidecar["readiness"]["passed"] is True
+    assert sidecar["labels"] == ["capability", "hermes-task", "needs-plan"]
+
+
+def test_prepare_olympus_blocks_missing_verification(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source="Implement the router issue workflow.",
+        title="Incomplete Olympus draft",
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+
+    assert sidecar["state"] == "blocked"
+    assert sidecar["readiness"]["passed"] is False
+    assert any("Verification" in gap for gap in sidecar["readiness"]["blocking_gaps"])
+
+
+def test_prepare_asgard_accepts_shaping_quality_input(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="exploration",
+        team="asgard",
+        project="asgard",
+        source=ASGARD_BODY,
+        title="Asgard shaping issue",
+        status=None,
+        risk="low",
+        mode="Rapid Action",
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+
+    assert sidecar["state"] == "ready_to_create"
+    assert sidecar["readiness"]["passed"] is True
+    assert any("Olympus promotion gaps" in warning for warning in sidecar["readiness"]["warnings"])
+
+
+def test_ready_status_blocks_prepared_draft(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="exploration",
+        team="asgard",
+        project="asgard",
+        source=ASGARD_BODY,
+        title="Too ready",
+        status="Ready",
+        risk="low",
+        mode="Rapid Action",
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+
+    assert sidecar["state"] == "blocked"
+    assert "Prepared issues must not start in Ready" in sidecar["readiness"]["blocking_gaps"]
+
+
+def test_non_default_status_blocks_prepared_draft(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Wrong status",
+        status="In Progress",
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+
+    assert sidecar["state"] == "blocked"
+    assert "Prepared olympus issues must start in 'Backlog', not 'In Progress'" in sidecar[
+        "readiness"
+    ]["blocking_gaps"]
+
+
+def test_olympus_requires_actionable_labels_and_risk(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Missing risk",
+        status=None,
+        risk=None,
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+    draft.write_text(
+        draft.read_text().replace("labels: capability, hermes-task, needs-plan", "labels: capability")
+    )
+    sidecar_path = draft.with_suffix(".json")
+    sidecar = json.loads(sidecar_path.read_text())
+    sidecar["labels"] = ["capability"]
+    sidecar_path.write_text(json.dumps(sidecar))
+
+    issue = sdlc_manager._read_prepared_issue(draft)
+    readiness = sdlc_manager._readiness_for_prepared_issue(issue)
+
+    assert not readiness.passed
+    assert any("Missing expected labels" in gap for gap in readiness.blocking_gaps)
+    assert "Missing author-visible risk metadata" in readiness.blocking_gaps
+
+
+def test_sidecar_conflict_blocks_draft_parse(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Conflict draft",
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+    sidecar_path = draft.with_suffix(".json")
+    sidecar = json.loads(sidecar_path.read_text())
+    sidecar["repo"] = "other-repo"
+    sidecar_path.write_text(json.dumps(sidecar))
+
+    with pytest.raises(RuntimeError, match="conflicts with sidecar"):
+        sdlc_manager._read_prepared_issue(draft)

--- a/plugins/sdlc-manager/tests/test_issue_prepare.py
+++ b/plugins/sdlc-manager/tests/test_issue_prepare.py
@@ -157,9 +157,10 @@ def test_non_default_status_blocks_prepared_draft(tmp_path) -> None:
     sidecar = json.loads(draft.with_suffix(".json").read_text())
 
     assert sidecar["state"] == "blocked"
-    assert "Prepared olympus issues must start in 'Backlog', not 'In Progress'" in sidecar[
-        "readiness"
-    ]["blocking_gaps"]
+    assert (
+        "Prepared olympus issues must start in 'Backlog', not 'In Progress'"
+        in sidecar["readiness"]["blocking_gaps"]
+    )
 
 
 def test_olympus_requires_actionable_labels_and_risk(tmp_path) -> None:
@@ -177,7 +178,9 @@ def test_olympus_requires_actionable_labels_and_risk(tmp_path) -> None:
     )
 
     draft.write_text(
-        draft.read_text().replace("labels: capability, hermes-task, needs-plan", "labels: capability")
+        draft.read_text().replace(
+            "labels: capability, hermes-task, needs-plan", "labels: capability"
+        )
     )
     sidecar_path = draft.with_suffix(".json")
     sidecar = json.loads(sidecar_path.read_text())

--- a/plugins/sdlc-manager/tests/test_prompt_alignment.py
+++ b/plugins/sdlc-manager/tests/test_prompt_alignment.py
@@ -19,7 +19,7 @@ def test_sdlc_manager_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "sdlc-manager")
 
     assert plugin_json["name"] == "sdlc-manager"
-    assert plugin_json["version"] == "1.5.0"
+    assert plugin_json["version"] == "1.6.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/sdlc-manager"
     assert "Jeff Intent" in entry["description"]
@@ -51,6 +51,9 @@ def test_operator_prompt_honors_hermes_actionability_contract() -> None:
     assert "(capability/enhancement/defect/exploration/context-update)" not in operator
     assert "Step 2: Applied labels (hermes-task, capability, needs-plan)" in operator
     assert "Step 2: Applied labels (hermes-task, capability, needs-analysis)" not in operator
+    assert "issue prepare" in operator
+    assert "issue create-prepared" in operator
+    assert "Asgard `Shaping`, Olympus `Backlog`" in operator
 
 
 def test_triage_command_uses_project_fields_and_current_actionable_labels() -> None:
@@ -72,3 +75,20 @@ def test_label_docs_mark_legacy_auto_label_rules_as_fallback() -> None:
     assert "legacy fallback labels" in reference
     assert "legacy fallback rules" in reference
     assert "Current capability,\nenhancement, and defect templates apply `needs-plan`" in reference
+
+
+def test_prepared_issue_guidance_routes_natural_language_creation() -> None:
+    skill = _read(PLUGIN_ROOT / "skills/sdlc-issues/SKILL.md")
+    command = _read(PLUGIN_ROOT / "commands/sdlc-create.md")
+    readme = _read(PLUGIN_ROOT / "README.md")
+
+    for text in (skill, command, readme):
+        assert "issue prepare" in text
+        assert "issue create-prepared" in text
+
+    assert "Create an Olympus issue from this text" in skill
+    assert "Create an Asgard issue from these notes" in skill
+    assert "If team or project is ambiguous, ask" in skill
+    assert "Never auto-move a prepared issue to `Ready`" in skill
+    assert "create an Olympus issue from this text" in command
+    assert "prepared-draft path" in command

--- a/plugins/sdlc-manager/tests/test_prompt_alignment.py
+++ b/plugins/sdlc-manager/tests/test_prompt_alignment.py
@@ -1,0 +1,74 @@
+"""Drift guards for sdlc-manager prompts, references, and release metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = ROOT / "plugins" / "sdlc-manager"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_sdlc_manager_metadata_and_marketplace_entry_match() -> None:
+    plugin_json = json.loads(_read(PLUGIN_ROOT / ".claude-plugin" / "plugin.json"))
+    marketplace = json.loads(_read(ROOT / ".claude-plugin" / "marketplace.json"))
+    entry = next(p for p in marketplace["plugins"] if p["name"] == "sdlc-manager")
+
+    assert plugin_json["name"] == "sdlc-manager"
+    assert plugin_json["version"] == "1.5.0"
+    assert entry["version"] == plugin_json["version"]
+    assert entry["source"] == "./plugins/sdlc-manager"
+    assert "Jeff Intent" in entry["description"]
+    assert "Beads" not in entry["description"]
+    assert "beads" not in entry["keywords"]
+
+
+def test_issue_type_reference_uses_current_template_labels() -> None:
+    issue_types = _read(PLUGIN_ROOT / "skills/sdlc-issues/references/issue-types.md")
+
+    assert "`capability`, `hermes-task`, `needs-plan`" in issue_types
+    assert "`enhancement`, `hermes-task`, `needs-plan`" in issue_types
+    assert "`defect`, `hermes-task`, `needs-plan`" in issue_types
+    assert "`objective`, `hermes-not-actionable`" in issue_types
+    assert "`exploration`, `research`, `hermes-not-actionable`" in issue_types
+    assert "`context-update`, `documentation`, `hermes-not-actionable`" in issue_types
+    assert "`capability`, `needs-analysis` (auto-applied by template)" not in issue_types
+    assert "`enhancement`, `needs-analysis` (auto-applied by template)" not in issue_types
+    assert "`defect`, `needs-triage` (auto-applied by template)" not in issue_types
+    assert "`objective:{short-name}`" not in issue_types
+    assert "`initiative:{name}`" not in issue_types
+
+
+def test_operator_prompt_honors_hermes_actionability_contract() -> None:
+    operator = _read(PLUGIN_ROOT / "agents/sdlc-operator.md")
+
+    assert "(capability/enhancement/defect)" in operator
+    assert "(objective/exploration/context-update)" in operator
+    assert "(capability/enhancement/defect/exploration/context-update)" not in operator
+    assert "Step 2: Applied labels (hermes-task, capability, needs-plan)" in operator
+    assert "Step 2: Applied labels (hermes-task, capability, needs-analysis)" not in operator
+
+
+def test_triage_command_uses_project_fields_and_current_actionable_labels() -> None:
+    triage = _read(PLUGIN_ROOT / "commands/sdlc-triage.md")
+
+    assert "Initiative/Objective project field values" in triage
+    assert "initiative/objective labels" not in triage
+    assert '"capability,hermes-task,needs-plan"' in triage
+    assert '"capability,needs-analysis"' not in triage
+    assert "Add `needs-analysis` label" not in triage
+
+
+def test_label_docs_mark_legacy_auto_label_rules_as_fallback() -> None:
+    skill = _read(PLUGIN_ROOT / "skills/sdlc-labels/SKILL.md")
+    reference = _read(PLUGIN_ROOT / "skills/sdlc-labels/references/labels-reference.md")
+
+    assert "legacy fallback behavior" in skill
+    assert "legacy fallback labels" in skill
+    assert "legacy fallback labels" in reference
+    assert "legacy fallback rules" in reference
+    assert "Current capability,\nenhancement, and defect templates apply `needs-plan`" in reference


### PR DESCRIPTION
## Summary
- add team-aware issue prepare and create-prepared workflow for Asgard/Olympus issue drafts
- add prepared draft artifacts, readiness checks, confirmed mutation planning, docs, and prompt guidance
- bump sdlc-manager release metadata and archive the queued follow-up

## Verification
- uv run pytest plugins/sdlc-manager/tests tests/test_sdlc_manager.py -q
- uv run ruff check .
- uv run python plugins/sdlc-manager/scripts/sync_template_docs.py --check
- uv run python marketplace/validator/validate.py
- git diff --check

## Notes
- Marketplace validation passes with existing recommended-field warnings across plugins.
