### PR TITLE
feat: add SDLC handoff flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -297,7 +297,7 @@
       "name": "infiquetra-loop",
       "source": "./plugins/infiquetra-loop",
       "version": "0.1.0",
-      "description": "Infiquetra lifecycle workflow plugin for strategy, planning, work execution, review, QA, and resume.",
+      "description": "Infiquetra lifecycle workflow plugin for strategy, planning, SDLC handoff, work execution, review, QA, and resume.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"
@@ -310,6 +310,7 @@
         "strategy",
         "ideation",
         "brainstorm",
+        "handoff",
         "doc-review",
         "code-review",
         "optimize",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -314,7 +314,6 @@
         "doc-review",
         "code-review",
         "optimize",
-        "qa",
         "sdlc"
       ],
       "category": "development"

--- a/docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md
+++ b/docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md
@@ -1,0 +1,383 @@
+---
+date: 2026-05-30
+topic: infiquetra-loop-sdlc-handoff
+title: Infiquetra Loop SDLC Handoff Requirements
+source_idea: docs/ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md
+related_requirements:
+  - docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md
+---
+
+# Requirements: Infiquetra Loop SDLC Handoff
+
+## Summary
+
+Add a handoff path from `infiquetra-loop` lifecycle artifacts into `sdlc-manager` issue artifacts.
+`infiquetra-loop` owns lifecycle exit detection and source-context packaging; `sdlc-manager` owns
+`/create-issue`, prepared drafts, GitHub/project mutation, and self-contained issue bodies that a
+recipient can execute without `infiquetra-loop` installed.
+
+---
+
+## Problem Frame
+
+The current loop is good at carrying work forward inside one human or agent session. It is weaker
+when the work should leave that session and be picked up by another team, another agent, or a later
+operator. The receiving side needs an issue that stands on its own: what changed, why it matters,
+what artifact it came from, what maturity it has, and what action is safe next.
+
+`sdlc-manager` already has the prepared-issue boundary: a markdown draft, JSON sidecar, readiness
+checks, and a confirmed create path. The missing product layer is the natural handoff experience:
+plain `/create-issue` naming, source-artifact discovery, lifecycle-aware maturity, and a thin
+`/handoff` command that routes rather than creating issues itself.
+
+One prerequisite must be handled before implementation. Current `infiquetra-sdlc` and synced
+`sdlc-manager` materials still describe Asgard as a feeder or promotion lane for Mount Olympus.
+The desired model is different: Asgard and Olympus are sibling target teams/boards. Either can
+carry work to completion, and cross-team movement is explicit operator action only.
+
+The Mimir orchestration reconsideration points at the same design principle: do not rebuild the
+downstream execution substrate. Use the native issue, board, and lifecycle mechanisms, then add
+only the context and readiness metadata the handoff recipient needs.
+
+---
+
+## Key Decisions
+
+- **`sdlc-manager` owns issue artifacts.** It owns `/create-issue`, prepared drafts, sidecars,
+  readiness checks, mutation plans, and GitHub/project side effects.
+- **`infiquetra-loop` owns lifecycle handoff.** It detects when local lifecycle work should stop,
+  packages source context, and routes to `/create-issue` or tells the operator the next loop action.
+- **`/create-issue` is the primary issue command.** `/sdlc-create` remains as a compatibility or
+  namespaced alias.
+- **Prepare is the safe no-mutation mode.** `--prepare` is canonical, `--draft` is an alias, and
+  explicit create intent still shows a mutation plan before side effects.
+- **Source artifacts are first-class.** `/create-issue --from <artifact>` is supported, and natural
+  language that implies an existing artifact should trigger repo-local artifact search before
+  asking the user for a path.
+- **Maturity is visible and machine-readable.** Handoff maturity appears in both the issue body and
+  the JSON sidecar.
+- **`/handoff` is thin.** It infers the active artifact and maturity when it can, asks only when
+  uncertain, and delegates issue creation to `sdlc-manager`.
+
+---
+
+## Actors
+
+- A1. Operator - the human deciding whether to carry work forward locally or hand it to another
+  team/session.
+- A2. `infiquetra-loop` - lifecycle command layer that manages ideation, brainstorm, planning,
+  review, work, retro, durable artifacts, and active pointers.
+- A3. `sdlc-manager` - issue command layer that prepares drafts, validates readiness, builds
+  mutation plans, and creates issues.
+- A4. Recipient team or agent - Asgard, Olympus, Jeff/operator, or another execution context that
+  must be able to use the issue without local loop assumptions.
+- A5. GitHub and project boards - repositories, issues, labels, project items, fields, and board
+  statuses.
+- A6. Canonical SDLC model - `infiquetra-sdlc` and synced plugin materials that define team,
+  issue-type, and board semantics.
+
+---
+
+## Requirements
+
+**Prerequisite Model Correction**
+
+- R1. The implementation plan generated from this requirements document must begin with a
+  prerequisite workstream to correct the stale Asgard-to-Olympus promotion model in canonical
+  `infiquetra-sdlc` materials.
+- R2. The same prerequisite workstream must sync the corrected model into vendored `sdlc-manager`
+  materials, prepared-issue wording, readiness checks, and tests.
+- R3. Corrected language must state that Asgard and Olympus are sibling target teams/boards, not
+  maturity stages in one funnel.
+- R4. Corrected behavior must treat cross-team movement, cloning, or linked issue creation as an
+  explicit operator action only.
+- R5. Readiness checks may warn that an issue does not fit a target team's profile, but they must
+  not imply automatic Asgard-to-Olympus promotion.
+
+**Command Surface And Ownership**
+
+- R6. `sdlc-manager` provides `/create-issue` as the primary operator-facing issue command.
+- R7. `/sdlc-create` remains available as a compatibility alias or namespaced form for existing
+  users and docs.
+- R8. `/create-issue` supports natural-language issue creation plus explicit flags for repo, team,
+  project, issue type, maturity, source artifact, and prepare mode.
+- R9. `/create-issue --prepare` writes the prepared markdown draft and JSON sidecar without
+  GitHub/project mutation.
+- R10. `/create-issue --draft` behaves as an alias for `--prepare`.
+- R11. Explicit create intent builds and displays the final mutation plan, then performs side
+  effects only after confirmation.
+- R12. `infiquetra-loop` must not create GitHub issues directly; it routes to `/create-issue` or
+  prepares the context needed by that command.
+- R13. `infiquetra-loop` provides a thin `/handoff` command for the current lifecycle artifact.
+
+**Source Artifact Discovery**
+
+- R14. `/create-issue --from <artifact>` accepts explicit source paths or URLs for ideation docs,
+  brainstorm requirements, plans, doc-review artifacts, work-session summaries, prepared drafts,
+  existing issues, PRs, branches, or equivalent resume state.
+- R15. Natural-language prompts that imply an existing source artifact must trigger local artifact
+  search before asking the user for a path.
+- R16. Artifact search covers the repo's durable lifecycle locations, including ideation,
+  brainstorms, plans, reviews, work-session summaries, prepared issue drafts, and the active
+  `infiquetra-loop` pointer when present.
+- R17. When artifact search finds exactly one confident match, the command may use it and report
+  the selected source in the draft or mutation plan.
+- R18. When artifact search finds multiple plausible matches, the command presents the candidates
+  and asks the operator to choose.
+- R19. When artifact search finds no plausible match, the command asks for a source path or enough
+  source text to continue.
+- R20. The source artifact type informs default handoff maturity, but explicit operator language or
+  `--maturity` can override the default.
+
+**Handoff Maturity And Issue Content**
+
+- R21. Every handoff issue draft includes a handoff maturity marker in both the issue body and JSON
+  sidecar.
+- R22. Supported maturity values are `idea-ready`, `requirements-ready`, `plan-ready`,
+  `resume-ready`, and `deferred-context`.
+- R23. The issue body is self-contained: target repo/surface, team/board/project, issue type,
+  maturity, source artifact links or excerpts, criteria appropriate to maturity, non-goals, risks,
+  blockers, open questions, and suggested next action.
+- R24. Optional `infiquetra-loop` next-action hints may appear in the issue body, but the issue
+  must remain executable without `infiquetra-loop`.
+- R25. `requirements-ready` issues suggest planning as the next action, not execution.
+- R26. `plan-ready` and `resume-ready` issues may suggest `/work <issue>` only when the issue body
+  contains or links a plan-grade execution contract.
+- R27. `/loop <issue>` is not suggested to agent teams by default; it is reserved for human or
+  operator lifecycle routing.
+
+**Lifecycle Handoff Behavior**
+
+- R28. `infiquetra-loop` offers handoff at natural lifecycle boundaries: post-ideation when intent
+  should be preserved, post-brainstorm when requirements are ready, post-plan when execution can
+  move elsewhere, and mid-work when another session must resume.
+- R29. The default after raw ideation is to continue shaping locally unless the operator explicitly
+  wants to preserve, defer, or route the idea.
+- R30. The first normal handoff point is post-brainstorm or post-requirements, where the likely next
+  action is `/plan <issue>`.
+- R31. Post-plan handoff is the normal implementation-team handoff, where the likely next action is
+  `/work <issue>` if review gates are satisfied.
+- R32. Mid-work handoff includes branch or PR state, completed phases, checks run, blockers,
+  remaining acceptance criteria, and review status.
+- R33. `/handoff` asks whether work is being carried forward locally or handed off when that cannot
+  be inferred from the operator's prompt.
+- R34. Cross-team transfer is supported only when explicitly requested; readiness alone must not
+  cause an Asgard issue to become an Olympus issue or vice versa.
+
+**Planning And Work Integration**
+
+- R35. `/plan <issue>` can consume a `requirements-ready` handoff issue, write a durable
+  `docs/plans/` artifact, and sync a compact plan summary plus link back to the issue.
+- R36. `/work <issue>` can consume a `plan-ready` or `resume-ready` issue when the issue links or
+  contains the required plan/resume contract.
+- R37. When a plan still needs review, the handoff issue may suggest `/doc-review <plan>` before
+  `/work <issue>`.
+- R38. Existing prepared-draft creation remains the deterministic base; the new handoff behavior
+  extends it with source artifact discovery, maturity, and clearer command names.
+
+**Validation And Documentation**
+
+- R39. Command docs and skills document `/create-issue`, `--prepare`, `--draft`, `--from`,
+  `/handoff`, maturity values, and the `/sdlc-create` compatibility path.
+- R40. Tests cover prepare/draft aliasing, explicit create confirmation, source-artifact search,
+  maturity sidecar/body output, `/plan <issue>` summary sync, and blocked creation when required
+  maturity inputs are missing.
+- R41. Tests or doc checks cover the stale Asgard/Olympus model correction so promotion-lane
+  language does not reappear in active `sdlc-manager` materials.
+
+---
+
+## Handoff Shape
+
+```mermaid
+flowchart TB
+  L[Loop lifecycle artifact] --> H{Carry locally or hand off}
+  H -->|carry locally| C[Continue brainstorm, plan, review, or work]
+  H -->|hand off| P[Package source context]
+  P --> S[Search or accept source artifact]
+  S --> M[Infer or confirm maturity]
+  M --> D[sdlc-manager prepared draft + sidecar]
+  D --> Q{Prepare only or create}
+  Q -->|prepare| R[Reviewable draft]
+  Q -->|create| X[Confirmed mutation plan]
+  X --> I[Self-contained issue]
+```
+
+The diagram is conceptual. The important boundary is that the loop packages context and
+`sdlc-manager` owns the issue artifact and mutation path.
+
+---
+
+## Key Flows
+
+- F1. Create from an explicit artifact
+  - **Trigger:** Operator runs `/create-issue --from docs/plans/example.md`.
+  - **Actors:** A1, A3, A5.
+  - **Steps:** Read the artifact, infer maturity from the artifact type, prepare the draft and
+    sidecar, show the mutation plan when creation is intended, and create only after confirmation.
+  - **Outcome:** The issue is created or drafted from the named source.
+  - **Covers:** R8-R11, R14, R20-R24.
+
+- F2. Create from natural-language artifact reference
+  - **Trigger:** Operator says, "Turn the plan we just made into an Olympus issue."
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Search likely lifecycle artifacts, select or ask about the matching plan, infer
+    `plan-ready`, prepare the issue, and show the confirmed create flow.
+  - **Outcome:** Natural language reaches the same artifact-backed path as explicit `--from`.
+  - **Covers:** R15-R20, R38.
+
+- F3. Handoff after requirements
+  - **Trigger:** Brainstorm or requirements work is complete and another team should plan it.
+  - **Actors:** A1, A2, A3, A4.
+  - **Steps:** `/handoff` packages the requirements artifact, sets `requirements-ready`, routes to
+    `/create-issue`, and suggests `/plan <issue>`.
+  - **Outcome:** The recipient can plan from the issue without reading chat history.
+  - **Covers:** R23-R25, R28-R30, R35.
+
+- F4. Handoff after plan
+  - **Trigger:** A plan exists and the implementation team or agent should execute it.
+  - **Actors:** A1, A2, A3, A4.
+  - **Steps:** `/handoff` packages the plan, sets `plan-ready`, routes to `/create-issue`, and
+    suggests review/work entrypoints as appropriate.
+  - **Outcome:** The recipient gets an execution-ready issue with the plan linked or embedded.
+  - **Covers:** R26, R31, R36, R37.
+
+- F5. Resume handoff after partial work
+  - **Trigger:** Work has started but another session must resume it.
+  - **Actors:** A1, A2, A3, A4.
+  - **Steps:** Package branch/PR state, work-session summary, checks, blockers, and remaining
+    criteria; set `resume-ready`; create or prepare the issue.
+  - **Outcome:** A later session can resume from durable state rather than chat memory.
+  - **Covers:** R22, R26, R32, R36.
+
+- F6. Explicit cross-team movement
+  - **Trigger:** Operator explicitly asks to move or clone an issue from one team board to another.
+  - **Actors:** A1, A3, A5, A6.
+  - **Steps:** Treat the target team as an explicit operator choice, run target-team readiness, and
+    show any warnings without implying automatic promotion.
+  - **Outcome:** Cross-team movement is possible but never inferred from readiness alone.
+  - **Covers:** R3-R5, R34.
+
+---
+
+## Acceptance Examples
+
+- AE1. Natural language finds the recent plan
+  - **Covers R15-R20.**
+  - **Given:** A recent plan exists under `docs/plans/`.
+  - **When:** The operator says, "Turn the plan we just made into an Olympus issue."
+  - **Then:** The command searches lifecycle artifacts before asking for a path, selects or
+    presents the likely plan, and prepares a `plan-ready` issue.
+
+- AE2. Prepare does not mutate GitHub
+  - **Covers R9, R10.**
+  - **Given:** The operator runs `/create-issue --prepare --from docs/brainstorms/example.md`.
+  - **When:** The command completes.
+  - **Then:** A draft and sidecar exist, and no GitHub issue or project item was created.
+
+- AE3. Create intent still requires confirmation
+  - **Covers R11.**
+  - **Given:** The operator says, "Create an issue for this plan."
+  - **When:** The source artifact and target are resolved.
+  - **Then:** The command shows all planned side effects and waits for confirmation before creating
+    the issue.
+
+- AE4. Requirements-ready issue points to planning
+  - **Covers R21-R26, R30.**
+  - **Given:** A brainstorm requirements artifact is handed off.
+  - **When:** The issue is prepared.
+  - **Then:** The issue carries `requirements-ready` maturity and suggests `/plan <issue>`, not
+    `/work <issue>`.
+
+- AE5. Plan-ready issue points to work
+  - **Covers R26, R31, R36, R37.**
+  - **Given:** An approved plan artifact is handed off.
+  - **When:** The issue is prepared.
+  - **Then:** The issue carries `plan-ready` maturity, links the plan, and may suggest
+    `/doc-review <plan>` followed by `/work <issue>` when review has not already passed.
+
+- AE6. Asgard issue does not imply Olympus promotion
+  - **Covers R1-R5, R34, R41.**
+  - **Given:** The target team is Asgard.
+  - **When:** The issue is prepared and readiness is evaluated.
+  - **Then:** The body and sidecar describe Asgard readiness without "Olympus promotion gaps" or
+    other feeder-lane language.
+
+- AE7. Recipient does not need `infiquetra-loop`
+  - **Covers R23, R24, R27.**
+  - **Given:** The recipient team lacks `infiquetra-loop`.
+  - **When:** They open the issue in GitHub.
+  - **Then:** The issue still contains enough context, criteria, source links, and next action to
+    proceed through normal SDLC surfaces.
+
+- AE8. `/plan <issue>` upgrades maturity through a durable plan artifact
+  - **Covers R35.**
+  - **Given:** A `requirements-ready` issue exists.
+  - **When:** `/plan <issue>` produces an approved plan.
+  - **Then:** A durable plan file exists under `docs/plans/`, and the issue receives a compact
+    plan summary plus link.
+
+---
+
+## Success Criteria
+
+- The next planning pass can produce implementation work without inventing command names,
+  ownership boundaries, maturity semantics, or handoff timing.
+- The first implementation workstream corrects the stale Asgard/Olympus model before adding new
+  handoff behavior.
+- Operators can say "create an issue," "prepare an issue," "draft an issue," or "hand this off"
+  without knowing the internal prepare/create state machine.
+- Natural-language references to existing artifacts find likely durable sources before asking the
+  operator to restate context.
+- Every created handoff issue is useful to a recipient that does not have `infiquetra-loop`.
+- No GitHub or project mutation occurs before a visible mutation plan is confirmed.
+- `/work <issue>` is suggested only when the issue is plan-ready or resume-ready.
+
+---
+
+## Scope Boundaries
+
+- Implementing `/create-issue`, `/handoff`, or the SDLC model correction is out of scope for this
+  brainstorm artifact.
+- Replacing the existing six SDLC issue types is out of scope.
+- Making `/loop` the only issue-creation surface is out of scope.
+- Suggesting `/loop <issue>` to agent teams by default is out of scope.
+- Requiring the recipient to have `infiquetra-loop` is out of scope.
+- Auto-moving issues to `Ready` is out of scope.
+- Auto-promoting Asgard work to Olympus is out of scope.
+- Reworking Mimir orchestration is out of scope; only its "lean into native substrate" lesson is
+  applied here.
+
+---
+
+## Dependencies And Assumptions
+
+- `sdlc-manager` prepared drafts remain the base issue artifact mechanism.
+- `infiquetra-loop` lifecycle commands keep writing durable artifacts and active pointers that can
+  be searched.
+- The target repository has, or can receive, the SDLC labels/templates and project mappings needed
+  by `sdlc-manager`.
+- The operator or agent session has repository filesystem access for source-artifact discovery.
+- GitHub/project mutation uses the existing confirmed `sdlc-manager` mutation-plan boundary.
+- Canonical `infiquetra-sdlc` docs and synced plugin materials can be updated before handoff work
+  ships.
+
+---
+
+## Sources
+
+- `docs/ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md`
+- `docs/brainstorms/2026-05-30-sdlc-manager-issue-prepare-requirements.md`
+- `plugins/infiquetra-loop/commands/plan.md`
+- `plugins/infiquetra-loop/commands/work.md`
+- `plugins/infiquetra-loop/skills/plan/SKILL.md`
+- `plugins/infiquetra-loop/skills/work/SKILL.md`
+- `plugins/sdlc-manager/commands/sdlc-create.md`
+- `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+- `plugins/sdlc-manager/scripts/sdlc_manager.py`
+- `plugins/sdlc-manager/config/sdlc-schema.json`
+- `plugins/sdlc-manager/tests/test_issue_prepare.py`
+- `infiquetra-sdlc: config/sdlc-schema.json`
+- `infiquetra-sdlc: docs/process/asgard-operating-model.md`
+- `infiquetra-sdlc: docs/process/issue-types.md`
+- `home-lab: docs/engineering-journal/narratives/2026-05-30-mimir-orchestration-reconsideration.md`

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -10,6 +10,26 @@
 
 ## Shipped
 
+### Correct Asgard/Olympus model before SDLC handoff work  {#asgard-olympus-model-before-handoff}
+
+**SHIPPED 2026-05-30** (`infiquetra-sdlc` commit `5fe5d91`; plugin sync commit pending).
+
+**Summary.** Removed the stale assumption that Asgard feeds or promotes work into Mount Olympus
+before building the SDLC handoff flow.
+
+**What shipped.**
+- Canonical `infiquetra-sdlc` docs and schema now define Asgard and Olympus as sibling target
+  boards.
+- Cross-team movement is explicit operator transfer, route, clone, or link action only.
+- `sdlc-manager` now vendors the corrected schema, renders Asgard transfer notes, and no longer
+  warns that every Asgard draft has Olympus readiness gaps.
+- Prompt-alignment tests now reject the stale Asgard-to-Olympus promotion language in active
+  plugin surfaces.
+
+**Refs.**
+- Requirements: [Infiquetra Loop SDLC Handoff](../brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md).
+- Plan: [Add SDLC handoff flow](../plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md).
+
 ### Asgard/Olympus issue readiness workflow for `sdlc-manager`  {#asgard-olympus-issue-readiness}
 
 **SHIPPED 2026-05-30** (PR #159, commit `74cd372`).

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -12,7 +12,7 @@
 
 ### Correct Asgard/Olympus model before SDLC handoff work  {#asgard-olympus-model-before-handoff}
 
-**SHIPPED 2026-05-30** (`infiquetra-sdlc` commit `5fe5d91`; plugin sync commit pending).
+**SHIPPED 2026-05-30** (`infiquetra-sdlc` commit `5fe5d91`; plugin sync commit `90956a4`).
 
 **Summary.** Removed the stale assumption that Asgard feeds or promotes work into Mount Olympus
 before building the SDLC handoff flow.

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-05-30
 
-### SDLC handoff issue artifacts belong to `sdlc-manager` (commit pending)  {#sdlc-handoff-ownership-boundary}
+### SDLC handoff issue artifacts belong to `sdlc-manager` (commit `2fc317e`)  {#sdlc-handoff-ownership-boundary}
 
 **Decision.** Put handoff issue drafting, source artifact resolution, handoff maturity metadata,
 prepared-draft sidecars, mutation plans, labels, board placement, and create-after-confirmation in

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,6 +24,33 @@
 
 ## 2026-05-30
 
+### SDLC handoff issue artifacts belong to `sdlc-manager` (commit pending)  {#sdlc-handoff-ownership-boundary}
+
+**Decision.** Put handoff issue drafting, source artifact resolution, handoff maturity metadata,
+prepared-draft sidecars, mutation plans, labels, board placement, and create-after-confirmation in
+`sdlc-manager`. Keep `infiquetra-loop` responsible for lifecycle context and future `/handoff`
+routing only.
+
+**Rejected alternatives.**
+- *Generate handoff issue bodies inside `infiquetra-loop`.* Rejected: it would duplicate SDLC
+  issue semantics and make two plugins responsible for labels, project fields, and readiness.
+- *Add a separate handoff artifact format.* Rejected: prepared issue drafts already provide the
+  markdown plus JSON sidecar boundary needed for review before mutation.
+- *Require recipient teams to have `infiquetra-loop` installed.* Rejected: handoff issues must be
+  self-contained for agent teams or humans working only from GitHub.
+
+**Rationale.** This keeps the lifecycle plugin thin at the exit point while centralizing SDLC
+mutation rules in the plugin that already owns issue readiness. The prepared draft remains useful
+without mutation, and `issue create-prepared` remains the single place where side effects are
+rendered and confirmed.
+
+**Revisit when.** Multiple non-SDLC destinations need the same handoff source resolver, or
+`infiquetra-loop` grows durable lifecycle state that cannot be represented cleanly in the
+prepared issue sidecar.
+
+**Refs.** Plan [Add SDLC handoff flow](../plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md);
+requirements [Infiquetra Loop SDLC Handoff](../brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md).
+
 ### Prepared issue workflow uses draft/sidecar boundary plus confirmed mutation (commit `74cd372`)  {#prepared-issue-workflow-boundary}
 
 **Decision.** Add `sdlc-manager issue prepare` and `issue create-prepared` as separate steps.

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -17,27 +17,6 @@
 
 ---
 
-## P0 - must ship before handoff implementation
-
-### Correct Asgard/Olympus model before SDLC handoff work  {#asgard-olympus-model-before-handoff}
-
-**Priority.** P0 (must ship before `/create-issue` + `/handoff` handoff implementation).
-
-**Effort.** Multi-day. Canonical SDLC docs/config update, synced `sdlc-manager` material update,
-prepared-issue wording/readiness/test updates, and follow-on implementation planning.
-
-**Worth it when.** Before planning or implementing the Infiquetra Loop to SDLC handoff flow.
-
-**Context.**
-- Requirements: [Infiquetra Loop SDLC Handoff](../brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md).
-- The stale model currently frames Asgard as a feeder or promotion lane for Mount Olympus. The
-  corrected model is that Asgard and Olympus are sibling target teams/boards; cross-team movement
-  is explicit operator action only.
-- The same plan should then implement `/create-issue`, `--prepare`/`--draft`, `--from` source
-  discovery, handoff maturity, and thin `/handoff` routing.
-
----
-
 ## P1 — urgent
 
 ### CI guard: assert plugin directories match marketplace.json entries  {#marketplace-ci-guard}

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -17,6 +17,27 @@
 
 ---
 
+## P0 - must ship before handoff implementation
+
+### Correct Asgard/Olympus model before SDLC handoff work  {#asgard-olympus-model-before-handoff}
+
+**Priority.** P0 (must ship before `/create-issue` + `/handoff` handoff implementation).
+
+**Effort.** Multi-day. Canonical SDLC docs/config update, synced `sdlc-manager` material update,
+prepared-issue wording/readiness/test updates, and follow-on implementation planning.
+
+**Worth it when.** Before planning or implementing the Infiquetra Loop to SDLC handoff flow.
+
+**Context.**
+- Requirements: [Infiquetra Loop SDLC Handoff](../brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md).
+- The stale model currently frames Asgard as a feeder or promotion lane for Mount Olympus. The
+  corrected model is that Asgard and Olympus are sibling target teams/boards; cross-team movement
+  is explicit operator action only.
+- The same plan should then implement `/create-issue`, `--prepare`/`--draft`, `--from` source
+  discovery, handoff maturity, and thin `/handoff` routing.
+
+---
+
 ## P1 — urgent
 
 ### CI guard: assert plugin directories match marketplace.json entries  {#marketplace-ci-guard}

--- a/docs/ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md
+++ b/docs/ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md
@@ -1,0 +1,469 @@
+# Ideation: Infiquetra Loop to SDLC Handoff
+
+**Date:** 2026-05-30
+
+**Focus:** Decide when lifecycle work should branch from local `infiquetra-loop` artifacts into an
+SDLC issue artifact owned by `sdlc-manager`, especially when another team such as Asgard or Mount
+Olympus will pick up the work.
+
+**Status:** Ready for brainstorm. This captures the handoff timing, command naming, and
+natural-language trigger decision surface. No command, issue, or remote mutation was created.
+
+## Current Thesis
+
+The useful product idea is not "make `/loop` create issues." The cleaner idea is a handoff boundary:
+when work is ready to leave the current human/session, `infiquetra-loop` can package durable
+context and route into an SDLC issue artifact, but `sdlc-manager` owns the issue artifact and all
+GitHub/project mutation.
+
+That boundary matters because the recipient may not have `infiquetra-loop` installed. The created
+issue should be useful on its own: full issue body, target board/team fields, readiness profile,
+links to source artifacts, and exact next action. It may include a small optional line for agents
+that do have `infiquetra-loop`, but the issue must not depend on that plugin to be executable.
+
+The operator-facing issue command should be named for the thing the user wants, not for the
+implementation phase. Prefer `/create-issue` with natural-language routing and flags such as
+`--prepare` or `--draft` over names like `/issue-handoff`, `/sdlc-handoff`, or
+`create-prepared`. "Prepared issue" can remain an internal artifact and CLI state, but it should
+not be the primary phrase users need to remember.
+
+Brainstorm decisions captured so far:
+
+- Explicit "create" language should build a mutation plan and create only after confirmation.
+- Explicit "prepare", "draft", or "do not create yet" language should stop at the draft/sidecar.
+- The canonical no-mutation flag is `--prepare`; `--draft` is an alias.
+- `/create-issue` should become the primary documented command; `/sdlc-create` remains as a
+  compatibility alias.
+- Handoff maturity should live in both the issue body and the JSON sidecar.
+- `/handoff` should infer maturity from the current artifact and ask only when uncertain.
+- V1 should include both `/create-issue` and a thin `/handoff` surface.
+- Asgard and Olympus are sibling target teams/boards, not stages in one funnel. Cross-team movement
+  is explicit human/operator action only.
+- The brainstorm requirements should include a P0 prerequisite to correct the stale
+  Asgard-to-Olympus promotion model in the canonical SDLC materials and synced `sdlc-manager`
+  references before implementing handoff behavior.
+- `/create-issue` should support explicit source artifacts through `--from`, and natural-language
+  prompts that imply an existing artifact should trigger repo-local artifact search before asking
+  the user for a path.
+
+## Grounding
+
+- `/plan` already accepts an issue, spec, or request. The command hint is `[issue, spec, or
+  request]`, and the plan skill starts by reading the issue, relevant docs, repository guidance, and
+  local code before planning.
+- `/work` accepts `[plan path or issue]`, but its skill says it is for an approved plan or resume
+  case. That implies `/work <issue>` is appropriate only when the issue already contains or links a
+  plan-grade execution contract.
+- `sdlc-manager` already owns the prepared issue boundary. `issue prepare` writes a markdown draft
+  plus JSON sidecar, and `issue create-prepared` re-runs readiness and shows a mutation plan before
+  issue creation.
+- `sdlc-manager` already distinguishes Asgard and Mount Olympus readiness profiles. Asgard can
+  accept shaping-quality issues; Olympus requires strict actionable fields, labels, safe status,
+  acceptance criteria, expected files, tests, and verification.
+- Asgard and Olympus should be treated as sibling target teams/boards for this command. Do not
+  imply an automatic Asgard-to-Olympus relationship. Asgard can carry work to completion; Olympus
+  can carry work to completion. Moving an issue between them, or creating a linked issue for the
+  other board, is an explicit human/operator action.
+- `sdlc-manager` already has `/sdlc-create`; this should become a compatibility or namespaced
+  alias if a clearer `/create-issue` command is added. The primary command should optimize for
+  natural operator language.
+- Current `infiquetra-sdlc` and vendored `sdlc-manager` materials still encode an older
+  Asgard-to-Olympus promotion model. That should be corrected before implementing the handoff
+  requirements so the new command does not inherit the stale team relationship.
+- The prior Mimir orchestration analysis points in the same direction: do not reimplement the
+  downstream team's execution substrate. Use the native board/card/issue mechanisms and add only
+  the source-context and readiness information the downstream team needs.
+
+## Domain Split
+
+### `sdlc-manager` Owns
+
+- The primary issue command, preferably `/create-issue`.
+- Backward-compatible or namespaced aliases such as `/sdlc-create`.
+- Draft/prepare behavior behind natural language or explicit flags:
+  - `/create-issue --prepare`
+  - `/create-issue --draft`
+  - "prepare an issue but do not create it yet"
+  - "turn this plan into an Olympus issue"
+- Explicit and inferred source artifact discovery:
+  - `/create-issue --from docs/brainstorms/router-requirements.md`
+  - "from the plan we just made"
+  - "from that brainstorm doc"
+  - "turn the current requirements into an issue"
+- Internal `issue prepare` and `issue create-prepared` mechanics.
+- Handoff maturity/readiness fields in the draft and sidecar.
+- Team-aware defaults:
+  - Asgard starts in `Shaping`.
+  - Mount Olympus starts in `Backlog`.
+  - Never auto-move prepared work to `Ready`.
+- The final issue body and mutation plan.
+
+### `infiquetra-loop` Owns
+
+- The lifecycle handoff prompt:
+  - "Are we carrying this forward here, or handing it off?"
+  - "Should this become an issue for another team?"
+  - "Do we stop at requirements, plan it here, or hand it to someone else?"
+- An optional `/handoff` command for the current lifecycle artifact.
+- Detecting lifecycle exit points during ideation, brainstorm, planning, review, work, retro, and
+  resume.
+- Packaging source artifacts into a clear handoff bundle:
+  - ideation doc
+  - brainstorm/requirements doc
+  - plan path
+  - doc-review artifact
+  - work-session summary
+  - PR or branch state
+  - checks and blockers
+- Asking whether to hand off when the current session should stop carrying the work directly.
+- Calling or pointing to `/create-issue` rather than creating issues itself.
+
+Avoid making `/handoff-plan` and `/handoff-requirements` the primary command surface. They are
+reasonable aliases or natural-language triggers, but a single `/handoff` can infer the current
+artifact type from context and ask only when ambiguous.
+
+## Planning Prerequisite
+
+The requirements for this work should explicitly include a prerequisite workstream:
+
+1. Correct the canonical Asgard/Olympus relationship in `infiquetra-sdlc`.
+2. Sync the corrected model into the vendored `sdlc-manager` plugin materials.
+3. Update `sdlc-manager` prepared-issue wording, readiness checks, and tests that still frame
+   Asgard as a feeder, promotion, or staging lane for Olympus.
+4. Only then implement `/create-issue`, `/handoff`, handoff maturity, and source-artifact packaging.
+
+This prerequisite belongs in the plan generated from the requirements, not merely in background
+notes. The plan should make it an early task group or precursor issue so the new handoff flow is
+built on the desired model:
+
+- Asgard and Olympus are sibling target teams/boards.
+- Asgard can carry work to completion.
+- Olympus can carry work to completion.
+- Moving or cloning work across teams is explicit human/operator action only.
+- Readiness can influence warnings and defaults, but it must not imply automatic promotion.
+
+## When To Handoff
+
+### 1. Raw Ideation
+
+Default: do not hand off yet.
+
+Use a handoff only when the target is Jeff Intent, Asgard Incubator, or an explicit exploration
+issue. The artifact is not implementation-ready. Suggested next action:
+
+```text
+If using infiquetra-loop: /brainstorm <issue>
+```
+
+or, if the issue is already a clear research/shaping prompt:
+
+```text
+If using infiquetra-loop: /plan <issue>
+```
+
+### 2. Post-Brainstorm / Post-Requirements
+
+This is the first natural handoff point.
+
+Use this for Asgard, Jeff, or any team that should plan the work later. The issue should be
+requirements-ready, not work-ready. It needs enough context for a recipient to understand the
+problem, constraints, non-goals, risks, and likely verification path, but it may still lack a final
+implementation plan.
+
+Suggested next action:
+
+```text
+If using infiquetra-loop: /plan <issue>
+```
+
+### 3. Post-Plan
+
+This is the best handoff point for Mount Olympus or another implementation team.
+
+Use this when the work has an approved plan or plan-grade issue body: acceptance criteria, likely
+files, tests, verification commands, review gates, deployment gates when relevant, and explicit
+non-goals. This is where `/work <issue>` becomes valid.
+
+Suggested next action:
+
+```text
+If using infiquetra-loop: /work <issue>
+```
+
+If the plan still needs review, use:
+
+```text
+If using infiquetra-loop: /doc-review <plan>, then /work <issue>
+```
+
+### 4. Mid-Work Pause Or Transfer
+
+Use this when the current session started execution but another session/team must resume.
+
+The issue must include the plan, current branch or PR, completed phases, checks run, blockers,
+remaining acceptance criteria, and any review status. This is not a fresh planning handoff; it is a
+resume handoff.
+
+Suggested next action:
+
+```text
+If using infiquetra-loop: /work <issue>
+```
+
+### 5. External Or Deferred Work
+
+Use this when the work should leave the current repo/session but is not ready for Asgard or
+Olympus execution.
+
+Targets include Jeff Intent, External/Deferred, context-update, exploration, or a repo engineering
+journal queue. The artifact should preserve context and a decision-needed state rather than
+pretending implementation is ready.
+
+### 6. Cross-Team Transfer
+
+Do not auto-offer cross-team transfer as part of normal handoff. If the human explicitly decides an
+Asgard issue belongs on Olympus, or an Olympus issue belongs on Asgard, treat that as a separate
+operator-directed action. The command should support it, but not infer it from readiness alone.
+
+Open prerequisite: align `infiquetra-sdlc` and `sdlc-manager` references that still describe Asgard
+as a feeder or staging lane for Olympus. The desired rule is: teams are target destinations; moving
+or cloning work across teams is an explicit operator decision.
+
+## Handoff Maturity Model
+
+The issue artifact should carry a small maturity marker so the recipient does not infer too much
+from the fact that an issue exists.
+
+| Maturity | Meaning | Likely target | Next action |
+|---|---|---|---|
+| `idea-ready` | Captured intent worth preserving, not shaped enough for planning. | Jeff Intent / Asgard Incubator | `/brainstorm <issue>` or manual shaping |
+| `requirements-ready` | Problem, constraints, risks, and desired outcome are clear. | Asgard / Jeff / later planner | `/plan <issue>` |
+| `plan-ready` | A plan-grade execution contract exists or is embedded. | Olympus / implementation agent | `/work <issue>` |
+| `resume-ready` | Work already started and has enough state to resume safely. | Current owner / implementation agent | `/work <issue>` |
+| `deferred-context` | Useful context, not current execution work. | External/Deferred / context-update | no automatic loop command |
+
+## Issue Artifact Expectations
+
+The artifact should be self-contained first and plugin-assisted second.
+
+Required:
+
+- target repo or surface
+- target team/board/project
+- issue type
+- handoff maturity
+- source artifacts and links
+- acceptance criteria or shaping criteria appropriate to maturity
+- risk and approval boundary
+- non-goals
+- verification or proof path
+- known blockers and open questions
+- suggested next action
+
+Optional:
+
+- `Using infiquetra-loop: /plan <issue>`
+- `Using infiquetra-loop: /work <issue>`
+- `Using infiquetra-loop: /loop <issue>` only when the target is Jeff/operator lifecycle routing.
+
+Do not suggest `/loop` to agent teams by default. `/loop` is a human lifecycle router, not the
+normal downstream execution entrypoint.
+
+## Command Naming Ideas
+
+### Recommended Primary SDLC Command: `/create-issue`
+
+This should be the operator-facing issue command in `sdlc-manager`.
+
+Examples:
+
+```text
+/create-issue
+/create-issue capability --repo infiquetra-claude-plugins
+/create-issue --team olympus --repo campps-mvp
+/create-issue --prepare --team asgard --from docs/brainstorms/router-requirements.md
+/create-issue --draft --team olympus --from docs/plans/router-plan.md
+/create-issue "turn this plan into an Olympus issue"
+/create-issue "prepare an Asgard issue from these notes, but don't create it yet"
+```
+
+Behavior:
+
+- Default to natural-language inference when the user supplies prose.
+- Support `--from` for explicit source artifacts such as ideation docs, brainstorm requirements,
+  plans, doc-review artifacts, work-session summaries, existing issue URLs, PR URLs, or branch
+  state notes.
+- When the user uses natural language that implies a source artifact exists, search likely local
+  artifact locations before asking for a path. Example phrases include "from the plan we just
+  made", "from that brainstorm", "from the requirements", "from the current issue", and "from the
+  work summary".
+- Present likely source matches when multiple artifacts fit the prompt; ask only after search
+  cannot find a confident single match.
+- Ask when repo, team, project, issue type, or maturity is ambiguous.
+- Use `--type`, `--team`, `--repo`, `--project`, and `--maturity` when the user wants absolute
+  control.
+- Treat `--prepare` and `--draft` as no-GitHub-mutation modes. They write the draft/sidecar and
+  stop.
+- Treat an explicit create intent as permission to run the confirmed creation flow, still showing
+  the mutation plan before side effects.
+
+This keeps the mental model simple: the user is always creating an issue. Sometimes they are
+creating only the draft first.
+
+### Recommended Loop Command: `/handoff`
+
+This should be an `infiquetra-loop` lifecycle command, not an issue system command.
+
+Examples:
+
+```text
+/handoff
+/handoff this plan to Olympus
+/handoff requirements to Asgard
+/handoff --team olympus --maturity plan-ready
+```
+
+Behavior:
+
+- Read the active lifecycle pointer or the provided artifact path.
+- Infer whether the source is ideation, requirements, plan, review, work-session, or resume state.
+- Ask whether the user is carrying the work forward locally or handing it to another team.
+- Package the source bundle and route to `/create-issue`.
+
+### Good Natural-Language Triggers
+
+These should activate `/create-issue` or `/handoff` without requiring slash-command precision:
+
+- "Create an issue for this."
+- "Turn this plan into an Olympus issue."
+- "Prepare an issue but don't create it yet."
+- "Draft an Asgard issue from these notes."
+- "This is ready to hand off."
+- "Hand this plan to Olympus."
+- "Hand the requirements to Asgard."
+- "We are stopping here; make the issue."
+- "Do not keep working this, file it for the team."
+- "Carry this forward here" should do the opposite: continue the local loop rather than create an
+  issue.
+
+### Names To Avoid As Primary Commands
+
+- `/issue-handoff` and `/sdlc-handoff`: too abstract and too focused on process mechanics.
+- `/create-prepared`, `/create-prepared-issue`, or `/issue-create-prepared`: describes the
+  implementation boundary, not the user's intent.
+- `/handoff-plan` and `/handoff-requirements`: useful as aliases or natural-language routes, but
+  too fragmented as the main surface.
+
+## Surviving Ideas
+
+### 1. Primary `/create-issue` command with prepare/draft modes
+
+Create one main issue command. It should infer issue type, target team, target repo, project, and
+maturity when the language makes them clear, and expose flags when the user wants to be absolute.
+Draft-only behavior should be expressed as `/create-issue --prepare`, `/create-issue --draft`, or
+natural language such as "prepare an issue but do not create it yet."
+
+**Why it matters:** The user wants to create an issue, not remember the internal prepare/create
+state machine. A single verb keeps the surface obvious while still preserving the safe draft-first
+boundary.
+
+### 2. Loop exit prompts at maturity boundaries, with `/handoff` as the manual trigger
+
+Teach `infiquetra-loop` to offer handoff at natural boundaries:
+
+- after ideation if the user wants to preserve intent
+- after brainstorm/requirements if another team should plan it
+- after plan/doc-review if another team should execute it
+- after interrupted work if another session should resume it
+
+**Why it matters:** This keeps `/loop` useful for humans without making it the only way to create a
+handoff artifact.
+
+The prompt language should be plain:
+
+```text
+Are we carrying this forward here, or handing it off?
+```
+
+### 3. Handoff maturity in the prepared issue sidecar
+
+Extend prepared issue metadata with an explicit maturity value and next-action hint. This is more
+important than the exact slash command name because it prevents premature `/work` or Olympus
+dispatch.
+
+**Why it matters:** "An issue exists" is too weak a signal. The downstream agent needs to know
+whether the issue is idea-ready, requirements-ready, plan-ready, resume-ready, or deferred context.
+
+### 4. Optional plugin next-action line
+
+Add a small optional line to the issue body:
+
+```text
+If using infiquetra-loop: /plan <issue>
+```
+
+or:
+
+```text
+If using infiquetra-loop: /work <issue>
+```
+
+**Why it matters:** It helps compatible sessions without making the issue depend on local plugin
+installation.
+
+## Rejected Or Deferred Ideas
+
+### Make `/loop` the only handoff surface
+
+Rejected. Handoff is a lifecycle exit in `/loop`, but it is also a standalone SDLC operation. The
+artifact belongs to `sdlc-manager`.
+
+### Make `/issue-handoff` or `/sdlc-handoff` the primary command
+
+Rejected for now. These names are accurate from a workflow architecture view, but they make the
+user think in process terms. `/create-issue` is closer to the operator's intent.
+
+### Suggest `/loop <issue>` to agent teams
+
+Reject as default behavior. `/loop` is for human/operator routing. Agent teams should receive an
+issue that says either plan it, work it, review it, or preserve it.
+
+### Require the target to have `infiquetra-loop`
+
+Rejected. The issue artifact must be executable from GitHub and normal SDLC surfaces. Plugin hints
+are optional convenience.
+
+### Route post-brainstorm directly to `/work`
+
+Rejected. Post-brainstorm output can be requirements-ready, but `/work` should require an approved
+plan or plan-grade issue.
+
+### Split the main surface into `/handoff-plan` and `/handoff-requirements`
+
+Defer as aliases only. These names are understandable, but they encode artifact type in command
+names. A context-aware `/handoff` should infer source type first and ask only when ambiguous.
+
+### Auto-promote Asgard work to Olympus when it becomes actionable
+
+Rejected. Asgard and Olympus are target teams, not maturity stages in a single funnel. Asgard can
+finish work itself. If the human wants to move or clone work onto Olympus, that should be an
+explicit action.
+
+## Brainstorm Resolution
+
+Resolved decisions:
+
+1. The explicit no-mutation flag is `--prepare`; `--draft` is an alias.
+2. `/create-issue` becomes the documented primary command; `/sdlc-create` remains a compatibility
+   alias.
+3. Handoff maturity appears in both the issue body and JSON sidecar.
+4. `/plan <issue>` creates a durable `docs/plans/` artifact and syncs a compact summary/link back
+   to the issue.
+5. Source artifacts are first-class through `--from`, and natural-language artifact references
+   trigger repo-local search before asking the operator for a path.
+6. Cross-team movement is explicit operator action only. Asgard and Olympus are sibling targets,
+   not stages in a single promotion funnel.
+
+Durable requirements:
+
+- `docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md`

--- a/docs/plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md
+++ b/docs/plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md
@@ -1,0 +1,689 @@
+---
+title: "feat: Add SDLC handoff flow"
+type: "feat"
+status: "active"
+date: "2026-05-30"
+origin: "docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md"
+---
+
+# feat: Add SDLC handoff flow
+
+## Summary
+
+Add a handoff path that lets durable `infiquetra-loop` artifacts become self-contained
+SDLC issue artifacts owned by `sdlc-manager`.
+
+The implementation must preserve the ownership boundary:
+
+- `infiquetra-loop` owns lifecycle state, active artifact selection, source-context
+  packaging, and "carry forward or hand off" prompts.
+- `sdlc-manager` owns issue drafting, readiness, sidecars, confirmation, GitHub mutation,
+  labels, board fields, and SDLC schema semantics.
+- The canonical SDLC model in `infiquetra-sdlc` must be corrected before the plugin surfaces
+  are extended, so the new handoff flow does not encode a stale Asgard to Olympus promotion
+  model.
+
+Target repositories:
+
+- Current repo: `infiquetra-claude-plugins`.
+- Sibling repo: `infiquetra-sdlc`. Paths prefixed with `infiquetra-sdlc:` are relative to
+  that repository root.
+
+This is an epic/parent plan. Individual implementation PRs should ship in the delivery slices
+below rather than as one oversized cross-repo change.
+
+Primary source:
+
+- Brainstorm requirements: [docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md](../brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md)
+
+Related context:
+
+- Ideation: [docs/ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md](../ideation/2026-05-30-infiquetra-loop-sdlc-handoff.md)
+- Local learning: prepared issue creation needs a reviewable artifact boundary before mutation.
+- Home-lab orchestration lesson: do not reimplement native issue and board primitives; add
+  source context and readiness around them.
+
+## Problem Frame
+
+The loop currently carries work naturally from ideation to brainstorm to plan to work when
+the same human or agent continues the thread. That breaks down when another team or agent
+team needs to pick up the work, especially if they do not have `infiquetra-loop` installed.
+
+The desired behavior is not a second lifecycle system. It is a clean handoff bridge:
+
+1. Discover the durable source artifact.
+2. Infer or ask for the handoff maturity.
+3. Prepare a self-contained SDLC issue artifact.
+4. Confirm before mutating GitHub.
+5. Let the recipient work the issue with or without `infiquetra-loop`.
+
+This plan also fixes a prerequisite model error: Asgard and Olympus are sibling execution
+targets, not a staged Asgard to Olympus funnel. Asgard can carry work to completion. Olympus
+can carry work to completion. Cross-team movement happens only when the human explicitly
+decides to move an issue.
+
+## Requirements
+
+R1. Correct the canonical Asgard/Olympus model first.
+
+- Active `infiquetra-sdlc` docs and schema must no longer imply that Asgard normally promotes
+  work to Olympus.
+- Asgard and Olympus must be described as sibling work targets with explicit, human-directed
+  transfer when needed.
+- Historical dated artifacts may remain historical unless they are reused as active guidance.
+
+R2. Sync the corrected model into `sdlc-manager`.
+
+- `sdlc-manager` schema, prepared issue body rendering, readiness warnings, command docs, skill
+  prompts, README, and tests must stop using default Asgard to Olympus promotion language.
+- Any remaining cross-team transfer wording must be neutral and explicit.
+
+R3. Make `/create-issue` the primary issue command.
+
+- Add `/create-issue` as the natural user-facing command for creating or preparing issues.
+- Keep `/sdlc-create` as a compatibility alias or compatibility command.
+- The command should infer the issue type when the user is natural-language casual and should
+  accept explicit flags when the user wants to be absolute.
+
+R4. Keep preparation and mutation separate.
+
+- `--prepare` is the canonical non-mutating mode.
+- `--draft` is an alias for `--prepare`.
+- Creating from a prepared artifact must still show a mutation plan and require confirmation.
+
+R5. Add source artifact input.
+
+- `--from <artifact-ref>` must read an explicit source artifact, including local path,
+  GitHub issue/PR URL, branch ref, or resume-state reference.
+- Natural language that implies an existing artifact, such as "from the brainstorm" or
+  "handoff the plan", must trigger deterministic repo-local artifact search before asking
+  the user for a path.
+- Ambiguous matches must be surfaced for user selection rather than guessed.
+
+R6. Capture handoff maturity.
+
+- The issue artifact must include enough maturity context for a recipient who does not have
+  `infiquetra-loop`.
+- Maturity must appear in both the issue body and the prepared issue sidecar.
+- Supported maturity values are `idea-ready`, `requirements-ready`, `plan-ready`,
+  `resume-ready`, and `deferred-context`.
+
+R7. Make issues self-contained but plugin-aware.
+
+- The body must include source summary, decision context, constraints, acceptance checks,
+  next action, and relevant links.
+- A short optional hint may say what to run when the recipient does have `infiquetra-loop`,
+  for example `/plan <issue>` or `/work <issue>`.
+- `/loop` must not be suggested for normal team handoff. It is a human lifecycle command, not
+  a recipient execution command.
+
+R8. Add a thin loop-side handoff command.
+
+- `/handoff` should find the current durable artifact, infer maturity, and route to
+  `sdlc-manager` issue preparation.
+- It must not own issue body templates or GitHub mutation.
+- It should ask only when the source artifact, maturity, target repository, target board, or
+  target team cannot be inferred with confidence.
+
+R9. Make `/plan <issue>` and `/work <issue>` first-class consumers of handoff issues.
+
+- `/plan <issue>` should recognize issue maturity and create or update a durable plan from
+  the issue.
+- `/work <issue>` should recognize when the issue is `plan-ready` or `resume-ready` and
+  proceed from the issue context.
+- When useful, these commands should sync compact status back to the issue without duplicating
+  the full plan or work log.
+
+R10. Add drift guards.
+
+- Tests must protect the new command names, preparation behavior, source discovery behavior,
+  maturity metadata, and corrected Asgard/Olympus language.
+- Validation must include a scoped stale-language scan so "promotion" survives only where it
+  means something other than Asgard to Olympus workflow movement.
+
+## Key Decisions
+
+D1. Correct source-of-truth SDLC first, plugin second.
+
+The plugin should not paper over stale canonical language. The first implementation unit
+updates active `infiquetra-sdlc` docs and schema so downstream `sdlc-manager` changes can
+sync from the corrected model.
+
+D2. Reuse the prepared issue artifact boundary.
+
+`sdlc-manager` already has prepared issue drafts, sidecars, readiness checks, mutation plans,
+and create-after-confirmation behavior. The handoff feature should extend that system rather
+than create a parallel issue artifact format.
+
+D3. Put artifact discovery in support code, not only prompt prose.
+
+Natural language can decide when to invoke discovery, but deterministic search and ambiguity
+handling belong in testable `sdlc-manager` support code.
+
+D4. Treat `/handoff` as a routing command.
+
+The loop plugin should own the user moment: "carry forward here or hand this to someone else?"
+It should then call the SDLC issue preparation path. It should not generate its own issue
+template or mutate GitHub directly.
+
+D5. Do not introduce implicit Asgard to Olympus promotion.
+
+Any cross-team transfer must be a user decision. The implementation must not ask whether an
+Asgard issue should become usable by Olympus, because all well-formed issues should be usable
+by any capable target team after the human chooses to route them there.
+
+D6. Avoid live board mutation in this feature unless explicitly approved.
+
+Docs and schema can rename or deprecate stale "Promotion Target" concepts, but changing live
+GitHub Project field names or moving cards is a separate operational action. If the live board
+still has a legacy field, document the compatibility mapping and queue the live migration.
+
+D7. Back natural slash-command flags with a deterministic command contract.
+
+`/create-issue --prepare` and `/create-issue --draft` can route through slash-command behavior,
+but `--from` and `--maturity` must land in testable `sdlc-manager` support code. Existing
+`issue prepare --source-file` behavior must remain compatible while the primary user-facing
+surface becomes `/create-issue --from`.
+
+## Technical Design
+
+### Flow
+
+```mermaid
+flowchart TD
+  A[Correct canonical SDLC model] --> B[Sync sdlc-manager schema and readiness]
+  B --> C[Add source artifact resolver]
+  B --> E[Add prepared issue maturity metadata]
+  C --> D[Add /create-issue primary command]
+  E --> D
+  D --> F[Add loop /handoff routing command]
+  F --> G[Teach /plan and /work to consume handoff issues]
+  G --> H[Add drift guards and journal updates]
+```
+
+### Handoff Preparation
+
+```mermaid
+flowchart TD
+  U[User asks to create or hand off issue] --> S{Source explicit?}
+  S -- yes --> R[Read --from artifact ref]
+  S -- no --> Q[Search durable lifecycle artifacts]
+  Q --> M{One confident match?}
+  M -- no --> C[Ask user to choose source]
+  M -- yes --> I[Infer maturity]
+  R --> I
+  C --> I
+  I --> T{Target and issue type clear?}
+  T -- no --> A[Ask focused clarification]
+  T -- yes --> P[Render prepared issue draft and sidecar]
+  A --> P
+  P --> V[Run readiness checks]
+  V --> K[Show mutation plan]
+  K --> X{Confirmed?}
+  X -- yes --> G[Create or update GitHub issue]
+  X -- no --> P
+```
+
+### Artifact Search Order
+
+The resolver should search likely durable lifecycle locations in priority order:
+
+1. Active loop state pointers under `.claude/infiquetra-loop/`, when present.
+2. `docs/plans/`
+3. `docs/brainstorms/`
+4. `docs/ideation/`
+5. `docs/reviews/`
+6. `docs/work-sessions/`
+7. Existing prepared issue drafts under `docs/sdlc-issue-drafts/`, if present.
+8. Current branch or PR/resume state when the source hint names work in progress.
+
+The resolver should prefer recent matching artifacts but must not silently choose between
+multiple plausible matches.
+
+## Implementation Units
+
+### U1. Correct Canonical SDLC Team Model
+
+Repository: `infiquetra-sdlc`
+
+Goal: remove active Asgard to Olympus promotion assumptions and replace them with sibling
+target-team semantics.
+
+Likely files:
+
+- `infiquetra-sdlc:config/sdlc-schema.json`
+- `infiquetra-sdlc:AGENTS.md`
+- `infiquetra-sdlc:CLAUDE.md`
+- `infiquetra-sdlc:README.md`
+- `infiquetra-sdlc:docs/process/asgard-operating-model.md`
+- `infiquetra-sdlc:docs/process/human-intent-intake.md`
+- `infiquetra-sdlc:docs/process/kanban-workflow.md`
+- `infiquetra-sdlc:docs/process/board-topology.md`
+- `infiquetra-sdlc:docs/process/issue-types.md`
+- `infiquetra-sdlc:docs/process/index.md`
+- `infiquetra-sdlc:docs/operations/team-registry.md`
+- `infiquetra-sdlc:docs/operations/operational-reference.md`
+- `infiquetra-sdlc:docs/engineering-journal/DECISIONS.md`
+- `infiquetra-sdlc:docs/engineering-journal/QUEUED.md`
+- `infiquetra-sdlc:docs/engineering-journal/ARCHIVE.md`
+
+Implementation notes:
+
+- Replace `asgard_to_olympus_rule` with a neutral transfer or target-selection rule.
+- Replace "Promotion Target" guidance with neutral routing or transfer guidance.
+- Update diagrams that show Asgard feeding Olympus as a default path.
+- Preserve any valid "promotion" language that refers to release promotion, environment
+  promotion, or unrelated knowledge promotion.
+- If a prior journal decision explicitly encoded the stale model, update it per the repo
+  journal rules and archive the superseded wording.
+
+Test scenarios:
+
+- The schema remains valid JSON.
+- Active docs describe Asgard and Olympus as sibling targets.
+- Active docs do not say Asgard work normally promotes to Olympus.
+- Any live-board field compatibility note is clearly described as legacy compatibility, not
+  the desired SDLC model.
+
+Verification outcomes:
+
+- Scoped stale-language scan finds no active default Asgard to Olympus promotion guidance.
+- The correction is understandable from the active docs without reading this plan.
+
+### U2. Sync `sdlc-manager` Schema And Readiness Wording
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: align plugin behavior with the corrected SDLC model.
+
+Likely files:
+
+- `plugins/sdlc-manager/config/sdlc-schema.json`
+- `plugins/sdlc-manager/scripts/sdlc_manager.py`
+- `plugins/sdlc-manager/tests/test_issue_prepare.py`
+- `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- `plugins/sdlc-manager/README.md`
+- `plugins/sdlc-manager/CHANGELOG.md`
+
+Implementation notes:
+
+- Remove default "Promotion gaps" sections from Asgard issue rendering.
+- Replace default Olympus readiness warnings with neutral handoff or routing checks.
+- Preserve explicit cross-team transfer support when the user names a target.
+- Avoid treating Olympus as the automatic next stage for Asgard issues.
+
+Test scenarios:
+
+- Preparing an Asgard issue does not emit `Promotion gaps`.
+- Readiness warnings do not mention Olympus unless the user explicitly selected Olympus or
+  supplied an Olympus-specific target.
+- The prompt-alignment test rejects stale Asgard to Olympus promotion language in active
+  command and skill docs.
+
+Verification outcomes:
+
+- Prepared Asgard issue bodies remain useful and complete.
+- Existing issue creation and prepared issue tests still pass after terminology changes.
+
+### U3. Add Handoff Maturity To Prepared Issue Artifacts
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: make prepared issues carry enough lifecycle state for a recipient without
+`infiquetra-loop`.
+
+Likely files:
+
+- `plugins/sdlc-manager/scripts/sdlc_manager.py`
+- `plugins/sdlc-manager/tests/test_issue_prepare.py`
+- `plugins/sdlc-manager/tests/test_issue_create_prepared.py`
+- `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+
+Implementation notes:
+
+- Extend the prepared issue model and sidecar with `handoff_maturity`.
+- Render a concise `Handoff maturity` section in the issue body.
+- Include the suggested next action, such as plan from issue or work from issue.
+- Add a handoff body-rendering contract that includes target repo/surface, team/board/project,
+  issue type, maturity, source links or excerpts, criteria appropriate to maturity, non-goals,
+  risks, blockers, open questions, and suggested next action.
+- Infer maturity from source artifact type when available:
+  - `docs/ideation/` -> `idea-ready`
+  - `docs/brainstorms/` -> `requirements-ready`
+  - `docs/plans/` -> `plan-ready`
+  - work-session, branch, PR, or resume-state source -> `resume-ready`
+  - explicit preserve/defer language -> `deferred-context`
+- Allow explicit user override.
+
+Test scenarios:
+
+- Prepared issue sidecar contains maturity metadata.
+- Issue body contains maturity and next-action text.
+- Issue body contains the required self-contained handoff sections.
+- Explicit maturity overrides inferred maturity.
+- Missing maturity is inferred from source path when possible.
+- `resume-ready` and `deferred-context` are accepted and rendered.
+
+Verification outcomes:
+
+- A prepared issue can be reviewed cold and the recipient can tell whether to plan, work,
+  or clarify.
+
+### U4. Implement Source Artifact Resolution
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: support explicit and natural-language source references before issue preparation.
+
+Likely files:
+
+- `plugins/sdlc-manager/scripts/sdlc_manager.py`
+- `plugins/sdlc-manager/tests/test_issue_source_artifacts.py`
+- `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+
+Implementation notes:
+
+- Add a small `SourceArtifact` model with type, path, URL, branch/ref, title, summary/content,
+  and inferred maturity.
+- Add `--from` support to the relevant prepare and create command paths, and keep
+  `--source-file` as a compatibility input.
+- For local paths, read the artifact content directly.
+- For GitHub issue and PR URLs, fetch title/body/description through the existing GitHub CLI
+  wrapper pattern where possible; if fetch fails, block readiness unless the operator accepts
+  a link-only draft.
+- For branch or resume-state sources, capture branch name, HEAD, upstream/PR reference when
+  discoverable, active loop pointer, checkpoint/work-session links, blockers, checks run, and
+  remaining criteria.
+- Add a search helper that accepts natural-language hints and searches durable lifecycle
+  locations.
+- Return "no match", "one match", or "ambiguous matches" explicitly.
+
+Test scenarios:
+
+- `--from docs/brainstorms/example.md` reads the source and infers requirements maturity.
+- Natural language "from the brainstorm" searches brainstorm artifacts.
+- Natural language "handoff the plan" searches plan artifacts.
+- `--from <issue-or-pr-url>` fetches enough content to prepare a self-contained draft or reports
+  a readiness blocker.
+- `--from <branch-or-resume-ref>` captures branch/resume context and infers `resume-ready`.
+- Ambiguous matches produce a deterministic list rather than selecting one.
+- Missing source gives a focused error with the searched locations.
+
+Verification outcomes:
+
+- The resolver is testable without relying on prompt behavior.
+- The issue preparation path can use the same resolver for `/create-issue` and `/handoff`.
+
+### U5. Add Primary `/create-issue` Command
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: make issue creation natural while preserving existing `sdlc-manager` semantics.
+
+Likely files:
+
+- `plugins/sdlc-manager/commands/create-issue.md`
+- `plugins/sdlc-manager/commands/sdlc-create.md`
+- `plugins/sdlc-manager/skills/sdlc-issues/SKILL.md`
+- `plugins/sdlc-manager/agents/sdlc-operator.md`
+- `plugins/sdlc-manager/README.md`
+- `plugins/sdlc-manager/CHANGELOG.md`
+- `plugins/sdlc-manager/.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+
+Implementation notes:
+
+- Add `/create-issue` as the primary command documentation and packaged command.
+- Keep `/sdlc-create` as a compatibility alias that points users to `/create-issue`.
+- Define the command contract from slash-command flags to deterministic implementation paths:
+  - `/create-issue --prepare` and `/create-issue --draft` route to non-mutating issue prepare.
+  - `/create-issue --from <artifact>` populates the source resolver.
+  - `/create-issue --maturity <value>` overrides inferred maturity.
+  - explicit create intent routes through prepared issue creation and confirmation.
+- Document natural-language examples:
+  - `/create-issue --prepare from the brainstorm for Asgard`
+  - `/create-issue --draft --from docs/plans/example.md`
+  - `/create-issue from this plan as a plan-ready issue`
+- Preserve the create-after-confirmation mutation plan for prepared drafts.
+- Update plugin metadata and marketplace entries if the repo convention requires feature
+  version bumps for new command surfaces.
+
+Test scenarios:
+
+- Prompt-alignment tests confirm `/create-issue` is documented as primary.
+- `/sdlc-create` remains discoverable as a compatibility command.
+- Slash-command prepare/draft/from/maturity inputs map to testable CLI or support-code behavior.
+- Prepared mode does not mutate GitHub.
+- Create mode from a prepared artifact requires confirmation.
+
+Verification outcomes:
+
+- Users can say "create an issue from the plan" without learning internal SDLC command names.
+- Existing users of `/sdlc-create` are not broken.
+
+### U6. Add Loop-Side `/handoff` Routing
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: give the loop a natural exit from lifecycle work into SDLC issue preparation.
+
+Likely files:
+
+- `plugins/infiquetra-loop/commands/handoff.md`
+- `plugins/infiquetra-loop/skills/handoff/SKILL.md`
+- `plugins/infiquetra-loop/skills/loop/SKILL.md`
+- `plugins/infiquetra-loop/skills/resume/SKILL.md`
+- `plugins/infiquetra-loop/README.md`
+- `plugins/infiquetra-loop/CHANGELOG.md`
+- `plugins/infiquetra-loop/.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `tests/test_infiquetra_loop_plugin.py`
+
+Implementation notes:
+
+- `/handoff` should inspect active loop state and durable artifacts, then invoke or instruct
+  the `sdlc-manager` `/create-issue --prepare` path.
+- Build a small loop handoff envelope before routing: selected source path or URL, active pointer,
+  lifecycle phase, inferred maturity, handoff reason, blockers/open questions, branch/PR or
+  checkpoint state when present, and suggested next command.
+- If multiple durable artifacts are plausible, ask the user to choose.
+- If the source artifact is clear but the target is unclear, ask only for the target.
+- If the target has `sdlc-manager` installed, the suggested next command may be
+  `/create-issue --prepare --from <source>`.
+- If the target may not have `sdlc-manager`, the prepared issue body still needs to be
+  sufficient on its own.
+- Do not embed SDLC issue templates in `infiquetra-loop`.
+
+Test scenarios:
+
+- The loop plugin packages a `handoff` command and skill.
+- Loop docs describe handoff as routing to `sdlc-manager`, not owning issue mutation.
+- Loop tests cover the handoff envelope fields and verify SDLC body rendering remains outside
+  `infiquetra-loop`.
+- Tests guard against `/handoff` suggesting `/loop` for recipient execution.
+
+Verification outcomes:
+
+- A user finishing brainstorm or planning can naturally branch into handoff without leaving
+  the lifecycle context.
+
+### U7. Teach `/plan <issue>` And `/work <issue>` Handoff Consumption
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: make handoff issues usable when the target also has `infiquetra-loop`.
+
+Likely files:
+
+- `plugins/infiquetra-loop/commands/plan.md`
+- `plugins/infiquetra-loop/commands/work.md`
+- `plugins/infiquetra-loop/skills/plan/SKILL.md`
+- `plugins/infiquetra-loop/skills/work/SKILL.md`
+- `plugins/infiquetra-loop/scripts/parse_issue.py`
+- `plugins/infiquetra-loop/scripts/issue_progress.py`
+- `tests/test_infiquetra_loop_plugin.py`
+
+Implementation notes:
+
+- Extend issue parsing to recognize handoff maturity and suggested next action.
+- `/plan <issue>` should create a durable plan when the issue is `requirements-ready` or
+  `idea-ready`.
+- `/work <issue>` should proceed when the issue is `plan-ready` or `resume-ready`, or when it
+  already links a plan-grade execution contract.
+- When a plan is created from an issue, sync a compact comment or status update back to the
+  issue; extend `issue_progress.py` minimally if the existing helper does not cover the event.
+- Do not duplicate full durable plan content into issue comments.
+
+Test scenarios:
+
+- Plan skill docs explicitly support `issue` input.
+- Work skill docs explicitly support `plan-ready` and `resume-ready` issue input.
+- Issue parsing handles maturity sections and missing maturity gracefully.
+- Progress rendering links a plan without pasting the entire plan.
+
+Verification outcomes:
+
+- A recipient can run `/plan <issue>` or `/work <issue>` based on the issue body hint.
+
+### U8. Add Drift Guards, Release Notes, And Journal Updates
+
+Repository: `infiquetra-claude-plugins`
+
+Goal: keep the feature from regressing and preserve the rationale for future agents.
+
+Likely files:
+
+- `plugins/sdlc-manager/tests/test_prompt_alignment.py`
+- `plugins/sdlc-manager/tests/test_issue_prepare.py`
+- `plugins/sdlc-manager/tests/test_issue_create_prepared.py`
+- `plugins/sdlc-manager/tests/test_issue_source_artifacts.py`
+- `tests/test_infiquetra_loop_plugin.py`
+- `plugins/sdlc-manager/CHANGELOG.md`
+- `plugins/infiquetra-loop/CHANGELOG.md`
+- `docs/engineering-journal/LEARNINGS.md`
+- `docs/engineering-journal/DECISIONS.md`
+- `docs/engineering-journal/QUEUED.md`
+- `docs/engineering-journal/ARCHIVE.md`
+
+Implementation notes:
+
+- Add a scoped stale-language assertion for active plugin docs.
+- Add changelog entries for `sdlc-manager` and `infiquetra-loop`.
+- Move the queued Asgard/Olympus prerequisite item to archive when it ships.
+- Add a decision entry for the handoff ownership boundary.
+- Add a learning if implementation exposes non-obvious command, packaging, or artifact
+  discovery behavior.
+
+Test scenarios:
+
+- Full relevant plugin test suite passes.
+- Active docs and prompts do not reintroduce default Asgard to Olympus promotion language.
+- New command docs are packaged and aligned with README examples.
+
+Verification outcomes:
+
+- The repo contains both behavior guards and a short durable rationale.
+
+## Sequencing
+
+1. U1 must happen first because it corrects the SDLC source of truth.
+2. U2 should happen immediately after U1 to sync `sdlc-manager` with the corrected model.
+3. U3 and U4 can be built together because maturity inference depends on source artifacts.
+4. U5 depends on U3 and U4 because `/create-issue` exposes those paths.
+5. U6 depends on U5 because `/handoff` should route to `/create-issue`.
+6. U7 depends on U3 because issue consumption needs maturity metadata.
+7. U8 runs throughout, with final journal and changelog updates after behavior is in place.
+
+## Delivery Slices
+
+Slice 1: canonical model correction.
+
+- Includes U1 and the `infiquetra-sdlc` validation outcomes.
+- Shippable on its own because it corrects source-of-truth guidance.
+
+Slice 2: SDLC handoff issue foundation.
+
+- Includes U2, U3, U4, and U5.
+- This is a foundation-only slice until `/handoff` exists; release notes should not claim the
+  natural lifecycle handoff moment is complete.
+
+Slice 3: user-facing lifecycle handoff.
+
+- Includes U6 plus the minimum U8 docs/tests/release updates.
+- This is the first slice that satisfies the product goal of handing off from loop lifecycle
+  boundaries.
+
+Slice 4: issue consumption by loop.
+
+- Includes U7 and remaining U8 validation.
+- This completes recipient-side `/plan <issue>` and `/work <issue>` behavior.
+
+## Validation Plan
+
+Minimum validation for `infiquetra-sdlc`:
+
+- Active SDLC schema remains valid JSON.
+- Scoped stale-language scan confirms active docs do not present Asgard as an Olympus intake
+  or promotion stage.
+- Active docs still explain how a human can explicitly route or transfer work between teams.
+
+Minimum validation for `infiquetra-claude-plugins`:
+
+- `sdlc-manager` issue preparation tests pass.
+- `sdlc-manager` prepared issue creation tests pass.
+- `sdlc-manager` prompt-alignment tests pass.
+- `infiquetra-loop` packaging and command tests pass.
+- Markdown diff check passes for changed docs.
+- Changelog and marketplace metadata are consistent with any version bumps.
+
+Manual acceptance examples:
+
+- `/create-issue --prepare from the brainstorm for Asgard` finds the brainstorm, prepares a
+  `requirements-ready` issue, and does not mutate GitHub.
+- `/create-issue --draft --from docs/plans/example.md` prepares a `plan-ready` issue and
+  writes maturity to the sidecar.
+- Creating from that prepared issue shows a mutation plan and waits for confirmation.
+- `/handoff` from an active brainstorm offers to prepare an issue rather than continue work
+  locally.
+- `/plan <issue>` can consume a `requirements-ready` handoff issue.
+- `/work <issue>` can consume a `plan-ready` or `resume-ready` handoff issue.
+- An Asgard issue body no longer says it needs Olympus promotion gaps.
+
+## Risks
+
+Risk: the live GitHub Project board may still have legacy field names.
+
+Mitigation: keep this feature to docs, config, prepared artifacts, command behavior, and tests.
+Queue or separately approve live board field mutation if needed.
+
+Risk: natural-language source search could choose the wrong artifact.
+
+Mitigation: return ambiguous matches instead of guessing. Prefer active loop pointers, then
+recent durable artifacts, and make the selected source visible in the prepared issue.
+
+Risk: issue bodies become too dependent on `infiquetra-loop` conventions.
+
+Mitigation: keep the issue self-contained first, with plugin hints as optional final guidance.
+
+Risk: the handoff command drifts into owning SDLC templates.
+
+Mitigation: tests and docs should state that `/handoff` routes to `sdlc-manager` issue
+preparation and does not mutate GitHub directly.
+
+## Non-Goals
+
+- Do not build a second lifecycle tracker inside `sdlc-manager`.
+- Do not make `/loop` a normal recipient instruction.
+- Do not auto-transfer Asgard work to Olympus.
+- Do not mutate live GitHub Project fields without a separately approved operational step.
+- Do not rewrite historical dated brainstorms or plans unless they are currently cited as
+  active guidance.
+
+## Open Items
+
+- Choose final neutral replacement wording for the legacy "Promotion Target" concept after
+  inspecting current live board compatibility needs.
+- Decide exact plugin version bump timing for the delivery slices once implementation PR
+  boundaries are chosen.

