### PR TITLE
fix(infiquetra-deploy): query_deployments.py GET + tag-ref selection

### DIFF
--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,16 @@
 
 ## 2026-05-30
 
+### `gh api` with `-f` silently defaults to POST — breaks read-only queries  {#gh-api-f-defaults-post}
+
+**Context.** `/deploy-status` was non-functional: `query_deployments.py` `latest_deployment()` called `gh api repos/{repo}/deployments -f environment={env} -f per_page=1` and got `HTTP 422 "ref wasn't supplied"`. The intent was to *read* the deployments list; the API was rejecting it as a malformed *create*.
+**Evidence.** Issue #161; `plugins/infiquetra-deploy/scripts/query_deployments.py:86` (pre-fix). Live repro against `infiquetra/campps-identity-access` returned 422; the GET form `gh api --method GET repos/infiquetra/campps-identity-access/deployments -f environment=nonprod -f per_page=1 --jq '.[0].ref'` returns `v0.1.0`.
+**Mechanism.** `gh api` chooses the HTTP method by *inference*: with no `--method`, the presence of any `-f`/`-F` field flag flips the default from GET to **POST** (the flags are assumed to be a request body). `POST repos/{repo}/deployments` is the create-deployment endpoint, which requires a `ref` — hence 422. With `--method GET` explicit, `gh` instead serializes `-f` params into the query string.
+**Fix.** Added `--method GET` and a tag-ref filter; commit on `fix/deploy-status-query-deployments`. Validated: live smoke prints `nonprod: v0.1.0`, no 422; regression test asserts `--method GET` is present so it can't silently revert to POST.
+**Second defect (same fix).** Even as a GET, taking the newest record per env was wrong — GitHub Actions `environment:` job keys auto-create Deployment objects with branch/SHA refs (`main`, PR branches) that interleave with real tag refs. Fixed by `is_tag_ref()` (known prefix + version digit) selecting the newest *tag-ref* record. See [QUEUED: per_page lookback cap](QUEUED.md#deploy-status-perpage-cap).
+**Generalizable rule.** Any `gh api` call meant to *read* must pass `--method GET` explicitly the moment it also passes `-f`/`-F` (e.g. for query params) — otherwise gh turns it into a POST. When asserting against an external API in tests, assert the *method*, not just the URL/params.
+**Refs.** Issue #161; [QUEUED.md#deploy-status-perpage-cap](QUEUED.md#deploy-status-perpage-cap).
+
 ### Prepared issue creation needs an artifact boundary before mutation  {#prepared-issue-artifact-boundary}
 
 **Context.** `sdlc-manager` needed to turn rough source text into Asgard or Mount Olympus issues

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -161,3 +161,23 @@ independent read-only review, exploration, or implementation-plan critique.
 - This plan's adoption of the journal in `infiquetra-claude-plugins` is **not** the plugin — it's a hand-built journal for this repo's own meta-work. The plugin work is downstream and uses this repo + home-lab as proven references when it's built.
 
 ---
+
+## P3 — nice-to-have
+
+### `deploy-status` per_page lookback can miss old tag refs  {#deploy-status-perpage-cap}
+
+**Priority.** P3.
+
+**Effort.** ~1 hour.
+
+**Worth it when.** A tag-promotion repo accrues more than 20 CI-auto `environment:`-key
+Deployment records (branch/SHA refs) since its last real tag promotion. Then
+`latest_deployment()` (which fetches `per_page=20` and filters to the newest tag-ref record)
+scrolls the real tag off the page and reports "no deployment found".
+
+**Context.**
+- Introduced by the #161 fix (`query_deployments.py latest_deployment()`): GET + `is_tag_ref()`
+  filtering on a single 20-record page.
+- Current behavior degrades gracefully (no crash, just a missing env line).
+- Fix options when triggered: paginate until a tag-ref is found or N pages exhausted, or use the
+  `environment` filter combined with a larger page. See [LEARNINGS.md#gh-api-f-defaults-post](LEARNINGS.md#gh-api-f-defaults-post).

--- a/docs/plans/2026-05-30-003-fix-deploy-status-query-deployments-plan.md
+++ b/docs/plans/2026-05-30-003-fix-deploy-status-query-deployments-plan.md
@@ -1,0 +1,168 @@
+---
+title: "fix(infiquetra-deploy): query_deployments.py GET + tag-ref selection"
+type: "fix"
+status: "ready"
+date: "2026-05-30"
+issue: 161
+handoff_maturity: "requirements-ready"
+source: "https://github.com/infiquetra/infiquetra-claude-plugins/issues/161"
+target: "PR -> merge to main"
+---
+
+# fix(infiquetra-deploy): query_deployments.py GET + tag-ref selection
+
+## Summary
+
+`/deploy-status` is non-functional. `latest_deployment()` in
+`plugins/infiquetra-deploy/scripts/query_deployments.py` has two defects:
+
+1. **POST-instead-of-GET.** It calls `gh api repos/{repo}/deployments -f environment={env}
+   -f per_page=1`. The `-f` flags make `gh` default to **POST** (create a deployment), so the
+   API returns `HTTP 422 "ref wasn't supplied"`. Must be a GET.
+2. **Newest-record, not newest-tag.** Even as a GET, taking the single newest deployment per
+   environment is wrong. GitHub Actions `environment:` job keys auto-create Deployment objects
+   whose `ref` is a branch/SHA (`main`, PR branch names). These interleave with the real
+   tag-ref records the deploy workflows write (`v0.1.0`, `staging-v*`, `production-v*`). When a
+   branch-ref record is newest, the reported version is wrong.
+
+Fix: GET a small page (`per_page=20`) and select the newest record whose `ref` matches a known
+tag pattern, reusing the existing `TAG_PREFIXES` / `strip_prefix`.
+
+## Source context
+
+- Issue: [#161](https://github.com/infiquetra/infiquetra-claude-plugins/issues/161) (defect, requirements-ready)
+- Original source file: `/Users/jefcox/.claude/jobs/33b54d6c/tmp/deploy-status-defect.md`
+- Found while verifying ADR-0005 tag-promotion on `campps-identity-access` (PR #4).
+- Issue-review feedback (advisory) sharpened ACs: drift scenarios, fixture-backed branch-ref
+  selection, and a multi-record (`per_page=20`) GET check. Folded into ACs below.
+
+## Root cause detail
+
+```python
+# current (broken) — defaults to POST because of -f
+payload = run(["gh", "api", f"repos/{repo}/deployments",
+               "-f", f"environment={env}", "-f", "per_page=1"])
+data = json.loads(payload or "[]")
+return data[0] if data else None
+```
+
+`gh api` issues POST whenever `-f`/`-F` params are present and no `--method` is given. With
+`--method GET`, gh moves `-f` params into the query string. The deployments list endpoint
+returns records newest-first, so after the GET we still must skip non-tag refs and pick the
+first tag-ref record.
+
+## Acceptance criteria
+
+- [ ] AC1 — `latest_deployment()` issues a GET (`gh api --method GET ...`); no HTTP 422.
+- [ ] AC2 — `/deploy-status` prints per-env versions for a repo with real deployments.
+      Authoritative pass/fail is the unit fixture (AC4); the live command against
+      `infiquetra/campps-identity-access` (`nonprod` at `ref=v0.1.0`) is smoke verification only,
+      since live deployment state is mutable.
+- [ ] AC3 — Records whose `ref` does not match a known tag pattern
+      (`v` / `nonprod-v` / `staging-v` / `production-v` / `rollback-*` followed by a version
+      digit) are ignored; the newest **tag-ref** record is selected per environment.
+- [ ] AC4 — Regression test: fixture where the newest record has `ref=main` (or a SHA/branch)
+      and an older record has `ref=v0.1.0`; assert `latest_deployment()` selects `v0.1.0`.
+- [ ] AC5 — Drift detection still works. Test: mocked `nonprod=v0.1.1`, `staging=v0.1.0`,
+      `production=v0.1.0` → `render_status` emits a drift block; all three `v0.1.0` →
+      `drift: none detected`.
+- [ ] AC6 — A test asserts the `gh` invocation is a GET (`--method GET` present, no POST body),
+      i.e. the 422 cannot regress.
+
+## Scope
+
+In scope:
+
+- `latest_deployment()` GET conversion + tag-ref selection.
+- A small `is_tag_ref()` helper (or inline predicate) that reuses `TAG_PREFIXES`, requiring the
+  post-prefix remainder to start with a digit so loose `v`-prefix matches (e.g. a `version-bump`
+  branch) are rejected.
+- Regression tests/fixtures in `tests/test_infiquetra_deploy_plugin.py`.
+
+Out of scope (per issue non-goals):
+
+- Changing how deploy **workflows** write Deployment records.
+- Suppressing auto-created `environment:`-key deployments at the workflow level.
+- Any change to `mint_tag.py` or `preview_release_notes.py`.
+
+## Files likely to change
+
+- `plugins/infiquetra-deploy/scripts/query_deployments.py` — `latest_deployment()` + helper.
+- `tests/test_infiquetra_deploy_plugin.py` — regression tests (monkeypatch `run` to return
+  fixture JSON; assert GET, tag-ref selection, drift).
+
+## Implementation notes
+
+1. Add a tag-ref predicate:
+
+   ```python
+   def is_tag_ref(ref: str | None) -> bool:
+       if not ref:
+           return False
+       for prefix in TAG_PREFIXES:
+           if ref.startswith(prefix):
+               remainder = ref[len(prefix):]
+               return bool(remainder) and remainder[0].isdigit()
+       return False
+   ```
+
+   Note `TAG_PREFIXES` is ordered longest-first, so `nonprod-v0.1.0` matches `nonprod-v`
+   before the bare `v`. Keep that ordering.
+
+2. Rewrite `latest_deployment()`:
+
+   ```python
+   def latest_deployment(repo: str, env: str) -> dict[str, Any] | None:
+       payload = run([
+           "gh", "api", "--method", "GET",
+           f"repos/{repo}/deployments",
+           "-f", f"environment={env}",
+           "-f", "per_page=20",
+       ])
+       data = json.loads(payload or "[]")
+       for record in data:  # API returns newest-first
+           if is_tag_ref(str(record.get("ref") or "")):
+               return record
+       return None
+   ```
+
+   Keep returning the full record dict so `render_status` still reads `ref`/`sha`.
+
+3. Leave `render_status`, `detect_drift`, `strip_prefix`, `resolve_repo` unchanged.
+
+## Checks
+
+```bash
+cd /Users/jefcox/workspace/infiquetra/infiquetra-claude-plugins
+uv run ruff check plugins/infiquetra-deploy/scripts/query_deployments.py tests/test_infiquetra_deploy_plugin.py
+uv run mypy plugins/infiquetra-deploy/scripts/query_deployments.py
+uv run bandit plugins/infiquetra-deploy/scripts/query_deployments.py
+uv run pytest tests/test_infiquetra_deploy_plugin.py -v
+# Live smoke (AC2, requires gh read access; non-blocking):
+python3 plugins/infiquetra-deploy/scripts/query_deployments.py --repo campps-identity-access
+gh api --method GET repos/infiquetra/campps-identity-access/deployments \
+  -f environment=nonprod -f per_page=1 --jq '.[0].ref'   # -> v0.1.0
+```
+
+## Review gates
+
+- Self pre-PR review: confirm GET path, tag-ref filtering, no behavior change to drift/render.
+- `/code-review` on the diff before opening the PR.
+
+## Issue updates
+
+- Comment plan path + handoff maturity (requirements-ready) + source link on #161 after writing.
+- On merge: comment the merged PR/commit and close #161 via PR `Closes #161`.
+
+## Deploy gates
+
+None. `infiquetra-deploy` is a plugin in this marketplace repo, not a deployed service. No
+version bump needed (test asserts `0.1.0`; this is a bugfix to script internals, not a packaged
+API change — leave `plugin.json`/`marketplace.json` at `0.1.0`).
+
+## Resume notes
+
+- Branch from `main`: `fix/deploy-status-query-deployments`.
+- Authoritative validation is `pytest tests/test_infiquetra_deploy_plugin.py`; the live `gh`
+  smoke is best-effort and may be skipped if gh lacks read access to campps-identity-access.
+- Auto-merge applies (just-Jeff-and-Claude repo): squash-merge once CI is green.

--- a/docs/work-sessions/2026-05-30-fix-deploy-status-query-deployments.md
+++ b/docs/work-sessions/2026-05-30-fix-deploy-status-query-deployments.md
@@ -1,0 +1,53 @@
+---
+title: "fix(infiquetra-deploy): query_deployments.py GET + tag-ref selection"
+date: "2026-05-30"
+issue: 161
+plan: "docs/plans/2026-05-30-003-fix-deploy-status-query-deployments-plan.md"
+status: "implemented — pending PR"
+---
+
+# Work session: fix deploy-status query_deployments.py
+
+## What changed
+
+`plugins/infiquetra-deploy/scripts/query_deployments.py`:
+
+- `latest_deployment()` now issues `gh api --method GET` (was defaulting to POST via bare `-f`,
+  causing HTTP 422 "ref wasn't supplied"). Fetches `per_page=20`.
+- New `is_tag_ref()` helper: a ref is a tag only if it matches a `TAG_PREFIXES` entry followed
+  by a version digit. Branch/SHA refs (`main`, `feature/*`, SHAs, `version-bump`) are rejected.
+- `latest_deployment()` walks the newest-first page and returns the first tag-ref record,
+  skipping CI-auto-created `environment:`-key deployments.
+- Typed `data` as `list[dict[str, Any]]` to satisfy mypy (no `Any` return).
+
+`tests/test_infiquetra_deploy_plugin.py` — 4 new tests:
+
+- `test_is_tag_ref_accepts_tags_and_rejects_branches`
+- `test_latest_deployment_issues_get_and_selects_newest_tag_ref` (AC4 + AC6)
+- `test_latest_deployment_returns_none_without_tag_refs`
+- `test_render_status_reports_and_omits_drift` (AC5)
+
+## Checks run
+
+| Gate | Result |
+|------|--------|
+| `ruff check` (script + tests) | All checks passed |
+| `mypy` (script) | Success: no issues |
+| `bandit` (script) | 0 issues |
+| `pytest tests/test_infiquetra_deploy_plugin.py` | 9 passed |
+| Live smoke (`--repo campps-identity-access`) | `nonprod: v0.1.0 (version 0.1.0)`, no HTTP 422 |
+| Ground-truth GET (`.[0].ref`) | `v0.1.0` (matches) |
+
+## Acceptance criteria
+
+- AC1 GET, no 422 — met (live smoke + AC6 test)
+- AC2 per-env versions live — met (campps-identity-access nonprod v0.1.0)
+- AC3 non-tag refs ignored — met (`is_tag_ref`)
+- AC4 newest-tag over newest-record — met (fixture test)
+- AC5 drift still works — met (render_status test)
+- AC6 GET assertion regression guard — met
+
+## Next
+
+- `/code-review` on the diff, then open PR `Closes #161`.
+- Auto-merge once CI green (just-Jeff-and-Claude repo).

--- a/plugins/infiquetra-deploy/scripts/query_deployments.py
+++ b/plugins/infiquetra-deploy/scripts/query_deployments.py
@@ -83,20 +83,42 @@ def detect_drift(tags_by_env: Mapping[str, str | None]) -> list[str]:
     return [f"{env}: {version}" for env, version in versions.items()]
 
 
+def is_tag_ref(ref: str | None) -> bool:
+    """True when ``ref`` is an Infiquetra deployment tag, not a branch/SHA ref.
+
+    GitHub Actions ``environment:`` job keys auto-create Deployment records whose ref is a
+    branch name or SHA (e.g. ``main``). Only records whose ref matches a known tag prefix
+    followed by a version digit are real tag-promotion deployments.
+    """
+
+    if not ref:
+        return False
+    for prefix in TAG_PREFIXES:
+        if ref.startswith(prefix):
+            remainder = ref[len(prefix) :]
+            return bool(remainder) and remainder[0].isdigit()
+    return False
+
+
 def latest_deployment(repo: str, env: str) -> dict[str, Any] | None:
     payload = run(
         [
             "gh",
             "api",
+            "--method",
+            "GET",
             f"repos/{repo}/deployments",
             "-f",
             f"environment={env}",
             "-f",
-            "per_page=1",
+            "per_page=20",
         ]
     )
-    data = json.loads(payload or "[]")
-    return data[0] if data else None
+    data: list[dict[str, Any]] = json.loads(payload or "[]")
+    for record in data:  # GitHub returns deployment records newest-first
+        if is_tag_ref(str(record.get("ref") or "")):
+            return record
+    return None
 
 
 def render_status(repo: str, deployments: Mapping[str, dict[str, Any] | None]) -> str:

--- a/tests/test_infiquetra_deploy_plugin.py
+++ b/tests/test_infiquetra_deploy_plugin.py
@@ -105,3 +105,89 @@ def test_query_deployments_strips_infiquetra_tag_prefixes() -> None:
     assert query_deployments.strip_prefix("staging-v1.2.3") == "1.2.3"
     assert query_deployments.strip_prefix("production-v1.2.3") == "1.2.3"
     assert query_deployments.strip_prefix("rollback-production-v1.2.3") == "1.2.3"
+
+
+def test_is_tag_ref_accepts_tags_and_rejects_branches() -> None:
+    query_deployments = _load_module("query_deployments.py")
+
+    assert query_deployments.is_tag_ref("v0.1.0")
+    assert query_deployments.is_tag_ref("nonprod-v1.2.3")
+    assert query_deployments.is_tag_ref("staging-v1.2.3")
+    assert query_deployments.is_tag_ref("production-v1.2.3")
+    assert query_deployments.is_tag_ref("rollback-production-v1.2.3")
+
+    # Branch/SHA refs and loose v-prefixed branch names are rejected.
+    assert not query_deployments.is_tag_ref("main")
+    assert not query_deployments.is_tag_ref("feature/deploy")
+    assert not query_deployments.is_tag_ref("version-bump")
+    assert not query_deployments.is_tag_ref("9f8c1de")
+    assert not query_deployments.is_tag_ref("")
+    assert not query_deployments.is_tag_ref(None)
+
+
+def test_latest_deployment_issues_get_and_selects_newest_tag_ref(monkeypatch) -> None:
+    query_deployments = _load_module("query_deployments.py")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], *, check: bool = True) -> str:
+        captured["cmd"] = cmd
+        # GitHub returns newest-first: a branch-ref CI deployment newer than the real tag.
+        return json.dumps(
+            [
+                {"ref": "main", "sha": "9f8c1de"},
+                {"ref": "v0.1.0", "sha": "abc1234"},
+            ]
+        )
+
+    monkeypatch.setattr(query_deployments, "run", fake_run)
+
+    deployment = query_deployments.latest_deployment("infiquetra/campps-identity-access", "nonprod")
+
+    assert deployment is not None
+    assert deployment["ref"] == "v0.1.0"
+
+    # AC6: the gh call must be a GET so the HTTP 422 (POST create) cannot regress.
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["gh", "api"]
+    method_index = cmd.index("--method")
+    assert cmd[method_index + 1] == "GET"
+    assert "environment=nonprod" in cmd
+    assert "per_page=20" in cmd
+
+
+def test_latest_deployment_returns_none_without_tag_refs(monkeypatch) -> None:
+    query_deployments = _load_module("query_deployments.py")
+
+    def fake_run(cmd: list[str], *, check: bool = True) -> str:
+        return json.dumps([{"ref": "main"}, {"ref": "dependabot/pip/foo"}])
+
+    monkeypatch.setattr(query_deployments, "run", fake_run)
+
+    assert query_deployments.latest_deployment("infiquetra/x", "nonprod") is None
+
+
+def test_render_status_reports_and_omits_drift() -> None:
+    query_deployments = _load_module("query_deployments.py")
+
+    drifted = query_deployments.render_status(
+        "infiquetra/x",
+        {
+            "nonprod": {"ref": "nonprod-v0.1.1"},
+            "staging": {"ref": "staging-v0.1.0"},
+            "production": {"ref": "production-v0.1.0"},
+        },
+    )
+    assert "drift:" in drifted
+    assert "drift: none detected" not in drifted
+    assert "0.1.1" in drifted
+
+    aligned = query_deployments.render_status(
+        "infiquetra/x",
+        {
+            "nonprod": {"ref": "nonprod-v0.1.0"},
+            "staging": {"ref": "staging-v0.1.0"},
+            "production": {"ref": "production-v0.1.0"},
+        },
+    )
+    assert "drift: none detected" in aligned


### PR DESCRIPTION
## Summary

`/deploy-status` was non-functional. `latest_deployment()` in `plugins/infiquetra-deploy/scripts/query_deployments.py` had two defects:

1. **POST instead of GET** — bare `-f` flags with no `--method` make `gh api` default to POST (create a deployment), so the API returned `HTTP 422 "ref wasn't supplied"`. Now uses `gh api --method GET ... -f per_page=20`.
2. **Newest record, not newest tag** — GitHub Actions `environment:` job keys auto-create Deployment records with branch/SHA refs (`main`, PR branches) that interleave with the real tag-ref records (`v0.1.0`, `staging-v*`, …). Added `is_tag_ref()` (known `TAG_PREFIXES` + version digit) and select the newest **tag-ref** record per env.

## Verification

| Gate | Result |
|------|--------|
| `ruff` / `mypy` / `bandit` | clean |
| `pytest tests/test_infiquetra_deploy_plugin.py` | 9 passed |
| Live smoke (`--repo campps-identity-access`) | `nonprod: v0.1.0 (version 0.1.0)`, no HTTP 422 |
| Ground-truth GET `.[0].ref` | `v0.1.0` (matches) |

## Tests added

- `test_is_tag_ref_accepts_tags_and_rejects_branches`
- `test_latest_deployment_issues_get_and_selects_newest_tag_ref` — asserts `--method GET` (422 cannot regress) and tag-over-branch selection
- `test_latest_deployment_returns_none_without_tag_refs`
- `test_render_status_reports_and_omits_drift` — drift both directions

## Notes

- No version bump — script-internal bugfix, not a packaged API change.
- Journal: LEARNINGS entry on the `gh -f`→POST mechanism; QUEUED P3 for the `per_page=20` lookback cap (graceful degradation if >20 newer CI deployments exist).

Plan: `docs/plans/2026-05-30-003-fix-deploy-status-query-deployments-plan.md`

Closes #161