### PR TITLE
fix(team-scaffold): apply ruff format (green main CI)

### DIFF
--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/materialize_specs.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/materialize_specs.py
@@ -13,6 +13,7 @@ Usage:
       --fixtures   $CLAUDE_JOB_DIR/tmp/live-fixtures \
       --hosts      ~/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml
 """
+
 from __future__ import annotations
 
 import argparse
@@ -83,7 +84,7 @@ def main() -> int:
     hosts_yml = args.hosts.expanduser()
 
     for repo, cfg in teams.items():
-        short = repo[len("team-"):]
+        short = repo[len("team-") :]
         spec = {
             "team": {
                 "name": short,

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/cli.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/cli.py
@@ -12,6 +12,7 @@ Everything here is scriptable + idempotent:
   team-scaffold register-host      team-spec.yaml [--hosts PATH] [--apply]
   team-scaffold golden             # re-derive 12 known teams vs frozen fixtures
 """
+
 from __future__ import annotations
 
 import argparse
@@ -71,6 +72,7 @@ def _cmd_stamp(args: argparse.Namespace) -> int:
 
 def _cmd_vault_wire(args: argparse.Namespace) -> int:
     from . import vault_wire
+
     ts = load_spec(args.spec)
     target = pathlib.Path(args.out) / "ansible/inventory/group_vars/all/vault.yml"
     var_names = [p.discord_token_var for p in ts.profiles if p.discord_token_var]
@@ -89,13 +91,16 @@ def _cmd_register_host(args: argparse.Namespace) -> int:
         print("✗ spec has no inventory block (ansible_host/ansible_user) — cannot register")
         return 1
     changed, diff = inventory_register.register(
-        args.hosts, ts.host_group, ts.limit_host, attrs, apply=args.apply)
+        args.hosts, ts.host_group, ts.limit_host, attrs, apply=args.apply
+    )
     if not changed:
         print(f"· {ts.limit_host} already in inventory — no change")
         return 0
     print(diff)
-    print(f"{'APPLIED' if args.apply else 'DRY-RUN (use --apply to write)'}: "
-          f"{ts.limit_host} -> group {ts.host_group}")
+    print(
+        f"{'APPLIED' if args.apply else 'DRY-RUN (use --apply to write)'}: "
+        f"{ts.limit_host} -> group {ts.host_group}"
+    )
     return 0
 
 

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
@@ -13,6 +13,7 @@ The only change from the migration script is the data source: instead of a
 hardcoded ``TEAMS`` dict it takes a spec ``cfg`` dict (see ``spec.py``), so new
 teams render from a ``team-spec.yaml`` rather than a code edit.
 """
+
 from __future__ import annotations
 
 REQUIREMENTS = """---