--- a/docs/plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md
+++ b/docs/plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add SDLC handoff flow"
 type: "feat"
-status: "active"
+status: "completed"
 date: "2026-05-30"
 origin: "docs/brainstorms/2026-05-30-infiquetra-loop-sdlc-handoff-requirements.md"
 ---

--- a/plugins/infiquetra-loop/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-loop/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "infiquetra-loop",
   "version": "0.1.0",
-  "description": "Infiquetra lifecycle workflow plugin for strategy, planning, work execution, review, QA, and resume.",
+  "description": "Infiquetra lifecycle workflow plugin for strategy, planning, SDLC handoff, work execution, review, QA, and resume.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
@@ -13,6 +13,7 @@
     "strategy",
     "ideation",
     "brainstorm",
+    "handoff",
     "doc-review",
     "code-review",
     "optimize",

--- a/plugins/infiquetra-loop/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-loop/.claude-plugin/plugin.json
@@ -17,7 +17,6 @@
     "doc-review",
     "code-review",
     "optimize",
-    "qa",
     "sdlc"
   ]
 }

--- a/plugins/infiquetra-loop/CHANGELOG.md
+++ b/plugins/infiquetra-loop/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `/handoff` to route durable lifecycle artifacts to `sdlc-manager` prepared issue drafts.
 - Add a thin handoff envelope helper that records source, maturity, target hints, blockers, open
   questions, and the `/create-issue --prepare` routing command without owning SDLC issue bodies.
+- Teach `/plan <issue>` and `/work <issue>` to consume handoff maturity and source context from
+  prepared SDLC issues.
 
 ## 0.1.0 - 2026-05-29
 

--- a/plugins/infiquetra-loop/CHANGELOG.md
+++ b/plugins/infiquetra-loop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add `/handoff` to route durable lifecycle artifacts to `sdlc-manager` prepared issue drafts.
+- Add a thin handoff envelope helper that records source, maturity, target hints, blockers, open
+  questions, and the `/create-issue --prepare` routing command without owning SDLC issue bodies.
+
 ## 0.1.0 - 2026-05-29
 
 - Add the Infiquetra lifecycle command set from office-hours through resume.

--- a/plugins/infiquetra-loop/README.md
+++ b/plugins/infiquetra-loop/README.md
@@ -8,6 +8,7 @@ Infiquetra lifecycle workflow plugin for day-to-day engineering work.
 - `/office-hours`, `/ideate`, and `/brainstorm` support early thinking.
 - `/strategy` maintains the root `STRATEGY.md`.
 - `/plan`, `/work`, `/qa`, `/retro`, and `/resume` run the durable work loop.
+- `/handoff` routes durable lifecycle artifacts to `sdlc-manager` prepared issue drafts.
 - `/founder-review` and `/ceo-review` review ambition, scope, and operator risk.
 - `/doc-review` reviews plans, requirements, and formal SDLC artifacts for implementation
   readiness.