@@ -30,14 +31,14 @@ def render_play(name: str, cfg: dict) -> str:
     """Render deploy/<team>.yml. ``name`` is the play filename (e.g. themis.yml)."""
     coresident = cfg.get("coresident")
     coresident_note = (
-        f" Co-resident team on this host ({coresident}) is NOT in the filter "
-        f"and is left untouched." if coresident else
-        " Only this team's profiles are touched.")
-    pin = ("    hermes_update: false  # runtime pinned (shared host)\n" if cfg["pin"] else "")
-    roles = "\n".join(
-        f"    - {{ role: {r}, tags: ['{t}'] }}" for r, t in cfg["roles"])
+        f" Co-resident team on this host ({coresident}) is NOT in the filter and is left untouched."
+        if coresident
+        else " Only this team's profiles are touched."
+    )
+    pin = "    hermes_update: false  # runtime pinned (shared host)\n" if cfg["pin"] else ""
+    roles = "\n".join(f"    - {{ role: {r}, tags: ['{t}'] }}" for r, t in cfg["roles"])
     return f"""---
-# Deploy the {cfg['team']} — and ONLY this team — from this repo.
+# Deploy the {cfg["team"]} — and ONLY this team — from this repo.
 #
 # Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
@@ -46,12 +47,12 @@ def render_play(name: str, cfg: dict) -> str:
 #
 # Usage (see deploy/README.md):
 #   cd deploy && ansible-playbook -i <home-lab-inventory> \\
-#     --limit {cfg['limit']} {name} --vault-password-file ~/.vault_pass.txt
+#     --limit {cfg["limit"]} {name} --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
 
-- name: Deploy {cfg['team']} (profile-scoped)
-  hosts: {cfg['hosts']}
+- name: Deploy {cfg["team"]} (profile-scoped)
+  hosts: {cfg["hosts"]}
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
@@ -153,10 +154,12 @@ def render_readme(cfg: dict) -> str:
     coresident_line = (
         f"\n\n**Note:** this team shares its host with {cfg['coresident']}; "
         f"the filter ensures {cfg['coresident']} is never touched by this deploy."
-        if cfg.get("coresident") else "")
+        if cfg.get("coresident")
+        else ""
+    )
     return README_TMPL.format(
-        team=cfg["team"], limit=cfg["limit"], play=cfg["play"],
-        coresident_line=coresident_line)
+        team=cfg["team"], limit=cfg["limit"], play=cfg["play"], coresident_line=coresident_line
+    )
 
 
 def render_harness(cfg: dict) -> dict[str, str]:

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/inventory_register.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/inventory_register.py
@@ -7,6 +7,7 @@ text-based insertion so the file's comments + formatting survive (PyYAML round
 
 Emit it as a single revertible commit (the caller's job); abort == git checkout.
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -85,8 +86,9 @@ def add_host(text: str, group: str, host_key: str, attrs: dict) -> tuple[str, bo
     return "".join(new_lines), True
 
 
-def register(hosts_yml: str | pathlib.Path, group: str, host_key: str,
-             attrs: dict, apply: bool = False) -> tuple[bool, str]:
+def register(
+    hosts_yml: str | pathlib.Path, group: str, host_key: str, attrs: dict, apply: bool = False
+) -> tuple[bool, str]:
     """Return (changed, unified_diff). Writes the file only when apply=True."""
     path = pathlib.Path(hosts_yml).expanduser()
     text = path.read_text()
@@ -94,9 +96,15 @@ def register(hosts_yml: str | pathlib.Path, group: str, host_key: str,
     if not changed:
         return False, ""
     import difflib
-    diff = "".join(difflib.unified_diff(
-        text.splitlines(keepends=True), new_text.splitlines(keepends=True),
-        fromfile=str(path), tofile=str(path) + " (new)"))
+
+    diff = "".join(
+        difflib.unified_diff(
+            text.splitlines(keepends=True),
+            new_text.splitlines(keepends=True),
+            fromfile=str(path),
+            tofile=str(path) + " (new)",
+        )
+    )
     if apply:
         path.write_text(new_text)
     return True, diff

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/profiles_validate.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/profiles_validate.py
@@ -7,6 +7,7 @@ headless workers, …). Rather than generate it, the scaffold validates it: the
 checks below encode the invariants the hermes role + orchestration depend on,
 and are proven by running against all 12 live team repos (test_profiles.py).
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -17,12 +18,30 @@ import yaml
 TOKEN_VAR_RE = re.compile(r"^vault_discord_bot_token_\w+$")
 KNOWN_ROLES = {
     # human-facing + headless roles seen across the fleet; unknown roles warn, not fail
-    "team_lead", "olympian_agent", "engineering_council", "software_engineering_expert",
-    "testing_expert", "security_expert", "stoic_skeptic", "polish_expert", "planner",
-    "readiness_reviewer", "fit_reviewer", "security_reviewer", "test_reviewer",
-    "announcer", "worker", "reviewer", "validator", "communications_steward",
-    "time_and_task_steward", "bookkeeping_steward", "wellness_steward",
-    "travel_and_expenses_steward", "research_steward", "procurement_steward",
+    "team_lead",
+    "olympian_agent",
+    "engineering_council",
+    "software_engineering_expert",
+    "testing_expert",
+    "security_expert",
+    "stoic_skeptic",
+    "polish_expert",
+    "planner",
+    "readiness_reviewer",
+    "fit_reviewer",
+    "security_reviewer",
+    "test_reviewer",
+    "announcer",
+    "worker",
+    "reviewer",
+    "validator",
+    "communications_steward",
+    "time_and_task_steward",
+    "bookkeeping_steward",
+    "wellness_steward",
+    "travel_and_expenses_steward",
+    "research_steward",
+    "procurement_steward",
     "skeptic_reviewer",
 }
 
@@ -59,24 +78,28 @@ def validate_data(data: dict) -> tuple[list[str], list[str]]:
 
         headless = p.get("headless", False)
         token_var = p.get("discord_token_var")
-        is_orchestrator = (p.get("role") == "team_lead"
-                           and name.endswith(("-orchestrator", "orchestrator")))
+        is_orchestrator = p.get("role") == "team_lead" and name.endswith(
+            ("-orchestrator", "orchestrator")
+        )
 
         if token_var is not None and not TOKEN_VAR_RE.match(token_var):
             errors.append(
                 f"{where}: discord_token_var {token_var!r} must match "
-                "vault_discord_bot_token_<persona>")
+                "vault_discord_bot_token_<persona>"
+            )
         # Invariants on who may/may not own a Discord identity:
         if headless and token_var:
             errors.append(f"{where}: headless workers must NOT carry a discord_token_var")
         if is_orchestrator and token_var:
             warnings.append(
                 f"{where}: orchestrator profile carries a discord_token_var "
-                "(orchestrators post as the conductor bot, not their own)")
+                "(orchestrators post as the conductor bot, not their own)"
+            )
         if not headless and not is_orchestrator and not token_var:
             warnings.append(
                 f"{where}: human-facing profile has no discord_token_var "
-                "(intentional only if it never posts to Discord)")
+                "(intentional only if it never posts to Discord)"
+            )
 
         if "persona" not in p and not headless:
             warnings.append(f"{where}: non-headless profile has no 'persona'")

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/repo_stamp.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/repo_stamp.py
@@ -11,6 +11,7 @@ template. config.yaml / distribution.yaml are labeled DEFERRED placeholders.
 Idempotent: existing files are never overwritten (so re-runs + hand edits are
 safe). Returns the list of paths actually created.
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -102,15 +103,16 @@ hermes_team_profiles:
 
 def _profiles_block(spec: TeamSpec) -> str:
     if not spec.profiles:
-        return ("  - name: {n}\n"
-                "    persona: {n}\n"
-                "    role: olympian_agent\n"
-                "    model: gemini-3-flash-preview:cloud\n"
-                "    reasoning_effort: medium\n"
-                "    max_turns: 90\n"
-                "    worker_pool: 1\n"
-                "    discord_token_var: vault_discord_bot_token_{n}\n"
-                ).format(n=spec.name)
+        return (
+            "  - name: {n}\n"
+            "    persona: {n}\n"
+            "    role: olympian_agent\n"
+            "    model: gemini-3-flash-preview:cloud\n"
+            "    reasoning_effort: medium\n"
+            "    max_turns: 90\n"
+            "    worker_pool: 1\n"
+            "    discord_token_var: vault_discord_bot_token_{n}\n"
+        ).format(n=spec.name)
     out = []
     for p in spec.profiles:
         out.append(f"  - name: {p.name}")
@@ -160,8 +162,9 @@ def _copy_if_absent(src: pathlib.Path, dst: pathlib.Path, created: list[str]) ->
     created.append(str(dst))
 
 
-def stamp(spec: TeamSpec, out_dir: str | pathlib.Path,
-          context_library: str | pathlib.Path) -> list[str]:
+def stamp(
+    spec: TeamSpec, out_dir: str | pathlib.Path, context_library: str | pathlib.Path
+) -> list[str]:
     root = pathlib.Path(out_dir)
     cl = pathlib.Path(context_library).expanduser()
     tmpl = cl / "templates"
@@ -174,8 +177,11 @@ def stamp(spec: TeamSpec, out_dir: str | pathlib.Path,
     _copy_if_absent(ai / "AGENTS.template.md", root / "AGENTS.md", created)
     _copy_if_absent(ai / "CLAUDE.template.md", root / "CLAUDE.md", created)
     _copy_if_absent(ai / "GEMINI.template.md", root / "GEMINI.md", created)
-    _copy_if_absent(ai / "copilot-instructions.template.md",
-                    root / ".github" / "copilot-instructions.md", created)
+    _copy_if_absent(
+        ai / "copilot-instructions.template.md",
+        root / ".github" / "copilot-instructions.md",
+        created,
+    )
     _copy_if_absent(ai / "llms.template.txt", root / "llms.txt", created)
 
     # engineering journal (full seed, verbatim)
@@ -187,12 +193,15 @@ def stamp(spec: TeamSpec, out_dir: str | pathlib.Path,
                 _copy_if_absent(f, root / "docs" / "engineering-journal" / rel, created)
 
     # team-specific stubs
-    _write_if_absent(root / "README.md",
-                     f"# {spec.repo}\n\n{spec.display} (polyrepo).\n\n"
-                     "## Source of truth\n- Org standards: `infiquetra-context-library`\n"
-                     "- Agent instructions: [AGENTS.md](AGENTS.md)\n"
-                     "- Engineering journal: [docs/engineering-journal/]"
-                     "(docs/engineering-journal/README.md)\n", created)
+    _write_if_absent(
+        root / "README.md",
+        f"# {spec.repo}\n\n{spec.display} (polyrepo).\n\n"
+        "## Source of truth\n- Org standards: `infiquetra-context-library`\n"
+        "- Agent instructions: [AGENTS.md](AGENTS.md)\n"
+        "- Engineering journal: [docs/engineering-journal/]"
+        "(docs/engineering-journal/README.md)\n",
+        created,
+    )
     _write_if_absent(root / ".gitignore", GITIGNORE, created)
     _write_if_absent(root / ".github" / "PULL_REQUEST_TEMPLATE.md", PR_TEMPLATE, created)
     _write_if_absent(root / "constitution.md", CONSTITUTION_TMPL.format(**sub), created)
@@ -204,9 +213,11 @@ def stamp(spec: TeamSpec, out_dir: str | pathlib.Path,
     persona_for = {p.name: (p.persona or p.name) for p in spec.profiles}
     for pname in profile_names:
         pdir = root / "profiles" / pname
-        _write_if_absent(pdir / "SOUL.md",
-                         SOUL_PLACEHOLDER.format(persona=persona_for.get(pname, pname)),
-                         created)
+        _write_if_absent(
+            pdir / "SOUL.md",
+            SOUL_PLACEHOLDER.format(persona=persona_for.get(pname, pname)),
+            created,
+        )
         _write_if_absent(pdir / "skills" / ".gitkeep", "", created)
         _write_if_absent(pdir / "config.yaml", CONFIG_STUB, created)
         _write_if_absent(pdir / "distribution.yaml", DISTRIBUTION_STUB, created)
@@ -215,7 +226,9 @@ def stamp(spec: TeamSpec, out_dir: str | pathlib.Path,
     harness = harness_gen.render_harness(spec.as_cfg())
     for fname, content in harness.items():
         _write_if_absent(root / "deploy" / fname, content, created)
-    _write_if_absent(root / "deploy" / "team_profiles.yml",
-                     TEAM_PROFILES_TMPL.format(name=spec.name,
-                                               profiles=_profiles_block(spec)), created)
+    _write_if_absent(
+        root / "deploy" / "team_profiles.yml",
+        TEAM_PROFILES_TMPL.format(name=spec.name, profiles=_profiles_block(spec)),
+        created,
+    )
     return created

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/spec.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/spec.py
@@ -10,6 +10,7 @@ The full per-profile RUNTIME config (model, skills, voice, fallback_providers,
 is authored not generated — see profiles_validate.py). The spec deliberately
 does NOT duplicate it.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -66,8 +67,7 @@ class TeamSpec:
         if not self.name or "/" in self.name or self.name != self.name.lower():
             problems.append(f"team.name must be a lowercase slug, got {self.name!r}")
         if self.host_group not in HOST_GROUPS:
-            problems.append(
-                f"team.host_group {self.host_group!r} not in {sorted(HOST_GROUPS)}")
+            problems.append(f"team.host_group {self.host_group!r} not in {sorted(HOST_GROUPS)}")
         if not self.roles:
             problems.append("team.roles is empty")
         role_names = [r for r, _ in self.roles]
@@ -76,13 +76,11 @@ class TeamSpec:
         # ollama is a per-team dependency on Linux hosts (not macOS).
         linux = self.host_group in {"agent_vms", "orchestrator_vms"}
         if linux and "ollama" not in role_names:
-            problems.append(
-                "Linux host_group requires the 'ollama' role (per-team inference dep)")
+            problems.append("Linux host_group requires the 'ollama' role (per-team inference dep)")
         if not linux and "ollama" in role_names:
             problems.append("macOS (mac_minis) teams must NOT include the 'ollama' role")
         if self.host_group == "orchestrator_vms" and "hermes_orchestrator" not in role_names:
-            problems.append(
-                "orchestrator_vms host_group expects the 'hermes_orchestrator' role")
+            problems.append("orchestrator_vms host_group expects the 'hermes_orchestrator' role")
         return problems
 
 

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/state.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/state.py
@@ -4,15 +4,28 @@ Each step probes live state (repo exists? token vaulted? host in inventory?) and
 skips if satisfied; this file just records which steps completed so a resumed run
 can narrate progress. A lost state file costs only re-probing, not re-doing.
 """