@@ -35,6 +36,8 @@ Ignored local state belongs under `.claude/infiquetra-loop/`.
 - `infiquetra-deploy` owns deployment mutation.
 - `team-execution` stays independent and is offered when risk, size, or parallelism justify it.
 - `sdlc-manager` owns SDLC issue creation, issue comments, and board movement.
+- `infiquetra-loop` owns only the handoff envelope; `sdlc-manager` owns issue bodies, readiness,
+  sidecars, labels, project fields, and GitHub mutation.
 
 ## Deterministic Helpers
 
@@ -46,3 +49,4 @@ Ignored local state belongs under `.claude/infiquetra-loop/`.
 - `scripts/discover_subissues.py` discovers GitHub sub-issues through GraphQL.
 - `scripts/detect_deploy_strategy.py` classifies tag-promotion workflow coverage.
 - `scripts/issue_progress.py` renders issue comments, including doc-review status when present.
+- `scripts/handoff_envelope.py` builds the thin source envelope for `/handoff`.

--- a/plugins/infiquetra-loop/README.md
+++ b/plugins/infiquetra-loop/README.md
@@ -38,10 +38,13 @@ Ignored local state belongs under `.claude/infiquetra-loop/`.
 - `sdlc-manager` owns SDLC issue creation, issue comments, and board movement.
 - `infiquetra-loop` owns only the handoff envelope; `sdlc-manager` owns issue bodies, readiness,
   sidecars, labels, project fields, and GitHub mutation.
+- `/plan <issue>` consumes `idea-ready` and `requirements-ready` handoff issues.
+- `/work <issue>` consumes `plan-ready` and `resume-ready` handoff issues.
 
 ## Deterministic Helpers
 
-- `scripts/parse_issue.py` extracts ADR, acceptance-criteria, round, and risk hints.
+- `scripts/parse_issue.py` extracts ADR, acceptance-criteria, handoff maturity, source context,
+  round, and risk hints.
 - `scripts/scaffold_checkpoint.py` writes ignored resume checkpoints under
   `.claude/infiquetra-loop/`.
 - `scripts/find_inflight_work.py` ranks resumable loop state.

--- a/plugins/infiquetra-loop/commands/handoff.md
+++ b/plugins/infiquetra-loop/commands/handoff.md
@@ -1,0 +1,22 @@
+---
+name: handoff
+description: Prepare a lifecycle artifact for SDLC issue handoff through sdlc-manager
+argument-hint: "[source artifact, target team, or handoff notes]"
+---
+
+Route current lifecycle work to `sdlc-manager` issue preparation.
+
+## Instructions
+
+1. Load `infiquetra-loop/skills/handoff/SKILL.md`.
+2. Identify the source artifact from arguments, active loop state, or durable repo docs.
+3. Build a handoff envelope with `scripts/handoff_envelope.py`.
+4. If source, maturity, target repo, target team, or issue type is ambiguous, ask a focused
+   question before routing.
+5. Route to `/create-issue --prepare --from <source> --maturity <maturity>`.
+6. Do not generate an SDLC issue body in `infiquetra-loop`; `sdlc-manager` owns that artifact and
+   all GitHub mutation.
+
+Arguments provided to the command:
+
+`$ARGUMENTS`

--- a/plugins/infiquetra-loop/commands/plan.md
+++ b/plugins/infiquetra-loop/commands/plan.md
@@ -5,7 +5,8 @@ argument-hint: "[issue, spec, or request]"
 ---
 
 Load `infiquetra-loop/skills/plan/SKILL.md`. Store non-trivial plans under `docs/plans/` and
-record the current pointer under `.claude/infiquetra-loop/`.
+record the current pointer under `.claude/infiquetra-loop/`. When the argument is a handoff issue,
+use its `Handoff maturity` and `Source context` sections before planning.
 
 Arguments provided to the command:
 

--- a/plugins/infiquetra-loop/commands/work.md
+++ b/plugins/infiquetra-loop/commands/work.md
@@ -4,8 +4,9 @@ description: Execute an approved Infiquetra plan with checkpoints, issue updates
 argument-hint: "[plan path or issue]"
 ---
 
-Load `infiquetra-loop/skills/work/SKILL.md`. Execute from durable plan artifacts, update issue
-progress, write work-session summaries, and run risk-based test gates.
+Load `infiquetra-loop/skills/work/SKILL.md`. Execute from durable plan artifacts or handoff issues
+marked `plan-ready` or `resume-ready`, update issue progress, write work-session summaries, and
+run risk-based test gates.
 
 Arguments provided to the command:
 