+
 from __future__ import annotations
 
 import json
 import pathlib
 
 STEPS = [
-    "validate-spec", "repo-create", "stamp", "author-soul", "gen-profiles",
-    "gen-harness", "discord-app", "vault-token", "vault-wire", "github-app",
-    "identity", "discord-topology", "push", "register-host", "dry-run-deploy",
+    "validate-spec",
+    "repo-create",
+    "stamp",
+    "author-soul",
+    "gen-profiles",
+    "gen-harness",
+    "discord-app",
+    "vault-token",
+    "vault-wire",
+    "github-app",
+    "identity",
+    "discord-topology",
+    "push",
+    "register-host",
+    "dry-run-deploy",
 ]
 
 

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/vault_wire.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/vault_wire.py
@@ -12,6 +12,7 @@ the encrypted blob + the single ~/.vault_pass.txt keep working. Two entry points
 
 Both are idempotent: a var already present in the target is left untouched.
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -50,8 +51,9 @@ def _write(target: pathlib.Path, blocks: dict[str, str], order: list[str]) -> No
     target.write_text(body)
 
 
-def copy_blocks_from(source_vault: pathlib.Path, target: pathlib.Path,
-                     var_names: list[str]) -> list[str]:
+def copy_blocks_from(
+    source_vault: pathlib.Path, target: pathlib.Path, var_names: list[str]
+) -> list[str]:
     """Copy named blocks verbatim from source into target (skip already-present).
 
     Returns the list of vars actually added.
@@ -71,8 +73,7 @@ def copy_blocks_from(source_vault: pathlib.Path, target: pathlib.Path,
     return added
 
 
-def append_encrypted_block(target: pathlib.Path, var_name: str,
-                           encrypted_block: str) -> bool:
+def append_encrypted_block(target: pathlib.Path, var_name: str, encrypted_block: str) -> bool:
     """Splice one freshly-encrypted block into target. Returns True if added.
 
     ``encrypted_block`` is the full ``var_name: !vault |\\n  $ANSIBLE_VAULT;...``

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
@@ -6,6 +6,7 @@ fixtures under specs/golden/ are frozen copies of the live infiquetra/team-*
 repos (fetched 2026-06-01); all 36 (3 files x 12 teams) matched the migration
 generator byte-for-byte at promotion time.
 """
+
 from __future__ import annotations
 
 import pathlib

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_modules.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_modules.py
@@ -1,4 +1,5 @@
 """Unit tests for vault_wire, inventory_register, and repo_stamp."""
+
 from __future__ import annotations
 
 import pathlib
@@ -93,8 +94,11 @@ mac_minis:
 
 def test_add_host_appends_under_group_and_preserves_comments():
     new, changed = inventory_register.add_host(
-        HOSTS, "agent_vms", "nyx.infiquetra.com",
-        {"ansible_host": "10.220.1.71", "ansible_user": "agent"})
+        HOSTS,
+        "agent_vms",
+        "nyx.infiquetra.com",
+        {"ansible_host": "10.220.1.71", "ansible_user": "agent"},
+    )
     assert changed
     assert "# a comment inside the group" in new  # comments survive
     # new host lands inside agent_vms, before the mac_minis group
@@ -107,8 +111,11 @@ def test_add_host_appends_under_group_and_preserves_comments():
 
 def test_add_host_idempotent():
     new, changed = inventory_register.add_host(
-        HOSTS, "agent_vms", "zeus.infiquetra.com",
-        {"ansible_host": "10.220.1.50", "ansible_user": "agent"})
+        HOSTS,
+        "agent_vms",
+        "zeus.infiquetra.com",
+        {"ansible_host": "10.220.1.50", "ansible_user": "agent"},
+    )
     assert not changed
     assert new == HOSTS
 
@@ -122,13 +129,21 @@ def test_register_dryrun_does_not_write(tmp_path: pathlib.Path):
     f = tmp_path / "hosts.yml"
     f.write_text(HOSTS)
     changed, diff = inventory_register.register(
-        f, "mac_minis", "freki.infiquetra.com",
-        {"ansible_host": "10.220.1.197", "ansible_user": "jefcox"}, apply=False)
+        f,
+        "mac_minis",
+        "freki.infiquetra.com",
+        {"ansible_host": "10.220.1.197", "ansible_user": "jefcox"},
+        apply=False,
+    )
     assert changed and diff
     assert f.read_text() == HOSTS  # unchanged on dry-run
     changed2, _ = inventory_register.register(
-        f, "mac_minis", "freki.infiquetra.com",
-        {"ansible_host": "10.220.1.197", "ansible_user": "jefcox"}, apply=True)
+        f,
+        "mac_minis",
+        "freki.infiquetra.com",
+        {"ansible_host": "10.220.1.197", "ansible_user": "jefcox"},
+        apply=True,
+    )
     assert changed2 and "freki.infiquetra.com:" in f.read_text()
 
 
@@ -139,55 +154,90 @@ CL = pathlib.Path("~/workspace/infiquetra/infiquetra-context-library").expanduse
 
 @pytest.mark.skipif(not CL.exists(), reason="context-library not checked out")
 def test_stamp_new_single_profile_team(tmp_path: pathlib.Path):
-    spec = from_dict({
-        "team": {
-            "name": "nyx", "display": "Nyx (night monitor)",
-            "host_group": "agent_vms", "limit_host": "nyx.infiquetra.com",
-            "pin_runtime": False, "coresident": None,
-            "roles": [
-                {"role": "ollama", "tags": "ollama,nyx"},
-                {"role": "hermes", "tags": "hermes,nyx"},
-                {"role": "hermes_dm_listener", "tags": "dm_listener,nyx"},
+    spec = from_dict(
+        {
+            "team": {
+                "name": "nyx",
+                "display": "Nyx (night monitor)",
+                "host_group": "agent_vms",
+                "limit_host": "nyx.infiquetra.com",
+                "pin_runtime": False,
+                "coresident": None,
+                "roles": [
+                    {"role": "ollama", "tags": "ollama,nyx"},
+                    {"role": "hermes", "tags": "hermes,nyx"},
+                    {"role": "hermes_dm_listener", "tags": "dm_listener,nyx"},
+                ],
+            },
+            "profiles": [
+                {
+                    "name": "nyx",
+                    "persona": "nyx",
+                    "discord_token_var": "vault_discord_bot_token_nyx",
+                }
             ],
-        },
-        "profiles": [{"name": "nyx", "persona": "nyx",
-                      "discord_token_var": "vault_discord_bot_token_nyx"}],
-    })
+        }
+    )
     created = repo_stamp.stamp(spec, tmp_path, CL)
     assert created
     # archetype-required artifacts exist
-    for rel in ("README.md", "AGENTS.md", ".gitignore",
-                ".github/PULL_REQUEST_TEMPLATE.md", "identity/README.md",
-                "orchestration/README.md", "profiles/nyx/SOUL.md",
-                "profiles/nyx/skills/.gitkeep", "profiles/nyx/config.yaml",
-                "profiles/nyx/distribution.yaml", "deploy/nyx.yml",
-                "deploy/requirements.yml", "deploy/README.md",
-                "deploy/team_profiles.yml",
-                "docs/engineering-journal/LEARNINGS.md"):
+    for rel in (
+        "README.md",
+        "AGENTS.md",
+        ".gitignore",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        "identity/README.md",
+        "orchestration/README.md",
+        "profiles/nyx/SOUL.md",
+        "profiles/nyx/skills/.gitkeep",
+        "profiles/nyx/config.yaml",
+        "profiles/nyx/distribution.yaml",
+        "deploy/nyx.yml",
+        "deploy/requirements.yml",
+        "deploy/README.md",
+        "deploy/team_profiles.yml",
+        "docs/engineering-journal/LEARNINGS.md",
+    ):
         assert (tmp_path / rel).exists(), f"missing {rel}"
     # identity records the token var NAME, never a secret value
     ident = (tmp_path / "identity/README.md").read_text()
     assert "vault_discord_bot_token_nyx" in ident
     # generated harness matches harness_gen exactly
     from team_scaffold import harness_gen
-    assert (tmp_path / "deploy/nyx.yml").read_text() == \
-        harness_gen.render_harness(spec.as_cfg())["nyx.yml"]
+
+    assert (tmp_path / "deploy/nyx.yml").read_text() == harness_gen.render_harness(spec.as_cfg())[
+        "nyx.yml"
+    ]
     # the stamped team_profiles.yml validates
     from team_scaffold import profiles_validate
+
     errors, _ = profiles_validate.validate_file(tmp_path / "deploy/team_profiles.yml")
     assert errors == []
 
 
 @pytest.mark.skipif(not CL.exists(), reason="context-library not checked out")
 def test_stamp_is_idempotent(tmp_path: pathlib.Path):
-    spec = from_dict({
-        "team": {"name": "nyx", "display": "Nyx", "host_group": "agent_vms",
-                 "limit_host": "nyx.infiquetra.com",
-                 "roles": [{"role": "ollama", "tags": "ollama,nyx"},
-                           {"role": "hermes", "tags": "hermes,nyx"}]},
-        "profiles": [{"name": "nyx", "persona": "nyx",
-                      "discord_token_var": "vault_discord_bot_token_nyx"}],
-    })
+    spec = from_dict(
+        {
+            "team": {
+                "name": "nyx",
+                "display": "Nyx",
+                "host_group": "agent_vms",
+                "limit_host": "nyx.infiquetra.com",
+                "roles": [
+                    {"role": "ollama", "tags": "ollama,nyx"},
+                    {"role": "hermes", "tags": "hermes,nyx"},
+                ],
+            },
+            "profiles": [
+                {
+                    "name": "nyx",
+                    "persona": "nyx",
+                    "discord_token_var": "vault_discord_bot_token_nyx",
+                }
+            ],
+        }
+    )
     repo_stamp.stamp(spec, tmp_path, CL)
     second = repo_stamp.stamp(spec, tmp_path, CL)
     assert second == []  # nothing re-created

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_profiles.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_profiles.py
@@ -4,6 +4,7 @@ Proves the validator is calibrated to reality (orchestrator-no-token, headless
 workers with no persona/token, voice fields, nested fallback_providers) and not
 just a toy schema. Live fixtures live next to the golden harness fixtures.
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -19,7 +20,9 @@ PROFILE_FILES = sorted(FIXTURES.glob("team-*.yml"))
 
 
 def test_have_all_twelve() -> None:
-    assert len(PROFILE_FILES) == 12, f"expected 12 live profile fixtures, found {len(PROFILE_FILES)}"
+    assert len(PROFILE_FILES) == 12, (
+        f"expected 12 live profile fixtures, found {len(PROFILE_FILES)}"
+    )
 
 
 @pytest.mark.parametrize("path", PROFILE_FILES, ids=lambda p: p.stem)
@@ -29,19 +32,32 @@ def test_live_profiles_validate_clean(path: pathlib.Path) -> None:
 
 
 def test_rejects_headless_with_token() -> None:
-    data = {"hermes_team_profiles": [
-        {"name": "w", "role": "worker", "model": "x", "headless": True,
-         "discord_token_var": "vault_discord_bot_token_w"},
-    ]}
+    data = {
+        "hermes_team_profiles": [
+            {
+                "name": "w",
+                "role": "worker",
+                "model": "x",
+                "headless": True,
+                "discord_token_var": "vault_discord_bot_token_w",
+            },
+        ]
+    }
     errors, _ = profiles_validate.validate_data(data)
     assert any("headless" in e for e in errors)
 
 
 def test_rejects_bad_token_var() -> None:
-    data = {"hermes_team_profiles": [
-        {"name": "a", "role": "olympian_agent", "model": "x",
-         "discord_token_var": "DISCORD_TOKEN_A"},
-    ]}
+    data = {
+        "hermes_team_profiles": [
+            {
+                "name": "a",
+                "role": "olympian_agent",
+                "model": "x",
+                "discord_token_var": "DISCORD_TOKEN_A",
+            },
+        ]
+    }
     errors, _ = profiles_validate.validate_data(data)
     assert any("discord_token_var" in e for e in errors)
 


### PR DESCRIPTION
Fixes the Lint (ruff format) failure on main from #165. `ruff format` only — no logic change; golden byte-parity preserved (12/12), 39 tests pass, ruff check + format + mypy clean.