--- a/plugins/infiquetra-loop/scripts/handoff_envelope.py
+++ b/plugins/infiquetra-loop/scripts/handoff_envelope.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Build a thin Infiquetra loop handoff envelope for sdlc-manager."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+STATE_DIR = Path(".claude/infiquetra-loop")
+SOURCE_DIRS = (
+    Path("docs/plans"),
+    Path("docs/brainstorms"),
+    Path("docs/ideation"),
+    Path("docs/reviews"),
+    Path("docs/work-sessions"),
+)
+
+
+def infer_maturity(source: str) -> str:
+    normalized = source.replace("\\", "/")
+    if "docs/ideation/" in normalized:
+        return "idea-ready"
+    if "docs/brainstorms/" in normalized:
+        return "requirements-ready"
+    if "docs/plans/" in normalized or "docs/reviews/" in normalized:
+        return "plan-ready"
+    if "docs/work-sessions/" in normalized or normalized.startswith("branch:"):
+        return "resume-ready"
+    return "requirements-ready"
+
+
+def infer_lifecycle_phase(source: str) -> str:
+    normalized = source.replace("\\", "/")
+    if "docs/ideation/" in normalized:
+        return "ideation"
+    if "docs/brainstorms/" in normalized:
+        return "brainstorm"
+    if "docs/plans/" in normalized:
+        return "plan"
+    if "docs/reviews/" in normalized:
+        return "review"
+    if "docs/work-sessions/" in normalized or normalized.startswith("branch:"):
+        return "work"
+    return "unknown"
+
+
+def read_state(root: Path) -> dict[str, object]:
+    state_path = root / STATE_DIR / "state.json"
+    if not state_path.exists():
+        return {}
+    try:
+        loaded = json.loads(state_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def discover_active_source(root: Path) -> str | None:
+    state = read_state(root)
+    current = state.get("current_work")
+    if isinstance(current, dict):
+        for key in ("plan_path", "work_session_path"):
+            value = current.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    candidates: list[Path] = []
+    for rel_dir in SOURCE_DIRS:
+        directory = root / rel_dir
+        if directory.exists():
+            candidates.extend(path for path in directory.rglob("*.md") if path.is_file())
+    if not candidates:
+        return None
+    latest = max(candidates, key=lambda path: path.stat().st_mtime)
+    return latest.relative_to(root).as_posix()
+
+
+def current_git_state(root: Path) -> dict[str, str]:
+    def run(args: list[str]) -> str:
+        result = subprocess.run(args, cwd=root, capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
+    branch = run(["git", "branch", "--show-current"])
+    head = run(["git", "rev-parse", "--short", "HEAD"])
+    return {"branch": branch, "head": head}
+
+
+def build_handoff_envelope(
+    source: str | None = None,
+    *,
+    target_team: str = "",
+    target_repo: str = "",
+    issue_type: str = "",
+    reason: str = "",
+    blockers: str = "",
+    open_questions: str = "",
+    root: Path | None = None,
+) -> dict[str, object]:
+    root = root or Path.cwd()
+    selected_source = source or discover_active_source(root)
+    if not selected_source:
+        raise RuntimeError("No handoff source found; provide --source or create a durable artifact")
+
+    maturity = infer_maturity(selected_source)
+    suggested_command = f"/create-issue --prepare --from {selected_source} --maturity {maturity}"
+    if target_team:
+        suggested_command += f" for {target_team}"
+    if target_repo:
+        suggested_command += f" in {target_repo}"
+
+    return {
+        "schema_version": "1.0",
+        "created_at": datetime.now(UTC).isoformat(),
+        "source": selected_source,
+        "lifecycle_phase": infer_lifecycle_phase(selected_source),
+        "handoff_maturity": maturity,
+        "handoff_reason": reason,
+        "target_team": target_team,
+        "target_repo": target_repo,
+        "issue_type": issue_type,
+        "blockers": blockers,
+        "open_questions": open_questions,
+        "suggested_command": suggested_command,
+        "loop_owner": "infiquetra-loop",
+        "issue_artifact_owner": "sdlc-manager",
+        "body_template_owner": "sdlc-manager",
+        "git": current_git_state(root),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", default=None)
+    parser.add_argument("--target-team", default="")
+    parser.add_argument("--target-repo", default="")
+    parser.add_argument("--issue-type", default="")
+    parser.add_argument("--reason", default="")
+    parser.add_argument("--blockers", default="")
+    parser.add_argument("--open-questions", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    envelope = build_handoff_envelope(
+        args.source,
+        target_team=args.target_team,
+        target_repo=args.target_repo,
+        issue_type=args.issue_type,
+        reason=args.reason,
+        blockers=args.blockers,
+        open_questions=args.open_questions,
+    )
+    print(json.dumps(envelope, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/infiquetra-loop/scripts/issue_progress.py
+++ b/plugins/infiquetra-loop/scripts/issue_progress.py
@@ -56,6 +56,9 @@ def render_issue_comment(
     doc_review_fixes: Sequence[str] | None = None,
     doc_review_findings: Sequence[str] | None = None,
     doc_review_override: str | None = None,
+    handoff_maturity: str | None = None,
+    handoff_source: str | None = None,
+    next_action: str | None = None,
     deploy_status: str | None = None,
     workflow_url: str | None = None,
     evidence_link: str | None = None,
@@ -72,6 +75,9 @@ def render_issue_comment(
         _line("PR", pr_url),
         _line("review status", review_status),
         _line("doc review artifact", doc_review_artifact),
+        _line("handoff maturity", handoff_maturity),
+        _line("handoff source", handoff_source),
+        _line("next action", next_action),
         _line(
             "doc review blocked",
             None if doc_review_blocked is None else ("yes" if doc_review_blocked else "no"),
@@ -97,6 +103,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--destination", required=True)
     parser.add_argument("--summary")
     parser.add_argument("--plan-path")
+    parser.add_argument("--handoff-maturity")
+    parser.add_argument("--handoff-source")
+    parser.add_argument("--next-action")
     return parser.parse_args(argv)
 
 
@@ -109,6 +118,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             destination=args.destination,
             summary=args.summary,
             plan_path=args.plan_path,
+            handoff_maturity=args.handoff_maturity,
+            handoff_source=args.handoff_source,
+            next_action=args.next_action,
         ),
         end="",
     )

--- a/plugins/infiquetra-loop/scripts/parse_issue.py
+++ b/plugins/infiquetra-loop/scripts/parse_issue.py
@@ -21,10 +21,66 @@ API_RE = re.compile(r"\b(endpoint|rest|openapi|api/|/api|handler|route|sdk|contr
 INFRA_RE = re.compile(r"\b(cdk|cloudformation|terraform|lambda|dynamodb|s3|vpc)\b")
 PRIVACY_RE = re.compile(r"\b(pii|gdpr|consent|retention|personal data|anonymize|hipaa)\b")
 REFACTOR_RE = re.compile(r"\b(refactor|dry|solid|complexity|technical debt|cleanup)\b")
+H3_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+HANDOFF_MATURITY_VALUES = {
+    "idea-ready",
+    "requirements-ready",
+    "plan-ready",
+    "resume-ready",
+    "deferred-context",
+}
 
 
 def unique_sorted_ints(values: Iterable[str]) -> list[int]:
     return sorted({int(value) for value in values})
+
+
+def split_h3_sections(body: str) -> dict[str, str]:
+    matches = list(H3_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        header = match.group(1).strip()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[header] = body[start:end].strip()
+    return sections
+
+
+def first_content_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip().strip("`")
+        if stripped:
+            return stripped
+    return ""
+
+
+def parse_source_context(text: str) -> dict[str, str]:
+    context: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- ") or ":" not in stripped:
+            continue
+        key, value = stripped[2:].split(":", 1)
+        context[key.strip().lower().replace(" ", "_")] = value.strip()
+    return context
+
+
+def extract_handoff(body: str) -> dict[str, object]:
+    sections = split_h3_sections(body)
+    maturity = first_content_line(sections.get("Handoff maturity", ""))
+    if maturity not in HANDOFF_MATURITY_VALUES:
+        maturity = ""
+    source_context = parse_source_context(sections.get("Source context", ""))
+    return {
+        "maturity": maturity,
+        "suggested_next_action": first_content_line(sections.get("Suggested next action", "")),
+        "source": source_context.get("source", ""),
+        "source_type": source_context.get("source_type", ""),
+        "source_title": source_context.get("source_title", ""),
+        "can_plan": maturity in {"idea-ready", "requirements-ready"},
+        "can_work": maturity in {"plan-ready", "resume-ready"},
+        "requires_clarification": maturity == "deferred-context",
+    }
 
 
 def extract(body: str) -> dict[str, object]:
@@ -32,6 +88,7 @@ def extract(body: str) -> dict[str, object]:
     acceptance = unique_sorted_ints(AC_RE.findall(body))
     rounds = unique_sorted_ints(ROUND_RE.findall(body))
     lowered = body.lower()
+    handoff = extract_handoff(body)
 
     test_name_parts: list[str] = []
     if adrs:
@@ -54,6 +111,7 @@ def extract(body: str) -> dict[str, object]:
             "has_privacy": bool(PRIVACY_RE.search(lowered)),
             "has_refactor": bool(REFACTOR_RE.search(lowered)),
         },
+        "handoff": handoff,
         "test_naming_pattern": test_naming_pattern,
         "first_line": body.splitlines()[0].strip()[:200] if body else "",
     }

--- a/plugins/infiquetra-loop/skills/handoff/SKILL.md
+++ b/plugins/infiquetra-loop/skills/handoff/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: handoff
+description: Route durable Infiquetra lifecycle artifacts into sdlc-manager prepared issue drafts.
+---
+
+# Handoff
+
+Use this when the user wants another team, agent team, or later session to pick up work from an
+Infiquetra lifecycle artifact.
+
+## Boundary
+
+`infiquetra-loop` owns the handoff moment:
+
+- select the durable source artifact or active pointer;
+- infer lifecycle phase and handoff maturity;
+- capture why the work is being handed off, blockers, open questions, target team, and target
+  repository when known;
+- route to `sdlc-manager`.
+
+`sdlc-manager` owns the issue artifact:
+
+- issue body sections;
+- prepared draft markdown and JSON sidecar;
+- readiness checks;
+- labels, project fields, board placement, and GitHub mutation;
+- create-after-confirmation mutation plan.
+
+Do not copy SDLC issue templates into this skill.
+
+## Workflow
+
+1. Prefer an explicit source path or URL from the command arguments.
+2. If no source is explicit, inspect `.claude/infiquetra-loop/state.json` and durable docs.
+3. Build the envelope:
+
+   ```bash
+   python3 plugins/infiquetra-loop/scripts/handoff_envelope.py \
+     --source docs/plans/example.md \
+     --target-team Asgard \
+     --target-repo infiquetra-claude-plugins
+   ```
+
+4. If the helper finds no source, ask for one.
+5. If multiple durable artifacts are plausible, ask the user to choose.
+6. Route with the envelope's `suggested_command`, shaped like
+   `/create-issue --prepare --from <source> --maturity <maturity>`.
+7. Review the prepared issue draft before mutation.
+8. Use `issue create-prepared` only after confirmation.
+
+## Maturity
+
+- `docs/ideation/` -> `idea-ready`
+- `docs/brainstorms/` -> `requirements-ready`
+- `docs/plans/` or `docs/reviews/` -> `plan-ready`
+- `docs/work-sessions/` or branch refs -> `resume-ready`
+- explicit preserve/defer language -> `deferred-context` when the user says execution should wait
+
+## Recipient Guidance
+
+Prepared issues must be self-contained for recipients without `infiquetra-loop`.
+
+When a recipient does have `infiquetra-loop`, the issue may suggest:
+
+- `/plan <issue>` for `idea-ready` or `requirements-ready`;
+- `/work <issue>` for `plan-ready` or `resume-ready`.
+
+Do not suggest `/loop` for normal team handoff.

--- a/plugins/infiquetra-loop/skills/loop/SKILL.md
+++ b/plugins/infiquetra-loop/skills/loop/SKILL.md
@@ -2,7 +2,8 @@
 name: loop
 description: |
   Infiquetra lifecycle router for strategy, ideation, planning, work execution, QA, issue
-  progress, engineering-journal updates, review, deployment handoff, retro, and resume.
+  progress, engineering-journal updates, review, SDLC handoff, deployment handoff, retro, and
+  resume.
 ---
 
 # Loop
@@ -22,6 +23,9 @@ clear:
 Use `scripts/lifecycle_state.py` for destination normalization and escalation decisions.
 Use `scripts/parse_issue.py` for ADR, acceptance-criteria, round, and risk hints when an issue
 body is available.
+
+When the lifecycle reaches a branch point, ask whether to carry the work forward in the current
+thread or hand it off. If handing off, route to `/handoff`.
 
 ## Durable Artifacts
 
@@ -43,6 +47,8 @@ pointers, raw checkpoint state, API caches, validator JSON, and resume scratch d
 ## SDLC Issue Behavior
 
 For non-trivial ad-hoc work, ask whether to file an SDLC issue first through `sdlc-manager`.
+For lifecycle artifacts that another team or session should pick up, use `/handoff` to prepare a
+source envelope and route to `sdlc-manager` `/create-issue --prepare`.
 If an issue exists, keep issue progress current:
 
 - Start comment: selected destination, plan link, and scope summary.
@@ -70,6 +76,8 @@ movement at Infiquetra SDLC phase boundaries.
 - Use `infiquetra-deploy` only when the selected destination includes deployment.
 - Offer or invoke `team-execution` for cross-repo, security, infra, large, deployment-sensitive,
   or high-parallelism work.
+- Use `/handoff` for SDLC issue handoff. `sdlc-manager` owns issue bodies, prepared drafts,
+  readiness, labels, board fields, and GitHub mutation.
 - Fall back cleanly when `infiquetra-deploy`, `team-execution`, or `sdlc-manager` is unavailable:
   explain the missing integration and continue with manual evidence where safe.
 

--- a/plugins/infiquetra-loop/skills/plan/SKILL.md
+++ b/plugins/infiquetra-loop/skills/plan/SKILL.md
@@ -10,11 +10,18 @@ Use this for multi-step work where chat history is not a reliable source of trut
 ## Workflow
 
 1. Read the issue, relevant docs, repository guidance, and local code before planning.
-2. Ask for destination if unknown: plan only, PR, merge, or nonprod deploy.
-3. Ask whether to file an SDLC issue first for non-trivial ad-hoc work.
-4. Write concise plans under `docs/plans/`.
-5. Include acceptance criteria, scope, files likely to change, checks, issue updates, review gates,
+2. If the input is an issue, run `scripts/parse_issue.py` and inspect the `handoff` object.
+3. For `idea-ready` or `requirements-ready` handoff issues, create or update a durable plan from
+   the issue and linked source context.
+4. For `plan-ready` or `resume-ready` handoff issues, tell the user `/work <issue>` is the more
+   direct consumer unless they explicitly want to re-plan.
+5. Ask for destination if unknown: plan only, PR, merge, or nonprod deploy.
+6. Ask whether to file an SDLC issue first for non-trivial ad-hoc work.
+7. Write concise plans under `docs/plans/`.
+8. Include acceptance criteria, scope, files likely to change, checks, issue updates, review gates,
    deploy gates when relevant, and resume notes.
-6. Offer `team-execution` when risk, size, or parallelism justify the cost.
+9. Comment compact progress back to the issue with plan path, handoff maturity, and source link
+   when an issue is available.
+10. Offer `team-execution` when risk, size, or parallelism justify the cost.
 
 Keep the plan decision-complete but short enough to maintain during execution.

--- a/plugins/infiquetra-loop/skills/resume/SKILL.md
+++ b/plugins/infiquetra-loop/skills/resume/SKILL.md
@@ -19,3 +19,5 @@ Use this when a session ended, context was lost, or the user asks to continue a 
 3. Reconstruct current phase, selected destination, blockers, checks run, and next step.
 4. Continue from the durable source of truth rather than chat memory alone.
 5. If evidence conflicts, prefer committed docs and issue state over raw local cache.
+6. If the user wants another team or later session to pick up the recovered work, route to
+   `/handoff` instead of continuing locally.

--- a/plugins/infiquetra-loop/skills/work/SKILL.md
+++ b/plugins/infiquetra-loop/skills/work/SKILL.md
@@ -10,18 +10,23 @@ Use this after a plan is approved or when resuming execution from a durable plan
 ## Workflow
 
 1. Load the plan and active issue or PR.
-2. Record the active pointer in `.claude/infiquetra-loop/`.
-3. When executing from a plan or requirements document, ask whether to run `/doc-review` first.
+2. If the input is an issue, run `scripts/parse_issue.py` and inspect the `handoff` object.
+3. Proceed directly from handoff issues marked `plan-ready` or `resume-ready` when the issue has
+   plan-grade execution context or linked source context.
+4. For `idea-ready` or `requirements-ready` handoff issues, route to `/plan <issue>` unless the
+   user explicitly overrides the missing plan step.
+5. Record the active pointer in `.claude/infiquetra-loop/`.
+6. When executing from a plan or requirements document, ask whether to run `/doc-review` first.
    If review runs and returns unresolved `P0` or `P1` findings, block execution unless the user
    explicitly overrides and provides a rationale.
-4. Execute one meaningful phase at a time.
-5. After each phase, write a concise summary under `docs/work-sessions/`.
-6. Comment issue progress through `sdlc-manager` with plan path, work-session path, commit SHA,
-   checks run, blockers, and any doc-review artifact, findings, block status, or override
-   rationale.
-7. Run hard test gates for behavior, security, infra, API, deployment, or data changes.
-8. Run `/code-review` before PR or shipping gates.
-9. If the destination includes nonprod deploy, hand off deployment mutation to `infiquetra-deploy`.
+7. Execute one meaningful phase at a time.
+8. After each phase, write a concise summary under `docs/work-sessions/`.
+9. Comment issue progress through `sdlc-manager` with plan path, work-session path, commit SHA,
+   checks run, blockers, handoff maturity/source, and any doc-review artifact, findings, block
+   status, or override rationale.
+10. Run hard test gates for behavior, security, infra, API, deployment, or data changes.
+11. Run `/code-review` before PR or shipping gates.
+12. If the destination includes nonprod deploy, hand off deployment mutation to `infiquetra-deploy`.
 
 Do not close or move the issue until acceptance criteria and the selected destination are satisfied.
 

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- Added `/create-issue` as the primary issue command surface, with `/sdlc-create` retained as a
+  compatibility alias.
+- Added prepared-issue handoff maturity metadata and source artifact resolution for local files,
+  GitHub issue/PR URLs, branch refs, and natural hints such as "from the brainstorm".
+
 ### Changed
 - Synced the vendored SDLC schema and Asgard prepared-issue readiness with the corrected
   Asgard/Olympus model: sibling target boards with explicit cross-team transfer, not an

--- a/plugins/sdlc-manager/CHANGELOG.md
+++ b/plugins/sdlc-manager/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+- Synced the vendored SDLC schema and Asgard prepared-issue readiness with the corrected
+  Asgard/Olympus model: sibling target boards with explicit cross-team transfer, not an
+  implied Asgard-to-Olympus promotion path.
+
 ## [1.6.0] — 2026-05-30
 
 ### Added
@@ -11,7 +16,7 @@
   confirmation, repair missing labels/templates, add issues to the requested project, set safe
   starting status, and record the created issue back onto the draft.
 - Added Asgard and Olympus readiness profiles. Asgard accepts shaping-quality drafts with mode,
-  constraints, risk, and promotion gaps; Olympus requires the strict actionable card body,
+  constraints, risk, and transfer notes; Olympus requires the strict actionable card body,
   expected labels, project presence, author-visible risk, and safe `Backlog` status.
 - Added mocked tests for blocked create, declined confirmation, direct create, missing
   labels/templates, missing mapping PR stop, and mapping override creation.

--- a/plugins/sdlc-manager/README.md
+++ b/plugins/sdlc-manager/README.md
@@ -7,7 +7,7 @@ SDLC management for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. 
 All operations run locally via the `gh` CLI, providing:
 
 - **Project board operations** — view, move, add, archive, WIP analysis, standup prep across Jeff Intent, Asgard, and Olympus
-- **Issue creation** — guided interactive creation plus prepared Asgard/Olympus issue drafts with readiness checks and confirmed creation
+- **Issue creation** — primary `/create-issue` command plus prepared Asgard/Olympus handoff drafts with readiness checks, source artifact resolution, and confirmed creation
 - **Label management** — deploy, audit, sync initiative/objective fields, auto-label rules
 - **Flow metrics** — cycle time, throughput, WIP age using GitHub timeline events
 - **Rollout tracking** — gap analysis and full SDLC deployment to any Infiquetra repo
@@ -52,22 +52,25 @@ python3 $SCRIPT issue prepare \
   --project mount-olympus \
   --risk medium \
   --title "Router prepared issue workflow" \
-  "Add the prepared issue workflow described in the design notes."
+  --from docs/plans/example.md \
+  --maturity plan-ready
 
 python3 $SCRIPT issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 ```
 
-Prepared drafts are written under `docs/sdlc-issue-drafts/` with a JSON sidecar. Creation renders a
-mutation plan before side effects, repairs missing labels/templates after confirmation, opens a
-mapping PR when the repo is not mapped to the requested project, and starts issues in safe statuses:
-Asgard `Shaping`, Mount Olympus `Backlog`.
+Prepared drafts are written under `docs/sdlc-issue-drafts/` with a JSON sidecar. The sidecar
+includes handoff maturity and source artifact metadata when available. Creation renders a mutation
+plan before side effects, repairs missing labels/templates after confirmation, opens a mapping PR
+when the repo is not mapped to the requested project, and starts issues in safe statuses: Asgard
+`Shaping`, Mount Olympus `Backlog`.
 
 ## Slash Commands
 
 | Command | Description |
 |---------|-------------|
 | `/sdlc-board [mount-olympus]` | Quick board status with WIP check |
-| `/sdlc-create [type] [--repo repo]` | Interactive issue creation |
+| `/create-issue [type] [--repo repo] [--prepare|--draft] [--from artifact]` | Primary issue creation and prepared handoff |
+| `/sdlc-create [type] [--repo repo]` | Compatibility alias for `/create-issue` |
 | `/sdlc-triage repo#number` | Triage existing issue |
 | `/sdlc-metrics [project] [--type metric]` | Flow metrics dashboard |
 
@@ -244,7 +247,7 @@ python3 $SCRIPT flow validate-card --repo campps-mvp --number 42
 ### Prepared Issue Workflow
 
 ```bash
-# Draft from source text without GitHub mutation
+# Draft from a source artifact without GitHub mutation
 python3 $SCRIPT issue prepare \
     --repo hermes-claude-code-router \
     --type capability \
@@ -252,7 +255,8 @@ python3 $SCRIPT issue prepare \
     --project mount-olympus \
     --risk medium \
     --title "Prepared issue workflow" \
-    "Create issue drafts that pass Olympus readiness before mutation."
+    --from docs/brainstorms/example.md \
+    --maturity requirements-ready
 
 # Create after reviewing the markdown draft and sidecar
 python3 $SCRIPT issue create-prepared docs/sdlc-issue-drafts/<draft>.md

--- a/plugins/sdlc-manager/agents/sdlc-operator.md
+++ b/plugins/sdlc-manager/agents/sdlc-operator.md
@@ -96,8 +96,9 @@ You are deeply familiar with the Infiquetra SDLC process as documented in the
 **Subcommand groups** (full list: `sdlc_manager.py --help`):
 - `board {view,add,move,archive,wip,standup,discover-fields}` — project board operations
 - `issue create` — sub-issue-first interactive issue creation (Phase C; see "Issue creation flow" below)
-- `issue prepare` / `issue create-prepared` — source-text to reviewed Asgard/Olympus issue draft,
-  then confirmed creation with readiness checks and repo prerequisite repair
+- `issue prepare` / `issue create-prepared` — source text or source artifact to reviewed
+  Asgard/Olympus issue draft, then confirmed creation with readiness checks, handoff maturity,
+  and repo prerequisite repair
 - `flow {set-field,field-options,discover-project,link-sub-issue,verify-label,validate-card}` —
   operator-facing GraphQL/REST helpers (Phase C minimum-viable). **`flow set-field` failure modes**:
   if the field doesn't exist on the project, raises `RuntimeError` with the available field list +
@@ -158,8 +159,8 @@ light up automatically.
 ### Prepared Asgard/Olympus Issue Creation
 
 Use this path when the user says "create an Olympus issue from this text", "create an Asgard issue
-from these notes", or provides rough queue/source text that should become an issue only after
-review.
+from these notes", "create an issue from the brainstorm", "handoff the plan", or provides rough
+queue/source text that should become an issue only after review.
 
 ```bash
 python3 "$SCRIPT" issue prepare \
@@ -170,16 +171,22 @@ python3 "$SCRIPT" issue prepare \
     --risk <low|medium|high> \
     --mode "Rapid Action" \
     --title "..." \
-    "source text..."
+    --from docs/plans/example.md \
+    --maturity plan-ready
 
 python3 "$SCRIPT" issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 ```
 
 Prepared drafts are durable markdown files with JSON sidecars under `docs/sdlc-issue-drafts/`.
-`issue create-prepared` re-runs readiness, renders every side effect before mutation, repairs
-missing labels/templates after confirmation, opens a mapping PR for unmapped repos, and starts new
-cards in safe statuses: Asgard `Shaping`, Olympus `Backlog`. If team or project is ambiguous,
-ask the operator; do not guess or bypass this path with direct `gh issue create`.
+`issue prepare --from` accepts local paths, GitHub issue/PR URLs, branch refs, and natural search
+hints such as "from the brainstorm" or "handoff the plan". Prepared drafts include
+`handoff_maturity` and source metadata so the receiving team can execute without
+`infiquetra-loop`. `issue create-prepared` re-runs readiness, renders every side effect before
+mutation, repairs missing labels/templates after confirmation, opens a mapping PR for unmapped
+repos, and starts new cards in safe statuses: Asgard `Shaping`, Olympus `Backlog`. If team,
+project, or source artifact is ambiguous, ask the operator; do not guess or bypass this path with
+direct `gh issue create`. Suggest `/plan <issue>` or `/work <issue>` only as optional
+`infiquetra-loop` follow-up commands; do not suggest `/loop` for team recipients.
 
 For batch issue creation from a blueprint, prefer the manual lifecycle below over the
 interactive flow:

--- a/plugins/sdlc-manager/commands/create-issue.md
+++ b/plugins/sdlc-manager/commands/create-issue.md
@@ -1,0 +1,73 @@
+---
+name: create-issue
+description: Primary SDLC issue creation and prepared handoff command with source artifact support
+---
+
+Create or prepare an SDLC issue in any Infiquetra repository. This is the primary user-facing
+issue command; `/sdlc-create` remains a compatibility alias.
+
+## Usage
+
+```
+/create-issue [type] [--repo repository-name] [--prepare|--draft] [--from artifact] [--maturity value]
+```
+
+## Arguments
+
+- `type` — Optional issue type: `capability`, `enhancement`, `defect`, `exploration`, `context-update`, `objective`
+- `--repo` — Target repository name without the org prefix
+- `--prepare` — Write a reviewable prepared draft and JSON sidecar without mutating GitHub
+- `--draft` — Alias for `--prepare`
+- `--from` — Source artifact: local path, GitHub issue/PR URL, branch ref, or natural search hint
+- `--maturity` — Override inferred handoff maturity: `idea-ready`, `requirements-ready`, `plan-ready`, `resume-ready`, or `deferred-context`
+
+## What This Does
+
+1. Infers or asks for issue type, target repository, target team, and target project.
+2. Resolves explicit source artifacts from `--from`.
+3. Searches durable repo-local artifacts when natural language implies one, such as "from the brainstorm" or "handoff the plan".
+4. Infers handoff maturity from source location unless `--maturity` is provided.
+5. Uses `issue prepare` for non-mutating prepared drafts.
+6. Uses `issue create-prepared` for confirmed GitHub mutation from a prepared draft.
+7. Keeps `/loop` out of recipient guidance; handoff issues may suggest `/plan <issue>` or `/work <issue>`.
+
+## Examples
+
+```
+/create-issue --prepare from the brainstorm for Asgard
+/create-issue --draft --from docs/plans/2026-05-30-002-feat-sdlc-handoff-flow-plan.md
+/create-issue capability --repo infiquetra-claude-plugins --from docs/brainstorms/example.md
+/create-issue --prepare --from branch:current --maturity resume-ready
+```
+
+## Script Commands
+
+Prepare from a source artifact:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
+  issue prepare --repo infiquetra-claude-plugins --type capability \
+  --team olympus --project mount-olympus --risk medium \
+  --from docs/plans/example.md --maturity plan-ready
+```
+
+Create after review and confirmation:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
+  issue create-prepared docs/sdlc-issue-drafts/<draft>.md
+```
+
+## Instructions
+
+When the user invokes `/create-issue`:
+
+1. If the user says `--prepare`, `--draft`, "prepare", or "draft", route to `issue prepare`.
+2. If the user gives `--from <artifact>`, pass it through to `issue prepare --from <artifact>`.
+3. If the user says "from the brainstorm", "from the plan", "handoff the plan", or similar natural language, search durable lifecycle artifacts before asking for a path.
+4. If multiple artifacts match, ask the user to choose; do not guess.
+5. If the user gives `--maturity`, pass it through to `issue prepare --maturity`.
+6. If creating from an existing prepared draft, run `issue create-prepared`; show the mutation plan and require confirmation unless the user explicitly requested the confirmed mutation.
+7. If target team or project is ambiguous, ask. Do not guess between Asgard and Mount Olympus.
+8. Ensure the prepared issue is self-contained for a recipient without `infiquetra-loop`.
+9. If the recipient does have `infiquetra-loop`, suggest `/plan <issue>` for `idea-ready` or `requirements-ready`, and `/work <issue>` for `plan-ready` or `resume-ready`.

--- a/plugins/sdlc-manager/commands/sdlc-create.md
+++ b/plugins/sdlc-manager/commands/sdlc-create.md
@@ -1,29 +1,32 @@
 ---
 name: sdlc-create
-description: Interactive SDLC issue creation with canonical template guidance, Hermes labels, and project board integration
+description: Compatibility alias for /create-issue with canonical SDLC issue guidance
 ---
 
-Create a new SDLC issue in any Infiquetra repository with guided template selection, canonical
-field guidance, Hermes label verification, project board integration, and prepared-draft readiness
-checks when starting from source text.
+Compatibility command for `/create-issue`. Prefer `/create-issue` for new prepared handoff work,
+especially when using `--prepare`, `--draft`, `--from`, or `--maturity`.
 
 ## Usage
 
 ```
-/sdlc-create [type] [--repo repository-name]
+/sdlc-create [type] [--repo repository-name] [--prepare|--draft] [--from artifact] [--maturity value]
 ```
 
 ## Arguments
 
 - `type` — Optional issue type: `capability`, `enhancement`, `defect`, `exploration`, `context-update`, `objective`
 - `--repo` — Optional repository name (without org prefix)
+- `--prepare` — Write a prepared draft without mutating GitHub
+- `--draft` — Alias for `--prepare`
+- `--from` — Source artifact path, GitHub issue/PR URL, branch ref, or search hint
+- `--maturity` — Override inferred handoff maturity
 
 ## What This Does
 
 1. Guides issue type selection using the decision tree when type is not specified
 2. Asks for the target repository when repo is not specified
 3. Walks through canonical template fields for the selected type
-4. For source-text requests, prepares a reviewable draft before mutation
+4. For source-text or source-artifact requests, prepares a reviewable draft before mutation
 5. Creates the issue via `gh issue create` or `issue create-prepared`
 6. Verifies canonical Hermes labels
 7. Adds to project board when repo is mapped or explicitly targeted
@@ -86,6 +89,7 @@ has optional `Capability size (human planning hint)`.
 /sdlc-create exploration
 /sdlc-create "create an Olympus issue from this text for hermes-claude-code-router"
 /sdlc-create "create an Asgard issue from these notes"
+/sdlc-create --draft --from docs/plans/example.md --maturity plan-ready
 ```
 
 ## Script Command
@@ -108,7 +112,7 @@ Prepared-draft path:
 python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
   issue prepare --repo hermes-claude-code-router --type capability \
   --team olympus --project mount-olympus --risk medium \
-  --title "Prepared issue workflow" "source text..."
+  --title "Prepared issue workflow" --from docs/plans/example.md --maturity plan-ready
 
 python3 ~/.claude/plugins/cache/infiquetra-plugins/sdlc-manager/1.6.0/scripts/sdlc_manager.py \
   issue create-prepared docs/sdlc-issue-drafts/<draft>.md
@@ -121,18 +125,20 @@ When the user invokes `/sdlc-create`:
 1. If no type given, walk through the decision tree with the user.
 2. If no repo given, ask which Infiquetra repo this belongs to.
 3. Use the `sdlc-issues` skill to guide issue creation.
-4. If the user asks to create an Asgard or Olympus issue from text, notes, a queue entry, or other
-   rough source, use the prepared-draft path: `issue prepare`, review gaps with the user, then
-   `issue create-prepared` after final confirmation.
-5. For actionable Olympus types, confirm the body includes the exact required field headers and Hermes validator semantics.
-6. If team or project is ambiguous, ask. Do not guess between Asgard and Mount Olympus.
-7. After creation, verify labels:
+4. If the user asks to create an Asgard or Olympus issue from text, notes, a queue entry, existing
+   artifact, or other rough source, use the prepared-draft path: `issue prepare`, review gaps with
+   the user, then `issue create-prepared` after final confirmation.
+5. If the user implies a source artifact exists, such as "from the brainstorm" or "handoff the
+   plan", search durable lifecycle artifacts before asking for a path.
+6. For actionable Olympus types, confirm the body includes the exact required field headers and Hermes validator semantics.
+7. If team or project is ambiguous, ask. Do not guess between Asgard and Mount Olympus.
+8. After creation, verify labels:
    - Actionable: type label + `hermes-task` + `needs-plan`
    - Non-actionable: `hermes-not-actionable` plus the template-specific context labels
-8. Add to project board if repo is mapped or the prepared draft supplied an explicit project.
-9. Set project fields with `flow set-field` when requested.
-10. For Objectives, create a GitHub Milestone when the target workflow still uses milestones.
-11. Show a concise summary of everything created or applied.
+9. Add to project board if repo is mapped or the prepared draft supplied an explicit project.
+10. Set project fields with `flow set-field` when requested.
+11. For Objectives, create a GitHub Milestone when the target workflow still uses milestones.
+12. Show a concise summary of everything created or applied.
 
 If user provides partial info, infer the likely type and ask for confirmation. Example: "create a
 defect about the auth timeout" implies `defect`, but still confirm target repo and required fields.

--- a/plugins/sdlc-manager/config/sdlc-schema.json
+++ b/plugins/sdlc-manager/config/sdlc-schema.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2026-05-29",
+  "schema_version": "2026-05-30",
   "status": "active",
   "description": "Canonical Infiquetra SDLC board, team, routing, review, approval, and deployment-state schema. This file intentionally contains no live GitHub Projects field option IDs; tooling must resolve those from GitHub at runtime.",
   "teams": {
@@ -12,11 +12,12 @@
     },
     "asgard": {
       "kind": "agent_team",
-      "status": "active_defining",
-      "role": "Jeff-proximal rapid-action team biased toward reversible work, shaping, incubation, and mission-mode execution",
+      "status": "active",
+      "role": "Jeff-proximal rapid-action, incubation, and mission-mode team with an issue-backed feed and lightweight proof model",
       "board": "asgard",
       "modes": ["Rapid Action", "Incubator", "Mission"],
-      "review_model": "team_owned_review"
+      "review_model": "team_owned_review",
+      "operating_model_doc": "docs/process/asgard-operating-model.md"
     },
     "olympus": {
       "kind": "agent_team",
@@ -91,7 +92,7 @@
   "fields": {
     "common": ["Status", "Owner", "Priority", "Risk", "Initiative", "Objective"],
     "jeff_intent": ["Status", "Target Team", "Jeff Needed", "Context Pack", "Decision Needed"],
-    "asgard": ["Status", "Mode", "Jeff Needed", "Target Repository", "Risk", "Promotion Target"],
+    "asgard": ["Status", "Mode", "Jeff Needed", "Target Repository", "Risk", "Transfer Target"],
     "olympus": ["Status", "Assigned Agent", "Initiative", "Objective", "Capability Size", "Risk", "Deploy Target", "Deploy State", "Snapshot Version", "Promotion Pending", "Release Risk", "Last Deployment"]
   },
   "pause_states": {
@@ -145,7 +146,8 @@
   "team_routing": {
     "target_team_values": ["Asgard", "Olympus", "Jeff", "External/Deferred"],
     "jeff_intent_ready_rule": "A Ready Jeff Intent card must name one target team before moving to another board or workflow.",
-    "asgard_to_olympus_rule": "Asgard may seed Olympus when work is repeatable, engineering-pipeline-shaped, and has acceptance criteria clear enough for autonomous execution.",
+    "asgard_issue_feed_rule": "Asgard-bound work enters through Jeff Intent Target Team=Asgard, a direct issue added to Asgard, or a context/issue pack. Before Active, set Mode, target repository or surface, risk, approval state, proof path, and transfer target when a cross-team handoff is expected.",
+    "cross_team_transfer_rule": "Asgard and Olympus are sibling target boards. Cross-team movement happens only when an operator explicitly routes, transfers, clones, or links work to another board; readiness checks may warn about target fit but must not infer movement.",
     "default_pressure_valve": "Prefer project views over new boards unless scale, automation, or reporting needs justify a separate board."
   },
   "review_model": {

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -17,7 +17,8 @@ Usage:
     sdlc_manager.py board discover-fields --project mount-olympus
 
     sdlc_manager.py issue create --repo athena-service --type capability
-    sdlc_manager.py issue prepare --repo athena-service --type capability --team olympus --project mount-olympus "source text"
+    sdlc_manager.py issue prepare --repo athena-service --type capability --team olympus \
+      --project mount-olympus --from docs/plans/example.md
     sdlc_manager.py issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 
     sdlc_manager.py labels sync-fields --repo athena-service --number 42
@@ -2662,6 +2663,33 @@ _ISSUE_TYPE_LABELS = {
     "context-update": ["context-update", "documentation", "hermes-not-actionable"],
 }
 _PREPARED_DRAFT_DIR = Path("docs") / "sdlc-issue-drafts"
+_HANDOFF_MATURITY_CHOICES = (
+    "idea-ready",
+    "requirements-ready",
+    "plan-ready",
+    "resume-ready",
+    "deferred-context",
+)
+_SOURCE_SEARCH_DIRS = (
+    Path(".claude") / "infiquetra-loop",
+    Path("docs") / "plans",
+    Path("docs") / "brainstorms",
+    Path("docs") / "ideation",
+    Path("docs") / "reviews",
+    Path("docs") / "work-sessions",
+    Path("docs") / "sdlc-issue-drafts",
+)
+_SOURCE_HINT_DIRS = {
+    "plan": (Path("docs") / "plans",),
+    "brainstorm": (Path("docs") / "brainstorms",),
+    "requirements": (Path("docs") / "brainstorms",),
+    "idea": (Path("docs") / "ideation",),
+    "ideation": (Path("docs") / "ideation",),
+    "review": (Path("docs") / "reviews",),
+    "work": (Path("docs") / "work-sessions",),
+    "resume": (Path("docs") / "work-sessions", Path(".claude") / "infiquetra-loop"),
+    "draft": (Path("docs") / "sdlc-issue-drafts",),
+}
 
 _HERMES_ACTIONABLE_TYPES = frozenset(
     {
@@ -2697,6 +2725,18 @@ class PreparedReadiness:
 
 
 @dataclass
+class SourceArtifact:
+    ref: str
+    kind: str
+    title: str
+    content: str
+    inferred_maturity: str
+    path: str | None = None
+    url: str | None = None
+    branch: str | None = None
+
+
+@dataclass
 class PreparedIssue:
     title: str
     repo: str
@@ -2708,6 +2748,8 @@ class PreparedIssue:
     risk: str | None
     mode: str | None
     body: str
+    handoff_maturity: str | None = None
+    source_artifact: dict[str, Any] | None = None
     draft_path: str | None = None
     sidecar_path: str | None = None
 
@@ -2740,6 +2782,267 @@ def _normalize_label_list(raw: Any) -> list[str]:
     if isinstance(raw, str):
         return [item.strip() for item in raw.split(",") if item.strip()]
     return []
+
+
+def _source_artifact_payload(artifact: SourceArtifact | None) -> dict[str, Any] | None:
+    if not artifact:
+        return None
+    payload = asdict(artifact)
+    content = str(payload.pop("content", "")).strip()
+    if content:
+        payload["content_excerpt"] = content[:1200]
+    return payload
+
+
+def _markdown_title(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip() or fallback
+    return fallback
+
+
+def _infer_maturity_from_path(path: Path) -> str:
+    normalized = path.as_posix()
+    if "docs/ideation/" in normalized:
+        return "idea-ready"
+    if "docs/brainstorms/" in normalized:
+        return "requirements-ready"
+    if "docs/plans/" in normalized or "docs/reviews/" in normalized:
+        return "plan-ready"
+    if "docs/work-sessions/" in normalized or "docs/sdlc-issue-drafts/" in normalized:
+        return "resume-ready"
+    if ".claude/infiquetra-loop/" in normalized:
+        return "resume-ready"
+    return "requirements-ready"
+
+
+def _infer_kind_from_path(path: Path) -> str:
+    normalized = path.as_posix()
+    if "docs/ideation/" in normalized:
+        return "ideation"
+    if "docs/brainstorms/" in normalized:
+        return "brainstorm"
+    if "docs/plans/" in normalized:
+        return "plan"
+    if "docs/reviews/" in normalized:
+        return "review"
+    if "docs/work-sessions/" in normalized:
+        return "work-session"
+    if "docs/sdlc-issue-drafts/" in normalized:
+        return "prepared-draft"
+    if ".claude/infiquetra-loop/" in normalized:
+        return "loop-state"
+    return "local-file"
+
+
+def _source_from_local_path(path: Path, root: Path | None = None) -> SourceArtifact:
+    root = root or Path.cwd()
+    resolved = path.expanduser()
+    if not resolved.is_absolute():
+        resolved = root / resolved
+    if not resolved.exists() or not resolved.is_file():
+        raise RuntimeError(f"Source artifact path does not exist or is not a file: {path}")
+    content = resolved.read_text(encoding="utf-8")
+    try:
+        display_path = resolved.relative_to(root).as_posix()
+    except ValueError:
+        display_path = resolved.as_posix()
+    return SourceArtifact(
+        ref=display_path,
+        kind=_infer_kind_from_path(Path(display_path)),
+        title=_markdown_title(content, resolved.stem),
+        content=content,
+        inferred_maturity=_infer_maturity_from_path(Path(display_path)),
+        path=display_path,
+    )
+
+
+def _source_from_github_url(url: str) -> SourceArtifact:
+    match = re.match(
+        r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
+        r"(?P<kind>issues|pull)/(?P<number>\d+)(?:\b|/|$)",
+        url.strip(),
+    )
+    if not match:
+        raise RuntimeError(f"Unsupported GitHub source URL: {url}")
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+    number = match.group("number")
+    is_pr = match.group("kind") == "pull"
+    resource = "pr" if is_pr else "issue"
+    try:
+        raw = _gh(
+            [
+                resource,
+                "view",
+                number,
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "title,body,url",
+            ]
+        )
+        data = json.loads(raw)
+    except Exception as e:
+        raise RuntimeError(f"Could not fetch GitHub source artifact {url}: {e}") from e
+
+    title = str(data.get("title") or f"{repo}#{number}").strip()
+    body = str(data.get("body") or "").strip()
+    content = f"# {title}\n\n{body}".strip()
+    return SourceArtifact(
+        ref=f"{owner}/{repo}#{number}",
+        kind="github-pr" if is_pr else "github-issue",
+        title=title,
+        content=content,
+        inferred_maturity="resume-ready" if is_pr else "requirements-ready",
+        url=str(data.get("url") or url),
+    )
+
+
+def _source_from_branch_ref(ref: str, root: Path | None = None) -> SourceArtifact:
+    root = root or Path.cwd()
+    branch = ref.removeprefix("branch:").strip() or "HEAD"
+    if branch in {"current", "current-branch", "current branch"}:
+        branch = _run_git_command(["git", "branch", "--show-current"], root) or "HEAD"
+    head = _run_git_command(["git", "rev-parse", branch], root)
+    try:
+        upstream = _run_git_command(["git", "rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}"], root)
+    except RuntimeError:
+        upstream = "none"
+    status = _run_git_command(["git", "status", "--short", "--branch"], root)
+    content = (
+        f"# Branch handoff: {branch}\n\n"
+        f"- Branch: {branch}\n"
+        f"- HEAD: {head}\n"
+        f"- Upstream: {upstream}\n\n"
+        "## Working tree\n\n"
+        f"```text\n{status}\n```\n"
+    )
+    return SourceArtifact(
+        ref=f"branch:{branch}",
+        kind="branch",
+        title=f"Branch handoff: {branch}",
+        content=content,
+        inferred_maturity="resume-ready",
+        branch=branch,
+    )
+
+
+def _hint_search_dirs(hint: str) -> tuple[Path, ...]:
+    lower = hint.lower()
+    dirs: list[Path] = []
+    for word, paths in _SOURCE_HINT_DIRS.items():
+        if word in lower:
+            dirs.extend(paths)
+    if dirs:
+        return tuple(dict.fromkeys(dirs))
+    return _SOURCE_SEARCH_DIRS
+
+
+def _source_matches_hint(path: Path, text: str, hint: str) -> bool:
+    lower = hint.lower()
+    ignored_terms = set(_SOURCE_HINT_DIRS) | {
+        "from",
+        "the",
+        "this",
+        "that",
+        "issue",
+        "handoff",
+        "hand",
+        "off",
+        "create",
+        "using",
+        "use",
+        "based",
+        "for",
+    }
+    terms = [
+        term
+        for term in re.findall(r"[a-z0-9][a-z0-9-]{2,}", lower)
+        if term not in ignored_terms
+    ]
+    if not terms:
+        return True
+    haystack = f"{path.stem}\n{text[:2000]}".lower()
+    return all(term in haystack for term in terms[:4])
+
+
+def find_source_artifacts(hint: str, root: Path | None = None) -> list[SourceArtifact]:
+    root = root or Path.cwd()
+    matches: list[tuple[float, SourceArtifact]] = []
+    for rel_dir in _hint_search_dirs(hint):
+        search_dir = root / rel_dir
+        if not search_dir.exists():
+            continue
+        for candidate in search_dir.rglob("*.md"):
+            if not candidate.is_file():
+                continue
+            text = candidate.read_text(encoding="utf-8")
+            if _source_matches_hint(candidate, text, hint):
+                artifact = _source_from_local_path(candidate, root)
+                matches.append((candidate.stat().st_mtime, artifact))
+    matches.sort(key=lambda item: item[0], reverse=True)
+    return [artifact for _, artifact in matches]
+
+
+def resolve_source_artifact(ref_or_hint: str, root: Path | None = None) -> SourceArtifact:
+    root = root or Path.cwd()
+    ref = ref_or_hint.strip()
+    if not ref:
+        raise RuntimeError("Source artifact reference is empty")
+
+    path = Path(ref).expanduser()
+    if path.exists() or (not path.is_absolute() and (root / path).exists()):
+        return _source_from_local_path(path, root)
+    if ref.startswith("https://github.com/"):
+        return _source_from_github_url(ref)
+    if ref.startswith("branch:") or ref in {"current-branch", "current branch"}:
+        return _source_from_branch_ref(ref, root)
+
+    matches = find_source_artifacts(ref, root)
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        searched = ", ".join(str(path) for path in _hint_search_dirs(ref))
+        raise RuntimeError(f"No source artifact matched {ref!r}. Searched: {searched}")
+    choices = ", ".join(artifact.ref for artifact in matches[:10])
+    raise RuntimeError(f"Ambiguous source artifact hint {ref!r}. Matches: {choices}")
+
+
+def _natural_language_source_hint(text: str) -> str | None:
+    lower = text.lower()
+    if not any(word in lower for word in _SOURCE_HINT_DIRS):
+        return None
+    if re.search(r"\b(from|handoff|hand off|using|use|based on)\b", lower):
+        return text
+    return None
+
+
+def _resolve_prepare_source(
+    source_parts: list[str],
+    source_file: str | None,
+    from_ref: str | None,
+    root: Path | None = None,
+) -> tuple[str, SourceArtifact | None]:
+    root = root or Path.cwd()
+    if from_ref:
+        artifact = resolve_source_artifact(from_ref, root)
+        return artifact.content, artifact
+    if source_file:
+        artifact = _source_from_local_path(Path(source_file), root)
+        return artifact.content, artifact
+    if source_parts:
+        source = " ".join(source_parts)
+        natural_hint = _natural_language_source_hint(source)
+        if natural_hint:
+            artifact = resolve_source_artifact(natural_hint, root)
+            return artifact.content, artifact
+        return source, None
+    if not sys.stdin.isatty():
+        return sys.stdin.read(), None
+    raise RuntimeError("Provide source text as an argument, stdin, --source-file, or --from")
 
 
 def _parse_draft_frontmatter(text: str) -> tuple[dict[str, str], str]:
@@ -2785,14 +3088,66 @@ def _render_draft_markdown(issue: PreparedIssue) -> str:
         frontmatter.append(f"risk: {issue.risk}")
     if issue.mode:
         frontmatter.append(f"mode: {issue.mode}")
+    if issue.handoff_maturity:
+        frontmatter.append(f"handoff_maturity: {issue.handoff_maturity}")
     frontmatter.append("---")
     return "\n".join(frontmatter) + f"\n\n# {issue.title}\n\n{issue.body.rstrip()}\n"
 
 
-def _source_to_issue_body(source: str, team: str, repo: str, mode: str | None) -> str:
+def _suggested_next_action(handoff_maturity: str) -> str:
+    return {
+        "idea-ready": "Use `/plan <issue>` to shape requirements before implementation.",
+        "requirements-ready": "Use `/plan <issue>` to create an implementation plan.",
+        "plan-ready": "Use `/work <issue>` to execute from the plan-grade context.",
+        "resume-ready": "Use `/work <issue>` to resume from the captured work state.",
+        "deferred-context": "Clarify current intent before planning or working this issue.",
+    }[handoff_maturity]
+
+
+def _render_handoff_context(
+    handoff_maturity: str | None,
+    source_artifact: SourceArtifact | None,
+) -> str:
+    if not handoff_maturity and not source_artifact:
+        return ""
+    maturity = handoff_maturity or "requirements-ready"
+    lines = [
+        "### Handoff maturity",
+        maturity,
+        "",
+        "### Suggested next action",
+        _suggested_next_action(maturity),
+    ]
+    if source_artifact:
+        lines.extend(
+            [
+                "",
+                "### Source context",
+                f"- Source: {source_artifact.ref}",
+                f"- Source type: {source_artifact.kind}",
+                f"- Source title: {source_artifact.title}",
+            ]
+        )
+        if source_artifact.url:
+            lines.append(f"- Source URL: {source_artifact.url}")
+        if source_artifact.branch:
+            lines.append(f"- Source branch: {source_artifact.branch}")
+    return "\n\n" + "\n".join(lines) + "\n"
+
+
+def _source_to_issue_body(
+    source: str,
+    team: str,
+    repo: str,
+    mode: str | None,
+    handoff_maturity: str | None = None,
+    source_artifact: SourceArtifact | None = None,
+) -> str:
     stripped = source.strip()
     if "### " in stripped:
-        return stripped
+        if "### Handoff maturity" in stripped:
+            return stripped
+        return stripped + _render_handoff_context(handoff_maturity, source_artifact)
     if team == "asgard":
         return f"""### Intent
 {stripped}
@@ -2811,7 +3166,7 @@ TBD
 
 ### Transfer notes
 - [ ] Record any explicit cross-team transfer target, or leave as none.
-"""
+""" + _render_handoff_context(handoff_maturity, source_artifact)
     return f"""### Objective
 {stripped}
 
@@ -2829,7 +3184,7 @@ TBD
 
 ### Verification
 TBD
-"""
+""" + _render_handoff_context(handoff_maturity, source_artifact)
 
 
 def _safe_slug(text: str) -> str:
@@ -2877,6 +3232,10 @@ def _read_prepared_issue(draft_path: Path) -> PreparedIssue:
         risk=field("risk") or None,
         mode=field("mode") or None,
         body=body.strip(),
+        handoff_maturity=field("handoff_maturity") or None,
+        source_artifact=sidecar.get("source_artifact")
+        if isinstance(sidecar.get("source_artifact"), dict)
+        else None,
         draft_path=str(draft_path),
         sidecar_path=str(sidecar_path),
     )
@@ -2921,6 +3280,12 @@ def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
     missing_labels = sorted(expected_labels - set(issue.labels))
     if missing_labels:
         blocking.append(f"Missing expected labels: {missing_labels}")
+
+    if issue.handoff_maturity and issue.handoff_maturity not in _HANDOFF_MATURITY_CHOICES:
+        allowed = ", ".join(_HANDOFF_MATURITY_CHOICES)
+        blocking.append(f"Unknown handoff maturity {issue.handoff_maturity!r}; expected {allowed}")
+    elif not issue.handoff_maturity:
+        warnings.append("Missing handoff maturity metadata")
 
     sections = _split_sections(issue.body)
     if issue.team == "olympus":
@@ -2976,6 +3341,8 @@ def _sidecar_payload(
         "labels": issue.labels,
         "risk": issue.risk,
         "mode": issue.mode,
+        "handoff_maturity": issue.handoff_maturity,
+        "source_artifact": issue.source_artifact,
         "draft_path": issue.draft_path,
         "sidecar_path": issue.sidecar_path,
         "readiness": asdict(readiness),
@@ -2993,6 +3360,8 @@ def issue_prepare(
     status: str | None,
     risk: str | None,
     mode: str | None,
+    handoff_maturity: str | None = None,
+    source_artifact: SourceArtifact | None = None,
     draft_dir: Path | None = None,
     fmt: str = "text",
 ) -> Path:
@@ -3009,6 +3378,12 @@ def issue_prepare(
 
     safe_status = status or _TEAM_SAFE_STATUSES[team]
     draft_title = title or f"{issue_type}: {repo} {team} work"
+    maturity = handoff_maturity or (
+        source_artifact.inferred_maturity if source_artifact else "requirements-ready"
+    )
+    if maturity not in _HANDOFF_MATURITY_CHOICES:
+        allowed = ", ".join(_HANDOFF_MATURITY_CHOICES)
+        raise RuntimeError(f"Unknown handoff maturity {maturity!r}; expected {allowed}")
     issue = PreparedIssue(
         title=draft_title,
         repo=repo,
@@ -3019,7 +3394,9 @@ def issue_prepare(
         labels=_issue_expected_labels(issue_type),
         risk=risk,
         mode=mode,
-        body=_source_to_issue_body(source, team, repo, mode),
+        body=_source_to_issue_body(source, team, repo, mode, maturity, source_artifact),
+        handoff_maturity=maturity,
+        source_artifact=_source_artifact_payload(source_artifact),
     )
     readiness = _readiness_for_prepared_issue(issue)
 
@@ -3334,14 +3711,13 @@ def issue_create_prepared(
     return result
 
 
-def _read_prepare_source(source_parts: list[str], source_file: str | None) -> str:
-    if source_file:
-        return Path(source_file).read_text(encoding="utf-8")
-    if source_parts:
-        return " ".join(source_parts)
-    if not sys.stdin.isatty():
-        return sys.stdin.read()
-    raise RuntimeError("Provide source text as an argument, stdin, or --source-file")
+def _read_prepare_source(
+    source_parts: list[str],
+    source_file: str | None,
+    from_ref: str | None = None,
+) -> str:
+    source, _ = _resolve_prepare_source(source_parts, source_file, from_ref)
+    return source
 
 
 def _safe_input(prompt: str) -> str | None:
@@ -3968,6 +4344,19 @@ def main() -> None:
     issue_prepare_p.add_argument("--risk", default=None)
     issue_prepare_p.add_argument("--mode", default=None)
     issue_prepare_p.add_argument("--source-file", default=None)
+    issue_prepare_p.add_argument(
+        "--from",
+        dest="from_ref",
+        default=None,
+        help="Source artifact ref: local path, GitHub issue/PR URL, branch ref, or search hint",
+    )
+    issue_prepare_p.add_argument(
+        "--maturity",
+        dest="handoff_maturity",
+        default=None,
+        choices=_HANDOFF_MATURITY_CHOICES,
+        help="Override inferred handoff maturity",
+    )
     issue_prepare_p.add_argument("source", nargs="*")
 
     issue_create_prepared_p = issue_sp.add_parser(
@@ -4219,16 +4608,23 @@ def main() -> None:
                     skip_metadata=args.skip_metadata,
                 )
             elif args.action == "prepare":
+                source, source_artifact = _resolve_prepare_source(
+                    args.source,
+                    args.source_file,
+                    args.from_ref,
+                )
                 issue_prepare(
                     repo=args.repo,
                     issue_type=args.type,
                     team=args.team,
                     project=args.project,
-                    source=_read_prepare_source(args.source, args.source_file),
+                    source=source,
                     title=args.title,
                     status=args.status,
                     risk=args.risk,
                     mode=args.mode,
+                    handoff_maturity=args.handoff_maturity,
+                    source_artifact=source_artifact,
                     fmt=fmt,
                 )
             elif args.action == "create-prepared":

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -2809,8 +2809,8 @@ TBD
 ### Risk
 TBD
 
-### Promotion gaps
-- [ ] Identify any Olympus promotion gaps
+### Transfer notes
+- [ ] Record any explicit cross-team transfer target, or leave as none.
 """
     return f"""### Objective
 {stripped}
@@ -2942,7 +2942,7 @@ def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
             "Mode": "mode",
             "Constraints": "constraints",
             "Risk": "risk",
-            "Promotion gaps": "promotion gaps",
+            "Transfer notes": "transfer notes",
         }
         for header, label in required.items():
             text = sections.get(header, "").strip()
@@ -2952,9 +2952,6 @@ def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
             blocking.append("Missing Asgard mode metadata")
         if not issue.risk:
             blocking.append("Missing Asgard risk metadata")
-        olympus_valid, olympus_errors = validate_card_body(issue.body)
-        if not olympus_valid:
-            warnings.append("Olympus promotion gaps: " + "; ".join(olympus_errors))
 
     return PreparedReadiness(
         profile=issue.team,

--- a/plugins/sdlc-manager/scripts/sdlc_manager.py
+++ b/plugins/sdlc-manager/scripts/sdlc_manager.py
@@ -2908,7 +2908,9 @@ def _source_from_branch_ref(ref: str, root: Path | None = None) -> SourceArtifac
         branch = _run_git_command(["git", "branch", "--show-current"], root) or "HEAD"
     head = _run_git_command(["git", "rev-parse", branch], root)
     try:
-        upstream = _run_git_command(["git", "rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}"], root)
+        upstream = _run_git_command(
+            ["git", "rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}"], root
+        )
     except RuntimeError:
         upstream = "none"
     status = _run_git_command(["git", "status", "--short", "--branch"], root)
@@ -2959,9 +2961,7 @@ def _source_matches_hint(path: Path, text: str, hint: str) -> bool:
         "for",
     }
     terms = [
-        term
-        for term in re.findall(r"[a-z0-9][a-z0-9-]{2,}", lower)
-        if term not in ignored_terms
+        term for term in re.findall(r"[a-z0-9][a-z0-9-]{2,}", lower) if term not in ignored_terms
     ]
     if not terms:
         return True

--- a/plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md
+++ b/plugins/sdlc-manager/skills/sdlc-board/references/kanban-workflow.md
@@ -119,13 +119,13 @@ Ask:
 1. Capture on Jeff Intent as `Idea`.
 2. Shape until target team and context pack are clear.
 3. Move to `Ready`.
-4. Promote to Asgard, Olympus, Jeff, or External/Deferred based on target team.
+4. Route to Asgard, Olympus, Jeff, or External/Deferred based on target team.
 
-### Asgard Seeds Olympus
+### Explicit Cross-Team Transfer
 
-1. Incubate or act in Asgard.
-2. Verify the result or direction.
-3. Promote to Olympus only when the work is repeatable, well-shaped, and has acceptance criteria clear enough for autonomous execution.
+1. Treat Asgard and Olympus as sibling target boards, not stages in a default funnel.
+2. Keep work on the selected board unless an operator explicitly routes, transfers, clones, or links it elsewhere.
+3. When a transfer is requested, make the receiving issue self-contained: target repo or surface, acceptance criteria, verification, risk, approvals, and context links must be clear.
 
 ### Olympus Engineering Flow
 

--- a/plugins/sdlc-manager/skills/sdlc-issues/SKILL.md
+++ b/plugins/sdlc-manager/skills/sdlc-issues/SKILL.md
@@ -32,6 +32,7 @@ when_to_use: |
   - "set up the issues for the platform launch objective"
 
   Prepared issue creation:
+  - "create an issue from the brainstorm", "handoff the plan as an issue"
   - "create an Olympus issue from this text"
   - "create an Asgard issue from these notes"
   - "turn this queue entry into an issue for the router repo"
@@ -104,6 +105,11 @@ research, or documentation context.
 Use the prepared workflow when the user starts from rough text, notes, copied queue entries, or
 asks for an Asgard/Olympus issue that should be reviewed before mutation.
 
+`/create-issue` is the primary user-facing command for this path. `/sdlc-create` remains a
+compatibility alias. `--prepare` is the canonical non-mutating mode; `--draft` means the same
+thing. `--from` accepts a local path, GitHub issue/PR URL, branch ref, or natural search hint.
+`--maturity` overrides inferred handoff maturity.
+
 ```bash
 python3 sdlc_manager.py issue prepare \
   --repo hermes-claude-code-router \
@@ -112,7 +118,8 @@ python3 sdlc_manager.py issue prepare \
   --project mount-olympus \
   --risk medium \
   --title "Prepared issue workflow" \
-  "source text..."
+  --from docs/plans/example.md \
+  --maturity plan-ready
 
 python3 sdlc_manager.py issue create-prepared docs/sdlc-issue-drafts/<draft>.md
 ```
@@ -122,8 +129,28 @@ The prepared workflow writes a markdown draft and JSON sidecar under
 plan, asks for confirmation, repairs missing labels/templates after confirmation, opens a mapping
 PR when needed, and only then creates the issue.
 
+Prepared handoff drafts include `handoff_maturity` in the sidecar and a body section with the
+suggested next action. Maturity values are:
+
+- `idea-ready` -> suggest `/plan <issue>`.
+- `requirements-ready` -> suggest `/plan <issue>`.
+- `plan-ready` -> suggest `/work <issue>`.
+- `resume-ready` -> suggest `/work <issue>`.
+- `deferred-context` -> preserve context and clarify before execution.
+
+Source artifact resolution:
+
+- Explicit local path: `--from docs/brainstorms/example.md`.
+- GitHub issue or PR URL: fetched through `gh issue view` or `gh pr view`.
+- Branch ref: `--from branch:current` or `--from branch:<name>` captures resume context.
+- Natural language such as "from the brainstorm" or "handoff the plan" searches durable
+  lifecycle artifact directories before asking for a path.
+- Ambiguous matches must be shown to the user; do not pick one silently.
+
 Natural-language routing rules:
 
+- "Create an issue from the brainstorm" -> search `docs/brainstorms/`, prepare, then
+  create-prepared after review.
 - "Create an Olympus issue from this text" -> prepare with `--team olympus --project mount-olympus`,
   then create-prepared after review.
 - "Create an Asgard issue from this text" -> prepare with `--team asgard --project asgard`, then
@@ -131,6 +158,8 @@ Natural-language routing rules:
 - If team or project is ambiguous, ask. Do not guess.
 - Do not bypass prepared readiness checks with ad hoc `gh issue create` when the prompt asks to
   create from source text.
+- Do not suggest `/loop` to a team recipient. Use `/plan <issue>` or `/work <issue>` only when the
+  recipient has `infiquetra-loop`.
 
 Safe starting statuses:
 
@@ -293,6 +322,11 @@ still uses milestones for that repository.
 
 **"Create an exploration to research biometric SDK options"**
 -> `issue create --repo infiquetra-blueprint --type exploration`
+
+**"Create an issue from the plan"**
+-> Search `docs/plans/`; if one plan matches, prepare with
+`issue prepare --from <plan> --maturity plan-ready`. If multiple plans match, ask the user to
+choose.
 
 **"Create an Olympus issue from this text for the router repo"**
 -> Prepare an Olympus draft with `issue prepare --team olympus --project mount-olympus`, review

--- a/plugins/sdlc-manager/tests/test_issue_prepare.py
+++ b/plugins/sdlc-manager/tests/test_issue_prepare.py
@@ -50,8 +50,8 @@ Keep issue creation separate from draft review.
 ### Risk
 Low operational risk.
 
-### Promotion gaps
-- [ ] Add strict verification before Olympus promotion.
+### Transfer notes
+- [ ] No cross-team transfer requested.
 """
 
 
@@ -117,7 +117,7 @@ def test_prepare_asgard_accepts_shaping_quality_input(tmp_path) -> None:
 
     assert sidecar["state"] == "ready_to_create"
     assert sidecar["readiness"]["passed"] is True
-    assert any("Olympus promotion gaps" in warning for warning in sidecar["readiness"]["warnings"])
+    assert sidecar["readiness"]["warnings"] == []
 
 
 def test_ready_status_blocks_prepared_draft(tmp_path) -> None:

--- a/plugins/sdlc-manager/tests/test_issue_prepare.py
+++ b/plugins/sdlc-manager/tests/test_issue_prepare.py
@@ -76,6 +76,8 @@ def test_prepare_olympus_writes_ready_draft_and_sidecar(tmp_path) -> None:
     assert sidecar["repo"] == "hermes-claude-code-router"
     assert sidecar["readiness"]["passed"] is True
     assert sidecar["labels"] == ["capability", "hermes-task", "needs-plan"]
+    assert sidecar["handoff_maturity"] == "requirements-ready"
+    assert "### Handoff maturity" in draft.read_text()
 
 
 def test_prepare_olympus_blocks_missing_verification(tmp_path) -> None:
@@ -138,6 +140,29 @@ def test_ready_status_blocks_prepared_draft(tmp_path) -> None:
 
     assert sidecar["state"] == "blocked"
     assert "Prepared issues must not start in Ready" in sidecar["readiness"]["blocking_gaps"]
+
+
+def test_prepare_records_explicit_handoff_maturity(tmp_path) -> None:
+    draft = sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=OLYMPUS_BODY,
+        title="Plan handoff",
+        status=None,
+        risk="medium",
+        mode=None,
+        handoff_maturity="plan-ready",
+        draft_dir=tmp_path,
+    )
+
+    sidecar = json.loads(draft.with_suffix(".json").read_text())
+    body = draft.read_text()
+
+    assert sidecar["handoff_maturity"] == "plan-ready"
+    assert "### Handoff maturity\nplan-ready" in body
+    assert "Use `/work <issue>`" in body
 
 
 def test_non_default_status_blocks_prepared_draft(tmp_path) -> None:

--- a/plugins/sdlc-manager/tests/test_issue_source_artifacts.py
+++ b/plugins/sdlc-manager/tests/test_issue_source_artifacts.py
@@ -1,0 +1,114 @@
+"""Tests for prepared-issue source artifact resolution."""
+
+# ruff: noqa: E402,I001
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+def _write(root: Path, rel_path: str, text: str) -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def test_from_local_brainstorm_infers_requirements_maturity(tmp_path) -> None:
+    _write(
+        tmp_path,
+        "docs/brainstorms/example.md",
+        "# Example Brainstorm\n\nRequirements and constraints.",
+    )
+
+    artifact = sdlc_manager.resolve_source_artifact("docs/brainstorms/example.md", tmp_path)
+
+    assert artifact.kind == "brainstorm"
+    assert artifact.title == "Example Brainstorm"
+    assert artifact.inferred_maturity == "requirements-ready"
+    assert artifact.path == "docs/brainstorms/example.md"
+
+
+def test_natural_language_brainstorm_hint_resolves_single_match(tmp_path) -> None:
+    _write(tmp_path, "docs/brainstorms/feature.md", "# Feature\n\nDo the thing.")
+
+    source, artifact = sdlc_manager._resolve_prepare_source(
+        ["handoff", "from", "the", "brainstorm"],
+        source_file=None,
+        from_ref=None,
+        root=tmp_path,
+    )
+
+    assert artifact is not None
+    assert artifact.ref == "docs/brainstorms/feature.md"
+    assert artifact.inferred_maturity == "requirements-ready"
+    assert "Do the thing" in source
+
+
+def test_natural_language_plan_hint_reports_ambiguous_matches(tmp_path) -> None:
+    _write(tmp_path, "docs/plans/a.md", "# Plan A\n")
+    _write(tmp_path, "docs/plans/b.md", "# Plan B\n")
+
+    with pytest.raises(RuntimeError, match="Ambiguous source artifact hint"):
+        sdlc_manager.resolve_source_artifact("handoff the plan", tmp_path)
+
+
+def test_github_issue_url_fetches_title_body_and_url() -> None:
+    payload = {
+        "title": "Issue handoff",
+        "body": "Issue body",
+        "url": "https://github.com/infiquetra/home-lab/issues/42",
+    }
+
+    with patch.object(sdlc_manager, "_gh", return_value=json.dumps(payload)) as mock_gh:
+        artifact = sdlc_manager.resolve_source_artifact(
+            "https://github.com/infiquetra/home-lab/issues/42"
+        )
+
+    mock_gh.assert_called_once_with(
+        [
+            "issue",
+            "view",
+            "42",
+            "--repo",
+            "infiquetra/home-lab",
+            "--json",
+            "title,body,url",
+        ]
+    )
+    assert artifact.kind == "github-issue"
+    assert artifact.title == "Issue handoff"
+    assert artifact.inferred_maturity == "requirements-ready"
+    assert "Issue body" in artifact.content
+
+
+def test_branch_source_captures_resume_context(tmp_path) -> None:
+    def fake_git(args: list[str], cwd: Path) -> str:
+        assert cwd == tmp_path
+        if args[:2] == ["git", "rev-parse"] and args[-1] == "feature/test":
+            return "abc123"
+        if args[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return "origin/feature/test"
+        if args[:2] == ["git", "status"]:
+            return "## feature/test"
+        raise AssertionError(args)
+
+    with patch.object(sdlc_manager, "_run_git_command", side_effect=fake_git):
+        artifact = sdlc_manager.resolve_source_artifact("branch:feature/test", tmp_path)
+
+    assert artifact.kind == "branch"
+    assert artifact.branch == "feature/test"
+    assert artifact.inferred_maturity == "resume-ready"
+    assert "abc123" in artifact.content
+
+
+def test_missing_source_reports_searched_locations(tmp_path) -> None:
+    with pytest.raises(RuntimeError, match="Searched: docs/brainstorms"):
+        sdlc_manager.resolve_source_artifact("from the brainstorm", tmp_path)

--- a/plugins/sdlc-manager/tests/test_prompt_alignment.py
+++ b/plugins/sdlc-manager/tests/test_prompt_alignment.py
@@ -79,19 +79,32 @@ def test_label_docs_mark_legacy_auto_label_rules_as_fallback() -> None:
 
 def test_prepared_issue_guidance_routes_natural_language_creation() -> None:
     skill = _read(PLUGIN_ROOT / "skills/sdlc-issues/SKILL.md")
+    create_command = _read(PLUGIN_ROOT / "commands/create-issue.md")
     command = _read(PLUGIN_ROOT / "commands/sdlc-create.md")
     readme = _read(PLUGIN_ROOT / "README.md")
 
-    for text in (skill, command, readme):
+    for text in (skill, create_command, command, readme):
         assert "issue prepare" in text
         assert "issue create-prepared" in text
 
+    assert "name: create-issue" in create_command
+    assert "--prepare" in create_command
+    assert "--draft" in create_command
+    assert "--from" in create_command
+    assert "--maturity" in create_command
+    assert "compatibility alias" in command.lower()
+    assert "`/create-issue` is the primary user-facing command" in skill
+    assert "/create-issue [type]" in readme
     assert "Create an Olympus issue from this text" in skill
     assert "Create an Asgard issue from these notes" in skill
+    assert "Create an issue from the brainstorm" in skill
+    assert "handoff_maturity" in skill
     assert "If team or project is ambiguous, ask" in skill
     assert "Never auto-move a prepared issue to `Ready`" in skill
-    assert "create an Olympus issue from this text" in command
+    assert "from the brainstorm" in create_command
+    assert "handoff the plan" in create_command
     assert "prepared-draft path" in command
+    assert "/loop <issue>" not in create_command
 
 
 def test_asgard_olympus_model_uses_explicit_transfer_language() -> None:
@@ -110,6 +123,7 @@ def test_asgard_olympus_model_uses_explicit_transfer_language() -> None:
         PLUGIN_ROOT / "scripts/sdlc_manager.py",
         PLUGIN_ROOT / "skills/sdlc-board/references/kanban-workflow.md",
         PLUGIN_ROOT / "skills/sdlc-issues/SKILL.md",
+        PLUGIN_ROOT / "commands/create-issue.md",
         PLUGIN_ROOT / "commands/sdlc-create.md",
         PLUGIN_ROOT / "agents/sdlc-operator.md",
         PLUGIN_ROOT / "README.md",

--- a/plugins/sdlc-manager/tests/test_prompt_alignment.py
+++ b/plugins/sdlc-manager/tests/test_prompt_alignment.py
@@ -92,3 +92,39 @@ def test_prepared_issue_guidance_routes_natural_language_creation() -> None:
     assert "Never auto-move a prepared issue to `Ready`" in skill
     assert "create an Olympus issue from this text" in command
     assert "prepared-draft path" in command
+
+
+def test_asgard_olympus_model_uses_explicit_transfer_language() -> None:
+    schema = json.loads(_read(PLUGIN_ROOT / "config/sdlc-schema.json"))
+
+    assert schema["schema_version"] == "2026-05-30"
+    assert schema["teams"]["asgard"]["status"] == "active"
+    assert "Transfer Target" in schema["fields"]["asgard"]
+    assert "Promotion Target" not in schema["fields"]["asgard"]
+    assert "cross_team_transfer_rule" in schema["team_routing"]
+    assert "asgard_to_olympus_rule" not in schema["team_routing"]
+    assert "sibling target boards" in schema["team_routing"]["cross_team_transfer_rule"]
+
+    active_surfaces = [
+        PLUGIN_ROOT / "config/sdlc-schema.json",
+        PLUGIN_ROOT / "scripts/sdlc_manager.py",
+        PLUGIN_ROOT / "skills/sdlc-board/references/kanban-workflow.md",
+        PLUGIN_ROOT / "skills/sdlc-issues/SKILL.md",
+        PLUGIN_ROOT / "commands/sdlc-create.md",
+        PLUGIN_ROOT / "agents/sdlc-operator.md",
+        PLUGIN_ROOT / "README.md",
+    ]
+    stale_phrases = [
+        "asgard_to_olympus",
+        "Promotion Target",
+        "Promotion gaps",
+        "Olympus promotion gaps",
+        "Asgard Seeds Olympus",
+        "seed Olympus",
+        "promote to Olympus",
+    ]
+
+    for path in active_surfaces:
+        text = _read(path)
+        for phrase in stale_phrases:
+            assert phrase not in text, f"{path.relative_to(ROOT)} contains stale phrase {phrase!r}"

--- a/tests/test_infiquetra_loop_plugin.py
+++ b/tests/test_infiquetra_loop_plugin.py
@@ -43,7 +43,7 @@ def test_infiquetra_loop_metadata_and_marketplace_entry_match() -> None:
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/infiquetra-loop"
     assert "lifecycle" in plugin_json["description"]
-    assert {"loop", "lifecycle", "strategy", "doc-review", "code-review", "optimize"} <= set(
+    assert {"loop", "lifecycle", "strategy", "handoff", "doc-review", "code-review"} <= set(
         plugin_json["keywords"]
     )
 
@@ -55,6 +55,7 @@ def test_infiquetra_loop_commands_are_packaged() -> None:
         "strategy",
         "ideate",
         "brainstorm",
+        "handoff",
         "plan",
         "work",
         "qa",
@@ -76,6 +77,7 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "strategy",
         "ideate",
         "brainstorm",
+        "handoff",
         "plan",
         "work",
         "qa",
@@ -98,6 +100,7 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "team-execution",
         "infiquetra-deploy",
         "sdlc-manager",
+        "/handoff",
         "issue progress",
         "doc-review",
         "engineering-journal",
@@ -111,6 +114,7 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
         "load_saga_context.py",
         "discover_subissues.py",
         "issue_progress.py",
+        "handoff_envelope.py",
     ):
         assert (PLUGIN_ROOT / "scripts" / script).exists()
 
@@ -132,6 +136,12 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
     ):
         assert required in doc_review_doc
     assert not (PLUGIN_ROOT / "commands" / "ce-doc-review.md").exists()
+
+    handoff_doc = _read(PLUGIN_ROOT / "skills" / "handoff" / "SKILL.md")
+    assert "sdlc-manager" in handoff_doc
+    assert "Do not copy SDLC issue templates" in handoff_doc
+    assert "/create-issue --prepare" in handoff_doc
+    assert "Do not suggest `/loop`" in handoff_doc
 
 
 def test_destination_selector_and_escalation_helpers() -> None:
@@ -235,3 +245,45 @@ def test_issue_parser_extracts_infiquetra_context_and_risk_flags() -> None:
     assert extracted["round_refs"] == [2]
     assert extracted["flags"]["has_api"] is True
     assert extracted["flags"]["has_security"] is True
+
+
+def test_handoff_envelope_routes_to_sdlc_manager_without_issue_body_ownership(tmp_path) -> None:
+    handoff = _load_module("handoff_envelope.py")
+    plan = tmp_path / "docs" / "plans" / "example.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Example Plan\n")
+
+    envelope = handoff.build_handoff_envelope(
+        "docs/plans/example.md",
+        target_team="Asgard",
+        target_repo="infiquetra-claude-plugins",
+        issue_type="capability",
+        reason="another team should pick this up",
+        root=tmp_path,
+    )
+
+    assert envelope["source"] == "docs/plans/example.md"
+    assert envelope["lifecycle_phase"] == "plan"
+    assert envelope["handoff_maturity"] == "plan-ready"
+    assert envelope["loop_owner"] == "infiquetra-loop"
+    assert envelope["issue_artifact_owner"] == "sdlc-manager"
+    assert envelope["body_template_owner"] == "sdlc-manager"
+    assert envelope["suggested_command"].startswith("/create-issue --prepare")
+    assert "--from docs/plans/example.md" in envelope["suggested_command"]
+    assert "--maturity plan-ready" in envelope["suggested_command"]
+    assert "/loop" not in envelope["suggested_command"]
+
+
+def test_handoff_envelope_discovers_active_plan_from_loop_state(tmp_path) -> None:
+    handoff = _load_module("handoff_envelope.py")
+    state = tmp_path / ".claude" / "infiquetra-loop" / "state.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(
+        json.dumps({"current_work": {"plan_path": "docs/plans/active.md"}}),
+        encoding="utf-8",
+    )
+
+    envelope = handoff.build_handoff_envelope(root=tmp_path)
+
+    assert envelope["source"] == "docs/plans/active.md"
+    assert envelope["handoff_maturity"] == "plan-ready"

--- a/tests/test_infiquetra_loop_plugin.py
+++ b/tests/test_infiquetra_loop_plugin.py
@@ -143,6 +143,12 @@ def test_infiquetra_loop_skills_document_required_lifecycle_behavior() -> None:
     assert "/create-issue --prepare" in handoff_doc
     assert "Do not suggest `/loop`" in handoff_doc
 
+    plan_doc = _read(PLUGIN_ROOT / "skills" / "plan" / "SKILL.md")
+    work_doc = _read(PLUGIN_ROOT / "skills" / "work" / "SKILL.md")
+    assert "`idea-ready` or `requirements-ready`" in plan_doc
+    assert "`plan-ready` or `resume-ready`" in work_doc
+    assert "/plan <issue>" in work_doc
+
 
 def test_destination_selector_and_escalation_helpers() -> None:
     lifecycle = _load_module("lifecycle_state.py")
@@ -206,6 +212,9 @@ def test_issue_progress_comments_include_required_evidence() -> None:
         event="phase",
         issue_ref="infiquetra/campps-service#42",
         destination="pr",
+        handoff_maturity="plan-ready",
+        handoff_source="docs/plans/example.md",
+        next_action="/work <issue>",
         doc_review_artifact="docs/reviews/2026-05-29-doc-review.md",
         doc_review_blocked=True,
         doc_review_fixes=["Added missing gate."],
@@ -213,6 +222,9 @@ def test_issue_progress_comments_include_required_evidence() -> None:
         doc_review_override="Proceeding after owner accepted risk.",
     )
     assert "doc review artifact: docs/reviews/2026-05-29-doc-review.md" in review
+    assert "handoff maturity: plan-ready" in review
+    assert "handoff source: docs/plans/example.md" in review
+    assert "next action: /work <issue>" in review
     assert "doc review blocked: yes" in review
     assert "doc review override: Proceeding after owner accepted risk." in review
     assert "doc review fixes:" in review
@@ -245,6 +257,39 @@ def test_issue_parser_extracts_infiquetra_context_and_risk_flags() -> None:
     assert extracted["round_refs"] == [2]
     assert extracted["flags"]["has_api"] is True
     assert extracted["flags"]["has_security"] is True
+    assert extracted["handoff"]["maturity"] == ""
+
+
+def test_issue_parser_extracts_handoff_maturity_and_source_context() -> None:
+    parse_issue = _load_module("parse_issue.py")
+
+    body = """### Objective
+Build the thing.
+
+### Handoff maturity
+plan-ready
+
+### Suggested next action
+Use `/work <issue>` to execute from the plan-grade context.
+
+### Source context
+- Source: docs/plans/example.md
+- Source type: plan
+- Source title: Example Plan
+"""
+
+    extracted = parse_issue.extract(body)
+
+    assert extracted["handoff"] == {
+        "maturity": "plan-ready",
+        "suggested_next_action": "Use `/work <issue>` to execute from the plan-grade context.",
+        "source": "docs/plans/example.md",
+        "source_type": "plan",
+        "source_title": "Example Plan",
+        "can_plan": False,
+        "can_work": True,
+        "requires_clarification": False,
+    }
 
 
 def test_handoff_envelope_routes_to_sdlc_manager_without_issue_body_ownership(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add `sdlc-manager` handoff maturity metadata, source artifact resolution, and primary `/create-issue` guidance
- add `infiquetra-loop` `/handoff` routing plus a thin source envelope helper
- teach `/plan <issue>` and `/work <issue>` to consume handoff maturity and source context
- sync the corrected Asgard/Olympus sibling-board model into plugin schema and readiness docs

## Validation
- `uv run pytest` -> 602 passed
- `uv run ruff check ...` on touched Python/test files
- `git diff --check`
- JSON validation for plugin manifests, marketplace, and SDLC schema
