### PR TITLE
feat(infiquetra-lifecycle): rebuild /ideate and /brainstorm as CE-class engines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -296,7 +296,7 @@
     {
       "name": "infiquetra-lifecycle",
       "source": "./plugins/infiquetra-lifecycle",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to sdlc-manager, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",
@@ -414,5 +414,5 @@
       "category": "development"
     }
   ],
-  "version": "2.3.0"
+  "version": "2.4.0"
 }

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,43 @@
 
 ---
 
+## 2026-06-01
+
+### Restore the CE ideation engine into `/ideate` + `/brainstorm`, self-contained (commit pending)  {#ce-ideation-engine-restore}
+
+**Decision.** Rebuild `infiquetra-lifecycle`'s `/ideate` and `/brainstorm` from thin facilitative
+stubs into full divergent→convergent engines ported from compound-engineering (CE) and adapted to the
+infiquetra world — self-contained, no runtime dependency on CE. `/ideate` generates many candidates
+across parallel frame agents, critiques all, and presents only survivors; cut ideas stay revivable.
+Two deliberate improvements over CE: (1) a two-way partnership — operator seeds feed *into* the frame
+agents and face the same critique; (2) a revival state machine that re-enters the filter with new
+evidence (and adjudicates novelty) so revival cannot soft-promote a categorically-cut idea. Added
+infiquetra grounding CE never had: context-library reader (`*-context-library` via `gh`), named-repo
+reader, grounding-fit gate, read-only `gh` issue-theme clustering. Dropped CE's Proof/HITL,
+HTML/output-mode, elsewhere/non-software modes, Slack, and web-research-cache.
+
+**Rejected alternatives.**
+- *Delegate to CE at runtime (load `ce-ideate` when present).* Rejected: couples lifecycle to CE
+  being installed at a compatible version and drags in CE's ecosystem (Proof, modes, conventions);
+  contradicts the plugin's standalone Boundaries.
+- *Keep the thin facilitative stubs.* Rejected: "produce a small option set; lead the user through
+  choices" biases toward facilitation, which is why ideation felt like the operator supplied all the
+  ideas. See LEARNINGS `{#stub-port-drops-engine}`.
+- *Issue themes via `sdlc-manager`.* Rejected: `sdlc-manager` has no theme-clustering and issue
+  *reads* are not its boundary (it owns mutation). `/ideate` reads issues read-only via `gh` and
+  clusters them itself.
+
+**Rationale.** The operator wanted CE's generative engine + survivors back, plus a genuine
+partnership where their ideas also enter the pool and rejected ideas are revivable. Self-contained
+keeps the plugin's ownership boundaries clean. Forked from CE 3.9.2; authored and adversarially
+verified via an ultracode workflow (13 agents; 5 major findings remediated, 0 blocking).
+
+**Revisit when.** CE ships a materially better ideation engine worth re-syncing, or the parallel-fork
+maintenance cost exceeds the value of staying self-contained.
+
+**Refs.** Plugin `0.3.0`, marketplace metadata `2.4.0`. LEARNINGS `{#stub-port-drops-engine}`. Plan
+`.claude/plans/can-you-review-the-inherited-lantern.md`.
+
 ## 2026-05-31
 
 ### Rename `infiquetra-loop` → `infiquetra-lifecycle` (commit `0ed70f2`)  {#rename-loop-to-lifecycle}

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,41 @@
 
 ---
 
+## 2026-06-01
+
+### Porting a skill's name without its engine — including its tuned sub-agent prompts — silently changes its behavior  {#stub-port-drops-engine}
+
+**Context.** `infiquetra-lifecycle`'s `/ideate` and `/brainstorm` were derived from
+compound-engineering (CE) but had been reduced to ~13–20 line facilitative stubs. In use they felt
+like the operator supplied all the ideas, and once Claude declared `/ideate` "too lightweight" and
+improvised its own fan-out.
+
+**Evidence.** Pre-rebuild `skills/ideate/SKILL.md` (13 lines) said "produce a small option set; lead
+the user through choices" — facilitation, not generation. CE's `ce-ideate` (~400-line SKILL + 3
+reference files) runs 6 parallel frame agents → adversarial filter → survivors. A home-lab artifact
+(`home-lab/docs/ideation/2026-05-31-card-sizing-...-ideation.md`) was labeled
+`/infiquetra-lifecycle:ideate` but used a hand-rolled decision-axis structure — Claude improvising a
+substitute engine because the skill had none.
+
+**Mechanism.** CE's repeatability does not live in the phase *structure* alone; it lives in the
+*verbatim, separately-tuned sub-agent prompts* (the codebase-scan prompt, the frame-generator prompt,
+the critique rubric). Porting the structure but reducing the sub-agents to "dispatch an Explore agent"
+reintroduces the same facilitate-instead-of-generate failure one level down. An adversarial-review
+workflow over the rebuild caught exactly this risk plus functional gaps it would have masked (a
+soft-promote loophole in revival; a gate promising multi-repo grounding no Phase 1 source delivered).
+
+**Fix (commit pending).** Rebuilt both engines self-contained with verbatim tuned prompts for every
+sub-agent; ran an author→adversarially-verify→remediate ultracode workflow (5 major findings fixed, 0
+blocking); plugin `0.3.0`.
+
+**Generalizable rule.** When you "port" or "slim" a skill, diff the *mechanics and the sub-agent
+prompt bodies*, not just the prose intent. A skill that keeps the name and the goal but drops the
+engine — or reduces its sub-agents to generic dispatch — will silently behave like a stub, and the
+degradation won't surface until someone notices the AI stopped doing the work.
+
+**Refs.** DECISIONS `{#ce-ideation-engine-restore}`. Plan
+`.claude/plans/can-you-review-the-inherited-lantern.md`.
+
 ## 2026-05-30
 
 ### `gh api` with `-f` silently defaults to POST — breaks read-only queries  {#gh-api-f-defaults-post}

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -164,6 +164,25 @@ independent read-only review, exploration, or implementation-plan critique.
 
 ## P3 — nice-to-have
 
+### Symmetric `/ideate` → `/brainstorm` handoff field contract  {#ideate-brainstorm-handoff-symmetry}
+
+**Priority.** P3.
+
+**Effort.** ~1 hour (tighten `/ideate` Phase 6.6 wording).
+
+**Worth it when.** The `/ideate` → `/brainstorm` handoff starts dropping survivor context in practice
+— e.g. a brainstorm opens missing the axis / basis / ideation-doc path it should have inherited.
+
+**Context.** `/ideate` Phase 6.6 (`skills/ideate/references/convergence-and-partnership.md`) hands off
+by loading `brainstorm/SKILL.md` "with the chosen idea as the seed" without enumerating which SURVIVOR
+SCHEMA fields and the ideation-doc path travel. The brainstorm side is already robust (Phase 0.2 pulls
+from the named SURVIVOR SCHEMA and asks once for the doc path if absent), so this is a symmetry/clarity
+improvement, not a correctness bug. Surfaced by the rebuild's adversarial review (the brainstorm-side
+mismatch was fixed; the producer side was left as-is). See DECISIONS
+[#ce-ideation-engine-restore](DECISIONS.md#ce-ideation-engine-restore).
+
+---
+
 ### `deploy-status` per_page lookback can miss old tag refs  {#deploy-status-perpage-cap}
 
 **Priority.** P3.

--- a/plugins/infiquetra-lifecycle/.claude-plugin/plugin.json
+++ b/plugins/infiquetra-lifecycle/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infiquetra-lifecycle",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to sdlc-manager, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/infiquetra-lifecycle/CHANGELOG.md
+++ b/plugins/infiquetra-lifecycle/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.3.0 - 2026-06-01
+
+- Rebuild `/ideate` from a thin facilitative stub into a full divergent→convergent engine ported from
+  compound-engineering and adapted to the infiquetra world: parallel frame agents generate many
+  grounded candidates, the orchestrator critiques all and presents only the survivors, and cut ideas
+  stay first-class and revivable. Adds a two-way thought-partnership — the operator's seed ideas feed
+  *into* the frame agents (build on / challenge / combine) and face the identical critique — and a
+  revival state machine that re-enters the filter with new evidence, preserving explicit rejection as
+  the quality mechanism.
+- Add infiquetra-specific grounding to `/ideate`: a grounding-fit gate (proceed / decline /
+  recommend `/office-hours` / ask) weighing idea breadth against available grounding; a
+  context-library reader (`*-context-library` repos via `gh`, local-clone preferred); a named-repo
+  reader for multi-repo asks; read-only `gh` issue-theme clustering on backlog intent; and smart-auto
+  web research for the cross-domain-analogy frame. Adaptive frame count (1–6) scales to scope.
+- Rebuild `/brainstorm` into a thinking-partner engine that deep-dives one chosen idea (a `/ideate`
+  survivor or a named topic) into a right-sized requirements document: scope assessment, a product
+  pressure-test, one-question-at-a-time dialogue, 2–3 approaches with a non-obvious angle, and a
+  `requirements-ready` artifact under `docs/brainstorms/` for `/plan`.
+- Add reference files: `skills/ideate/references/convergence-and-partnership.md`,
+  `skills/ideate/references/ideation-artifact.md`, and
+  `skills/brainstorm/references/requirements-sections.md`. Self-contained — no runtime dependency on
+  compound-engineering.
+- Add `/handoff` to route durable lifecycle artifacts to `sdlc-manager` prepared issue drafts, with a
+  thin handoff-envelope helper that records source, maturity, target hints, blockers, open questions,
+  and the `/create-issue --prepare` routing command without owning SDLC issue bodies. Teach
+  `/plan <issue>` and `/work <issue>` to consume handoff maturity and source context from prepared
+  SDLC issues.
+
 ## 0.2.0 - 2026-05-31
 
 - Rename the plugin from `infiquetra-loop` to `infiquetra-lifecycle`; "loop" named only the `/loop`
@@ -10,14 +38,6 @@
 - Rename the handoff-envelope `loop_owner` field to `lifecycle_owner`.
 - Document the command set by lifecycle phase: Think, Plan & execute, Hand off, Review, and
   Improve & route.
-
-## Unreleased
-
-- Add `/handoff` to route durable lifecycle artifacts to `sdlc-manager` prepared issue drafts.
-- Add a thin handoff envelope helper that records source, maturity, target hints, blockers, open
-  questions, and the `/create-issue --prepare` routing command without owning SDLC issue bodies.
-- Teach `/plan <issue>` and `/work <issue>` to consume handoff maturity and source context from
-  prepared SDLC issues.
 
 ## 0.1.0 - 2026-05-29
 

--- a/plugins/infiquetra-lifecycle/commands/brainstorm.md
+++ b/plugins/infiquetra-lifecycle/commands/brainstorm.md
@@ -1,11 +1,12 @@
 ---
 name: brainstorm
-description: Explore requirements, constraints, and candidate approaches before planning
+description: Deep-dive one chosen Infiquetra idea into a right-sized requirements doc before planning
 argument-hint: "[topic]"
 ---
 
-Load `infiquetra-lifecycle/skills/brainstorm/SKILL.md`. Use collaborative discovery before narrowing
-to a plan, issue, or strategy update.
+Load `infiquetra-lifecycle/skills/brainstorm/SKILL.md`. Deep-dive one chosen idea — a `/ideate`
+survivor handoff or a named topic — as a thinking partner: pressure-test it, explore 2–3 approaches,
+and write a right-sized `requirements-ready` doc under `docs/brainstorms/` for `/plan`.
 
 Arguments provided to the command:
 

--- a/plugins/infiquetra-lifecycle/commands/ideate.md
+++ b/plugins/infiquetra-lifecycle/commands/ideate.md
@@ -1,11 +1,14 @@
 ---
 name: ideate
-description: Generate and evaluate grounded Infiquetra implementation or product ideas
+description: Generate, critique, and surface surviving grounded Infiquetra ideas — a multi-agent divergent→convergent engine
 argument-hint: "[topic]"
 ---
 
-Load `infiquetra-lifecycle/skills/ideate/SKILL.md`. Produce a small set of options, lead the user
-through tradeoffs one at a time when useful, and persist chosen directions under `docs/ideation/`.
+Load `infiquetra-lifecycle/skills/ideate/SKILL.md` and run its full engine: ground in the repo,
+journal, and relevant context-libraries; generate many candidates across parallel frames (the
+operator's seed ideas enter the same pool and face the same critique); critique all; and present only
+the survivors, with their rejection reasons preserved and revivable. Persist to `docs/ideation/` on
+request.
 
 Arguments provided to the command:
 

--- a/plugins/infiquetra-lifecycle/skills/brainstorm/SKILL.md
+++ b/plugins/infiquetra-lifecycle/skills/brainstorm/SKILL.md
@@ -1,19 +1,342 @@
 ---
 name: brainstorm
-description: Explore Infiquetra requirements, constraints, and implementation approaches before planning.
+description: Deep-dive one chosen Infiquetra idea into a right-sized requirements document before planning.
 ---
 
 # Brainstorm
 
-Use this for collaborative requirement discovery.
+Brainstorm answers **WHAT to build** for one chosen idea, then writes a right-sized requirements
+document. It precedes `/plan`, which answers **HOW to build it**.
 
-## Workflow
+Take a single idea — seeded from a `/ideate` survivor handoff, or a topic the operator names directly
+— and pressure-test it into a durable requirements doc strong enough that planning never has to invent
+product behavior, scope boundaries, or success criteria. This skill does not write implementation
+code. It explores, clarifies, and records product decisions.
 
-1. Gather local evidence first when the answer is discoverable from the repository.
-2. Identify goals, non-goals, users, constraints, failure modes, and deployment implications.
-3. Push on hidden operational and security risk.
-4. Produce a compact decision surface rather than a giant transcript.
-5. Persist durable output under `docs/brainstorms/`.
+The engine is **orchestrator-side dialogue**: the steps below run sequentially, in this session, one
+question at a time. The only parallel work allowed is the Phase 1 context scan (`Explore` agents).
+Resolve product decisions here; defer schemas, endpoints, file layouts, and code-level design to
+`/plan` unless the brainstorm is itself about a technical or architectural decision.
 
-Move to `/plan` when the approach is selected. Move to `/office-hours` when the topic is still
-more personal thought-partner than concrete engineering.
+Use repo-relative paths in every generated document. Absolute paths break portability across machines
+and worktrees.
+
+## Interaction rules
+
+These govern every turn of the dialogue.
+
+1. **One question per turn.** Even when sub-questions feel related, pick the single most useful one
+   and ask it. Stacking questions dilutes the answers.
+2. **Prefer single-select multiple choice** when choosing one direction, priority, or next step. Use
+   `AskUserQuestion` (call `ToolSearch` with `select:AskUserQuestion` first if its schema is not
+   loaded). It carries a free-text fallback, so options scaffold without confining.
+3. **Use multi-select rarely** — only for compatible sets (goals, constraints, non-goals, success
+   criteria that can coexist). If prioritization matters, follow up on which selected item is primary.
+4. **Ask open-ended only when the question is genuinely open** — the answer is inherently narrative,
+   the question is diagnostic and options would nudge the answer, or you cannot write 3-4 distinct
+   plausible options without padding. The rigor probes in Phase 1 are open-ended for exactly this
+   reason. Never silently skip the question.
+5. **Open-ended questions must be specific.** Name what counts as an answer ("the most concrete thing
+   someone's already done about this — paid, built a workaround, quit a tool"). Avoid "what's your
+   take?", "briefly", yes/no traps, and warmth wrappers.
+
+In a channel session (`redis-channel` active), do not call `AskUserQuestion`; inline the choices in
+your reply text instead ("Which? A) ... B) ... C) ...").
+
+## Topic
+
+Take the topic from command arguments, a `/ideate` survivor reference (e.g. `dig deeper on #N` or a
+survivor title), or the active artifact. If no topic is supplied, ask: "What would you like to dig
+into? Name the feature, problem, or `/ideate` survivor." Do not proceed without one.
+
+## Phase 0 — Resume, assess, route
+
+### 0.1 Resume
+
+If the operator references an existing brainstorm topic, or a recent matching
+`docs/brainstorms/*-requirements.md` exists, read it and confirm: "Found an existing requirements doc
+for [topic]. Continue from this, or start fresh?" If resuming, summarize current state, continue from
+its decisions and open questions, and update that file rather than creating a duplicate.
+
+### 0.2 Seed capture
+
+If the topic arrived from a `/ideate` handoff, ingest the survivor using `/ideate`'s SURVIVOR SCHEMA
+(defined in `infiquetra-lifecycle/skills/ideate/references/convergence-and-partnership.md`): its
+title, description, `axis` (when the ideation run produced an axis list), basis, rationale, downsides,
+confidence (0-100), complexity (Low/Med/High), and status. Treat status (`Unexplored` / `Explored`) as
+informational only — it records ideation-side state, not a requirement. Treat the basis and rationale
+as starting context, not settled requirements — the brainstorm still pressure-tests them. Any schema
+field absent from the handoff is treated as unstated, not invented; never fabricate a basis, axis, or
+confidence the survivor did not carry.
+
+**Capture provenance.** Record the ideation doc's repo-relative path (e.g.
+`docs/ideation/YYYY-MM-DD-<topic>-ideation.md`) and the survivor reference — its title or its `R#` id —
+so Phase 3 can populate the `source` field in the requirements-doc metadata. If the handoff did not
+name the ideation doc path, ask for it once; if still unavailable, note provenance as unstated rather
+than inventing a path.
+
+If the topic is direct (no `/ideate` handoff), treat the operator's opening as the seed and leave
+`source` unset — there is no upstream ideation doc to reference.
+
+### 0.3 Need check
+
+Scan for clear-requirements signals: specific acceptance criteria, a referenced pattern to follow,
+exact expected behavior, constrained well-defined scope. If requirements are already clear, keep it
+brief — confirm understanding and skip the Phase 1 *dialogue probes*. Still run the Phase 1.1
+existing-context scan: its verify-before-claiming rule holds even when no dialogue is needed. Then go
+to Phase 2.5 — announce mode (Path A) applies only when the scope is **Lightweight**; a richly
+pre-loaded Standard/Deep ask still gets Path B's confirmation gate before Phase 3. Do not force a long
+brainstorm onto a tight, well-framed ask.
+
+### 0.4 Scope assessment
+
+Classify the work from the seed plus a light repo scan:
+
+- **Lightweight** — small, well-bounded, low ambiguity.
+- **Standard** — a normal feature or bounded refactor with real decisions to make.
+- **Deep** — cross-cutting, strategic, or highly ambiguous.
+
+If scope is unclear, ask one targeted question to disambiguate, then proceed.
+
+**Deep sub-mode — feature vs product.** For Deep scope, also classify whether the brainstorm must
+establish product shape or inherit it:
+
+- **Deep — feature** (default): the existing product shape anchors the decisions. Primary actors,
+  core outcome, positioning, and primary flows are already established in the repo or product. The
+  brainstorm extends or refines within that shape.
+- **Deep — product**: the brainstorm must establish product shape rather than inherit it. Primary
+  actors, core outcome, positioning against adjacent products, or primary end-to-end flows are
+  materially unresolved. Existing code lowers the odds of product-tier but does not rule it out — a
+  half-built tool with ambiguous shape is still product-tier.
+
+Product-tier triggers the extra Phase 1.2 probes and the extra requirements sections noted in the
+section contract. Feature-tier uses Deep behavior unchanged.
+
+## Phase 1 — Understand the idea
+
+### 1.1 Existing-context scan (verify before claiming)
+
+Scan the repo before substantive dialogue. Match depth to scope. This scan may run parallel `Explore`
+agents; the dialogue that follows is sequential.
+
+**Lightweight** — search for the topic, check whether something similar already exists, move on.
+
+**Standard and Deep** — two passes:
+
+- *Constraint check* — read project instruction files (`AGENTS.md`, `CLAUDE.md`) for workflow,
+  product, or scope constraints. Read root `STRATEGY.md` when present — its target problem, wedge,
+  persona, non-goals, and active tracks are direct input to scope, success criteria, and which
+  approaches are aligned vs out of scope. If they add nothing, move on.
+- *Topic scan* — search relevant terms. Read the most relevant existing artifact (brainstorm, plan,
+  spec, prior `/ideate` doc) and skim adjacent examples of similar behavior. Check
+  `docs/engineering-journal/LEARNINGS.md` and `DECISIONS.md` for prior findings or decisions that bind
+  this idea.
+
+Two rules govern the scan:
+
+1. **Verify before claiming.** When the brainstorm touches checkable infrastructure (tables, routes,
+   config, dependencies, model definitions, deploy workflows), read the actual source to confirm what
+   exists. Any claim that something is *absent* — a missing table, an endpoint that does not exist, a
+   dependency not declared — must be verified against the code first. If you did not verify it, label
+   it an unverified assumption. This holds for every brainstorm regardless of topic.
+2. **Defer design to planning.** Schemas, migration strategy, endpoint structure, deploy topology
+   belong in `/plan` — unless the brainstorm is itself about that technical decision, in which case
+   those details are the subject and should be explored.
+
+If nothing obvious appears after a short scan, say so and continue.
+
+### 1.2 Product pressure-test (internal)
+
+Before generating approaches, read the operator's opening and note which rigor gaps actually exist.
+This is internal analysis, not a user-facing checklist. Raise only the gaps you found, folded into the
+Phase 1.3 dialogue — not fired as a pre-flight gauntlet. A fuzzy opening may earn three or four probes;
+a concrete, well-framed one may earn zero.
+
+**Lightweight:**
+- Is this solving the real problem?
+- Are we duplicating something that already covers this?
+- Is there a clearly better framing at near-zero extra cost?
+
+**Standard — scan for these gaps:**
+- **Evidence gap.** The opening asserts a want or need but points to nothing anyone has already done
+  (time spent, money paid, workarounds built) that would make the want observable.
+- **Specificity gap.** The beneficiary is described so abstractly you could not design without silently
+  inventing who they are and what changes for them.
+- **Counterfactual gap.** The opening does not make visible what people do today when this problem
+  arises, nor what changes if nothing ships.
+- **Attachment gap.** The opening treats a particular solution shape as the thing being built, rather
+  than the value that shape delivers, and has not been examined against smaller forms.
+
+Plus two synthesis questions you weigh in your own reasoning (not gap lenses):
+- Is there a nearby framing that creates more value without more carrying cost? What complexity does
+  it add?
+- Given the current state, goal, and constraints, what is the single highest-leverage move now: the
+  request as framed, a reframing, one adjacent addition, a simplification, or doing nothing?
+
+**Deep** — Standard, plus: is this a local patch, or does it move the broader system toward where it
+wants to be?
+
+**Deep — product** — Deep, plus:
+- **Durability gap.** The value proposition rests on a current state of the world that may shift in
+  predictable ways within the horizon the operator cares about.
+- What adjacent product could we accidentally build instead, and why is that the wrong one?
+- What would have to be true in the world for this to fail?
+
+These force an explicit product thesis and feed the Scope Boundaries and Dependencies/Assumptions
+sections of the requirements doc.
+
+### 1.3 Collaborative dialogue
+
+Follow the interaction rules above. Be a thinking partner — bring alternatives, challenge assumptions,
+explore what-ifs; do not only extract requirements.
+
+- Ask what the operator is already thinking before offering your own ideas. This surfaces hidden
+  context and prevents fixation on your framing.
+- Start broad (problem, users, value), then narrow (constraints, exclusions, edge cases).
+- **Probe only the gaps Phase 1.2 actually found, open-ended, one probe per gap.** Phase 1 cannot end
+  with an un-probed rigor gap that is present. Surface the probes progressively across the
+  conversation; interleaving with narrowing moves is fine. Examples, one per gap:
+  - *evidence* — "What's the most concrete thing someone's already done about this — paid, built a
+    workaround, quit a tool over it?"
+  - *specificity* — "Can you name a team or person you've actually watched hit this, or are you
+    reasoning from the abstract?"
+  - *counterfactual* — "What do people do today when this breaks — who picks up the slack?"
+  - *attachment* — "Before we look at approaches: what's the smallest version that still proves the
+    bet right, and what's excluded?" Fire this last of the rigor probes when the attachment gap is
+    present, regardless of whether a specific shape emerged through narrowing.
+  - *durability* — "Under the most plausible near-term shifts, how does this bet hold? Push past
+    answers every competitor could also make."
+  If a probe reveals genuine uncertainty, record it as an explicit assumption in the doc rather than
+  skipping it.
+- Clarify the problem frame, validate assumptions, ask about success criteria.
+- Make requirements concrete enough that planning will not need to invent behavior.
+- Surface dependencies or prerequisites only when they materially affect scope.
+- Resolve product decisions here; leave implementation choices for `/plan`.
+
+**Before exiting 1.3 — integration check.** Combine what the operator has said and surface any
+non-obvious consequence the dialogue has not probed. If stated-X plus stated-Y plus your-default-Z
+produces a downstream effect they are unlikely to have tracked through one-question-at-a-time dialogue,
+probe it now, open-ended, one probe per genuine combination effect. Phase 2.5 is a safety net for
+residuals, not a punt list for consequences you could ask about here.
+
+**Exit condition:** continue until the idea is clear AND no integration-check question is pending, OR
+the operator explicitly wants to proceed.
+
+## Phase 2 — Explore approaches
+
+If multiple plausible directions remain, propose **2-3 concrete approaches** grounded in the scan and
+the dialogue. Otherwise state the recommended direction directly.
+
+Use **at least one non-obvious angle** — inversion (what if we did the opposite?), constraint removal
+(what if X weren't a limit?), or analogy from how another domain solves this. The first approaches
+that come to mind are usually variations on the same axis.
+
+**Present approaches first, then evaluate.** Let the operator see all options before hearing which is
+recommended — leading with a recommendation anchors the conversation prematurely.
+
+When useful, include one deliberately higher-upside challenger: the adjacent addition or reframing
+that would most increase usefulness, compounding value, or durability without disproportionate
+carrying cost. Present it alongside the baseline, not as the default. Omit it when the work is already
+over-scoped or the baseline request is clearly the right move.
+
+At product tier, alternatives differ on **what** is built (product shape, actor set, positioning), not
+**how** it is built. Implementation-variant alternatives belong at feature tier.
+
+For each approach give:
+- Brief description (2-3 sentences).
+- Pros and cons.
+- Key risks or unknowns.
+- When it is best suited.
+
+**Granularity: mechanism / product shape, not architecture.** Name mechanism-level distinctions and
+product trade-offs (coupling, complexity surface, migration difficulty). Do NOT name column names,
+table names, file paths, class names, or JSON shapes — that is `/plan`'s job. Bringing architecture
+forward here forces architectural decisions on intentionally-shallow research, and the Phase 2.5
+synthesis then has to filter the leak back out.
+
+After presenting all approaches, state your recommendation and explain why. Prefer simpler solutions
+when added complexity creates real carrying cost, but do not reject low-cost, high-value polish just
+because it is not strictly necessary. If one approach is clearly best and alternatives are not
+meaningful, skip the menu and state it directly. When relevant, call out whether the choice is: reuse
+an existing pattern, extend an existing capability, or build something net new.
+
+## Phase 2.5 — Scope-confirmation synthesis
+
+Surface a scoping synthesis before Phase 3 writes the doc — the operator's last chance to correct
+scope before the artifact lands. Shape it like what two product collaborators confirm before writing a
+spec, not like a comprehensive audit. Each bullet must pass two tests: the **affirmability test** (can
+the operator evaluate it without reading code?) and the **detail test** (1-2 lines, conversational,
+not documentary). Over-share and over-detail are the failure modes.
+
+Two paths, decided by whether any blocking question fired AND the Phase 0.4 tier:
+
+- **Path A — no blocking question fired AND tier is Lightweight:** announce mode. Emit a 1-3 sentence
+  "What we're building" prose summary, then proceed to Phase 3 in the same turn. No confirmation
+  question; do not wait for acknowledgment. Lightweight docs are short and post-hoc revision is cheap.
+- **Path B — at least one blocking question fired, OR tier is Standard / Deep-feature / Deep-product:**
+  full scoping synthesis with a confirmation gate. Surface what we're building, what's in scope,
+  what's explicitly out, and the open questions; confirm before writing. Confirmation is
+  unconditional even when zero call-outs survive — the operator invested answer-time (or pre-loaded
+  substantive scope), so the substance earns a real checkpoint.
+
+The tier guard distinguishes a tight one-liner (Lightweight → Path A) from a richly pre-loaded ask
+that needs no dialogue only because everything was pre-stated (Standard/Deep → Path B).
+
+## Phase 3 — Capture the requirements
+
+Write or update a requirements document only when the dialogue produced durable decisions worth
+preserving. Skip it when the operator needed only brief alignment and the decisions can flow straight
+to `/plan` or a commit message without a brainstorm artifact in between.
+
+When a doc is warranted, compose it from the section contract:
+
+Load `infiquetra-lifecycle/skills/brainstorm/references/requirements-sections.md` and follow it.
+
+When the topic arrived from a `/ideate` handoff, populate the metadata `source` field from the
+provenance captured in Phase 0.2 — the ideation doc's repo-relative path plus the survivor reference
+(its title or `R#`). Leave `source` unset for a direct topic. This keeps the ideate → brainstorm
+provenance link traceable.
+
+Write to `docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md` (today's date; `<topic>` kebab-case).
+Use repo-relative paths inside the doc. Confirm completion with the absolute path so the reference is
+clickable.
+
+## Phase 4 — Handoff
+
+The brainstorm artifact carries handoff maturity **`requirements-ready`**, which feeds `/handoff` →
+`sdlc-manager` and is consumed by `/plan`.
+
+Present next-step options and execute the operator's selection. Hide options that do not apply and
+renumber so visible options stay contiguous. While any "Resolve before planning" question remains
+open, hide **Plan** and **Build it now**: resolve those blocking questions first (one at a time), or,
+if the operator proceeds anyway, convert each remaining item into an explicit decision, assumption, or
+"Deferred to planning" question; if they pause, present the handoff as paused, not complete.
+
+Options:
+
+1. **Plan it with `/plan` (recommended)** — move to `/plan` for structured implementation planning.
+   Pass the requirements doc path. Shown only when no "Resolve before planning" question remains.
+2. **Hand off via `/handoff`** — route the `requirements-ready` artifact to `sdlc-manager` as a
+   prepared issue draft for another team or a later session. Shown when a requirements doc exists.
+3. **Review with `/doc-review`** — dispatch a readiness review of the requirements doc before
+   planning. Shown when a requirements doc exists.
+4. **More clarifying questions** — return to Phase 1.3, keep refining scope, edge cases, and
+   constraints one question at a time, then return here. Always shown.
+5. **Back to `/office-hours`** — when the topic turns out to be more open thought-partner work than a
+   concrete requirements ask. Always available.
+6. **Done for now** — the requirements doc is saved and resumable later. Always shown.
+
+Use `AskUserQuestion` when 4 or fewer options are visible; render a numbered list ("Pick a number or
+describe what you want.") when 5 or more are visible. Never silently skip the question.
+
+When the run ends or hands off, close with the requirements doc's absolute path, the key decisions, and
+the recommended next step (`/plan` when ready, or `/office-hours` if it bounced back). When paused with
+blocking questions still open, state that planning is blocked by those questions and that the operator
+can resume with `/brainstorm`.
+
+## Dropped from the CE original
+
+No HTML rendering or output-mode resolution; no Proof / HITL review loop; no non-software / universal
+brainstorming mode; no Slack researcher; no dedicated Visualizations affordance (introduce a diagram
+ad hoc via agent agency when it genuinely helps). The artifact is always a single markdown file under
+`docs/brainstorms/`. Scratch, when needed, goes under `.claude/infiquetra-lifecycle/`, never `/tmp`.

--- a/plugins/infiquetra-lifecycle/skills/brainstorm/references/requirements-sections.md
+++ b/plugins/infiquetra-lifecycle/skills/brainstorm/references/requirements-sections.md
@@ -1,0 +1,157 @@
+# Requirements-Doc Section Contract
+
+Loaded by `/brainstorm` Phase 3. Describes WHAT the requirements document contains and how to
+right-size it by scope. The doc is always a single markdown file at
+`docs/brainstorms/YYYY-MM-DD-<topic>-requirements.md`.
+
+The discipline of this contract: **resolve product decisions here; defer implementation to `/plan`.**
+User-facing behavior, scope boundaries, and success criteria belong in this doc. Schemas, endpoints,
+file layouts, and code-level design do not — unless the brainstorm is itself about that technical
+decision, in which case those details are the subject and belong here.
+
+## The outcome
+
+A great requirements doc lets three audiences act:
+
+- **The planning agent** (`/plan` or a human) produces an implementation plan without inventing user
+  behavior, scope boundaries, or success criteria — this doc answered those.
+- **The reviewer** sees the framing choices, distinguishes pinned from open, and catches scope gaps
+  before planning.
+- **The future reader** traces why the proposed thing matters, who it's for, and what success is.
+
+Sections earn their place by serving one of these audiences. Omit padding.
+
+## Decide whether a doc is warranted at all
+
+Not every brainstorm needs a durable doc. Skip it when **both** hold:
+
+- The dialogue produced no novel scope, framing, or decision worth preserving in IDed shape — the
+  operator needed only brief alignment.
+- Any durable decision can flow straight to `/plan`, the commit message, or `docs/` without a
+  brainstorm artifact in between.
+
+Create the doc when the dialogue surfaced enough structural decisions, scope boundaries, or acceptance
+criteria that the planner, reviewer, or future reader needs them in durable, IDed form — not just as
+conversation.
+
+**Stress test:** a brainstorm about a tiny bug fix where the operator asks "null check or upstream
+validation?" and you confirm "upstream validation, here's why" does NOT need a doc — the decision
+flows to `/plan` directly. A brainstorm about a multi-actor feature with contested scope and several
+behavioral conditions probably does — the planner needs the structured content.
+
+## Right-sizing by scope
+
+Depth matches what the dialogue produced and the Phase 0.4 tier. A sparse brainstorm produces a sparse
+doc; a rich one produces a rich doc. Do not add ceremony to make a slim brainstorm look substantial.
+
+- **Lightweight** — Summary plus a short Requirements list, often without R-IDs. May be a handful of
+  bullets. No actors, flows, or acceptance examples unless they genuinely apply.
+- **Standard** — Hard floor plus the include-when-material sections the dialogue actually populated:
+  typically Key Decisions, Requirements (grouped, R-IDs), Scope Boundaries, and Success Criteria.
+- **Deep — feature** — Standard depth plus Key Flows, Acceptance Examples for conditional
+  requirements, and Dependencies / Assumptions as warranted.
+- **Deep — product** — Deep plus the product-shape sections: an explicit product thesis, Scope
+  Boundaries split into "Deferred for later" and "Outside this product's identity", and the durability
+  assumptions surfaced in the Phase 1.2 product probes.
+
+## Metadata
+
+Markdown frontmatter at the top of the file. Field names are stable — never rename or repurpose them;
+adding new fields is fine.
+
+- **`date`** — ISO 8601 (`YYYY-MM-DD`), ASCII digits. Used in the filename.
+- **`topic`** — kebab-case slug identifying the subject (e.g. `surface-scope-earlier`). Used in the
+  filename and as the resume-detection key when Phase 0.1 scans `docs/brainstorms/`.
+- **`maturity`** — `requirements-ready`. The handoff maturity this artifact carries into `/handoff`
+  and `/plan`.
+- **`source`** — when the topic came from `/ideate`, the relative path of the ideation doc and the
+  survivor reference (e.g. the survivor title or its `R#`), so provenance is traceable.
+
+There is no `status` field — a requirements doc is a one-time output, not a lifecycle artifact.
+
+## Hard floor
+
+When a doc is warranted, these are always present.
+
+- **Summary** — what is being proposed, in 1-3 lines. Forward-looking. Orients the reader before they
+  invest in detail.
+- **Requirements** (stable R-IDs) — what must be true about the proposed thing. For very sparse
+  brainstorms (≤3 simple items where the bullets ARE the summary), plain bullets without IDs are fine;
+  the trigger for R-IDs is whether downstream consumers will reference them. When requirements span
+  distinct concerns, group them under bold inline headers — group by capability or concern, not by the
+  order discussed. R-IDs stay continuous across groups (R1, R2 in the first group; R3, R4 in the
+  second; never restart per group). A long flat list is a smell that subgroups were missed.
+
+## Include when material
+
+Decide per brainstorm whether each section carries information not covered elsewhere. Placeholder
+prose is worse than omission.
+
+- **Problem Frame** — include when motivation is not obvious from Summary alone (the *why* needs
+  paragraphs). Backward-looking / situational. Does NOT restate the proposal — the remedy lives in
+  Summary.
+- **Key Decisions** — include when the brainstorm produced opinionated framing choices (defaults,
+  scope narrowings, foundational picks) that constrain Requirements / Flows / Scope below. Name each
+  in bold with prose rationale. Sits high so readers meet the framing before the detail.
+- **Actors** — include when the proposed thing has multi-party behavior (multiple humans, agents, or
+  systems meaningfully involved). Skip for non-behavioral briefs.
+- **Key Flows** — include when the proposed thing has multi-step behavior. Expected by default for
+  behavioral brainstorms unless the thing is genuinely non-flow-shaped (pure API surface, policy,
+  artifact output) and Actors / Requirements / Scope / Acceptance Examples together prevent downstream
+  invention. When omitting from a behavioral brainstorm, note the reason.
+- **Acceptance Examples** — include when any requirement has a state-dependent or conditional shape
+  ("When X, Y") where prose alone leaves edge-case ambiguity. Always cover behavioral-conditional
+  requirements — that is where ambiguity bites hardest. Skip when all requirements are unconditional
+  and unambiguous.
+- **Success Criteria** — include when there are quality / metric / handoff signals Requirements do not
+  already carry: quantitative ("p95 under 200ms"), qualitative ("reads as one voice"), or handoff
+  ("`/doc-review` can act on this without follow-ups"). Skip when Requirements ARE the success
+  criteria.
+- **Scope Boundaries** — include when scope is contested or there are tempting non-goals worth naming.
+  At Deep-product, split into "Deferred for later" (eventually but not v1) and "Outside this product's
+  identity" (a positioning decision). Otherwise a single list is fine.
+- **Dependencies / Assumptions** — include when material upstream dependencies exist or load-bearing
+  assumptions need surfacing — including any unverified-absence assumption from the Phase 1.1 scan and
+  any durability assumption from the Phase 1.2 probes.
+- **Outstanding Questions** — include when items are unresolved. Distinguish "Resolve before planning"
+  (blocks `/plan`) from "Deferred to planning" (answered during planning or codebase exploration).
+  Phase 4 hides Plan and Build-it-now while any "Resolve before planning" item remains.
+- **Sources / Research** — surface research that orients the planner or justifies framing: code
+  locations, `STRATEGY.md` direction, journal `LEARNINGS`/`DECISIONS` entries, context-library
+  guidance, prior plans, external docs. Test: *would this breadcrumb help a planner reading cold?*
+  Process exhaust (reading the prompt, glancing at obvious files) → omit.
+
+## Agent agency
+
+The catalog is a floor, not a ceiling. When content does not fit any catalog section, introduce a new
+one — content drives section choices, not the reverse. You also pick whether Acceptance Examples render
+as a separate section or embed in each requirement, and how much depth each present section gets.
+
+## ID and content rules
+
+- **Stable IDs.** R-IDs (Requirements), A-IDs (Actors), F-IDs (Flows), AE-IDs (Acceptance Examples).
+  No other ID namespaces.
+- **Plain prefix.** `R1.`, `A1.`, `F1.`, `AE1.` as bullet prefixes. Do not bold them.
+- **Bold leader labels** inside Flows and Acceptance Examples (`**Trigger:**`, `**Covers R4, R8.**`)
+  give structure without deeper heading levels.
+- **Repo-relative paths.** Always. Never absolute paths — they break portability across machines and
+  worktrees.
+- **No process exhaust.** No "captured at Phase X" notes, no "## Next steps" pointing at `/plan`, no
+  italic provenance lines in the body. Process metadata belongs in commit messages and tool output.
+- **No implementation details by default.** Libraries, schemas, endpoints, file layouts, and code
+  structure stay out unless the brainstorm is inherently about that technical or architectural change
+  and those details are the subject of the decision.
+
+## Summary vs Problem Frame
+
+When both are present, they earn separate sections only by holding to different purposes:
+
+| Section | Question it answers | Time direction | Length |
+|---|---|---|---|
+| `## Summary` | What is this doc proposing? | Forward-looking | 1-3 lines |
+| `## Problem Frame` | Why does this proposal exist? | Backward-looking / situational | Paragraphs |
+
+- **Summary** needs no problem context — a reader scanning it gets the proposal at a glance.
+- **Problem Frame** does not restate the proposal. It establishes the situation, the moment of pain,
+  and the cost shape, then stops. The remedy lives in Summary; restating it here is the duplication
+  that makes the two sections feel redundant.

--- a/plugins/infiquetra-lifecycle/skills/ideate/SKILL.md
+++ b/plugins/infiquetra-lifecycle/skills/ideate/SKILL.md
@@ -1,19 +1,529 @@
 ---
 name: ideate
-description: Generate and critically evaluate grounded Infiquetra product, architecture, or workflow ideas.
+description: Generate and critically evaluate grounded Infiquetra product, architecture, or workflow ideas. Multi-agent divergent→convergent engine — generate many, critique all, explain survivors only. Triggers on "ideate on X", "give me ideas", "what should I improve", "surprise me", "what would you change".
 ---
 
 # Ideate
 
-Use this when the user needs options, not execution yet.
+Generate and critically evaluate grounded Infiquetra ideas. The engine generates many
+candidates across parallel frames, critiques all of them, and explains only the survivors —
+with their rejection reasons preserved and revivable.
 
-## Workflow
+`/ideate` sits in the Think phase, before `/brainstorm` and `/plan`:
 
-1. Ground ideas in repository evidence, current SDLC context, and context-library links.
-2. Produce a small option set with clear tradeoffs.
-3. When the option set is broad, lead the user through choices one at a time.
-4. Label risks and assumptions explicitly.
-5. Persist selected ideas under `docs/ideation/` with links to issues, strategy, or plans.
+- `/office-hours` answers: "What is even the right frame here?"
+- `/ideate` answers: "What are the strongest ideas worth exploring?"
+- `/brainstorm` answers: "What exactly should one chosen idea mean?"
+- `/plan` answers: "How should it be built?"
 
-Graduate to `/brainstorm` when requirements need exploration, `/strategy` when the durable
-direction changed, or `/plan` when the implementation path is clear.
+This skill produces a ranked ideation artifact under `docs/ideation/`. It does **not** produce
+requirements, plans, or code.
+
+## Core principles
+
+1. **Ground before ideating.** Scan the actual repo, journal, and relevant context-libraries
+   first. Do not generate abstract advice detached from the infiquetra world.
+2. **Generate many → critique all → explain survivors only.** The quality mechanism is explicit
+   rejection with reasons, not optimistic ranking. Extra process must not obscure this.
+3. **Two-way partnership.** AI-generated and user-supplied ideas enter the **same** pool and face
+   the **same** critique. User seeds are fed **into** the frame agents to build on / challenge /
+   combine — never just judged at the end, never rubber-stamped, never silently dropped.
+4. **Rejection is first-class and revivable.** Cut ideas keep stable IDs and can be revived — but
+   only by re-entering the filter with new evidence (see the convergence reference).
+
+## Interaction method
+
+Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch`
+with `select:AskUserQuestion` first if its schema isn't loaded). Fall back to numbered options in
+chat only when no blocking tool exists or the call errors. In a channel session, inline the
+choices in the reply text. Never silently skip a gate question. Ask one question at a time.
+
+## Focus hint
+
+<focus_hint> #$ARGUMENTS </focus_hint>
+
+Treat any argument as optional context: a concept (`DX improvements`), a path
+(`plugins/test-suite/`), a constraint (`low-complexity quick wins`), a backlog phrasing
+(`themes in our open issues`), or a volume hint (`top 3`, `100 ideas`, `raise the bar`). With no
+argument, proceed open-ended.
+
+---
+
+## Phase 0: Scope, grounding-fit gate, and seed capture
+
+### 0.1 Resume check
+
+Look in `docs/ideation/` for ideation docs from the last 30 days. Treat one as relevant when the
+topic matches, the path/subsystem overlaps, or the request is open-ended with one obvious recent
+open doc. Keep issue-grounded and non-issue ideation as distinct topics — do not offer to resume
+across that boundary. If a relevant doc exists, ask whether to **continue** (read it, summarize
+what was explored, preserve prior idea statuses, update the file in place) or **start fresh**.
+
+### 0.2 Grounding-fit gate — ASK when unsure, never silently auto-route
+
+Every downstream agent needs an identifiable subject and enough grounding to say something
+specific. Weigh the **idea's breadth** against the **available grounding** — the current repo,
+relevant `*-context-library` repos, and any named infiquetra repos. There are four outcomes.
+When the call is not obvious, **ask** rather than auto-deciding; a vibe-check that routes silently
+is the failure this gate exists to prevent.
+
+**Outcome 1 — Clearly groundable → proceed.** The idea is bound to grounding you can actually
+reach:
+
+- Repo-bound — the idea lives inside the current repo. *Example: sitting in
+  `infiquetra-claude-plugins`, `/ideate quick wins in the test-suite plugin` — the plugin source
+  is right here.*
+- Multi-repo with named repos — the idea spans repos and names them. *Example: `/ideate how
+  campps-auth and campps-identity-access should share session state` — both repos exist and are
+  named, so grounding is bounded.* Record the named repos; Phase 1 grounds against each of them
+  through the named-repo reader (Source 3).
+- Inside a `*-context-library` with an idea that library grounds. *Example: sitting in
+  `mimir-context-library`, `/ideate gaps in our mimir routing taxonomy` — the library is exactly
+  the substance the idea needs.* Record that **the current repo is itself a `*-context-library`**;
+  Phase 1 threads this flag so the library is read locally in place as the primary grounding
+  (Source 4), not re-fetched over `gh` as if it were a remote. When it is borderline whether the
+  library actually grounds the idea (vs. the idea being broader than the library's domain), lean to
+  the **Case B** ask below rather than silently proceeding.
+
+State the inferred framing in one plain sentence ("Treating this as a topic inside the test-suite
+plugin — about X") and proceed. Never print internal routing labels. Carry forward two facts the
+gate establishes for Phase 1: **the named repos** (when the multi-repo branch fired) and **whether
+the current repo is itself a `*-context-library`** (when the in-library branch fired).
+
+**Outcome 2 — Out of the engineering domain → politely decline / redirect.** The subject has no
+software surface in the infiquetra world — coffee, branding independent of a product, personal
+decisions, non-digital business strategy. *Example: `/ideate names for my side coffee roastery`
+→ decline: "That's outside what `/ideate` grounds against — I'd be generating ungrounded slop.
+Want to take it to a general chat instead?"* Redirect kindly; do not run the engine. When a
+subject sits on the engineering / non-engineering line — *"the infiquetra brand voice in our
+docs"*, *"our developer-onboarding experience"* — do **not** hard-decline; **ask** which side it
+is on (ground it as an engineering topic, or take it to general chat), per ASK-when-unsure.
+
+**Outcome 3 (Case A) — Unframed / cannot settle a scope → recommend `/office-hours`.** The prompt
+refers only to a quality or placeholder, not a subject — `improvements`, `ideas`, `what to
+build`, `things to fix`, an empty prompt — and no repo footprint settles it. Being inside a repo
+does **not** settle this: `improvements` in `infiquetra-claude-plugins` still scatters across DX,
+reliability, new plugins, docs, and tests. *Example: `/ideate ideas` with nothing else → "There's
+no settled subject here for the agents to work on. `/office-hours` is built for finding the frame
+first — want to start there?"* Recommend `/office-hours`; proceed only if the operator declines,
+and only after asking them to name a subject or pick "surprise me."
+
+> Cheap disambiguation before asking: if a short phrase *might* name something
+> (`browser sniff`, `dark mode`), Glob filenames or Grep the README/docs for it. Any footprint →
+> treat as identifiable and proceed. No footprint and still reads as a bare quality → Case A.
+
+**Outcome 4 (Case B) — Broad relative to grounding but still infiquetra → surface the mismatch
+and ASK, leaning `/office-hours`.** The idea is legitimately infiquetra but far broader than the
+grounding you are sitting in. *Example: sitting in `mimir-context-library`, `/ideate the whole
+infiquetra plugin marketplace strategy` — real infiquetra topic, but the library grounds mimir,
+not the marketplace.* Surface it plainly: "You're in `mimir-context-library`, but this idea spans
+the whole marketplace — the grounding here won't carry it. `/office-hours` fits a question this
+broad better. Or name the repos it should span and I'll ground against each of them. Proceed broad
+in place anyway?" Lean office-hours; proceed broad in-place only if the operator declines the
+redirect. If the operator takes the "name the repos" offer, record those repos and ground against
+them via the named-repo reader (Source 3) — do not promise grounding the engine cannot reach. If
+they decline and proceed broad in-place without naming repos, note that grounding will be thin
+(only the library you are sitting in), and weight survivors accordingly.
+
+### 0.3 Capture user seed ideas
+
+Ask whether the operator already has ideas they want in the run. Capture each verbatim as a
+`user-seed` candidate. These are **partnership inputs**: they will be passed *into* the Phase 2
+frame agents to build on / challenge / combine, AND enter the merged pool, AND face the identical
+Phase 3 critique. They are never rubber-stamped and never silently dropped. If the operator has
+none, note "no user seeds" and proceed — generation does not depend on them.
+
+### 0.4 Focus, volume, and adaptive frame count
+
+Infer two things from the focus hint and intake:
+
+- **Focus context** — concept, path, constraint, backlog phrasing, or open-ended.
+- **Volume override** — honor clear hints: `top 3`, `100 ideas`, `go deep`, `raise the bar`.
+
+**Tactical-scope detection.** Scan the focus for tactical signals: `polish`, `typo`, `typos`,
+`quick wins`, `small improvements`, `cleanup`, `small fixes`, or a single narrow file/line. When
+present, lower the Phase 2 ambition floor (the meeting-test is waived) — the operator has opted
+into tactical scope.
+
+**Adaptive frame count (1–6) by scope.** Frame agents run on the **inherited model — no
+tier-down** (creative ideation needs full reasoning). Scale the count to scope:
+
+- **Tactical / single narrow file or fix** → 1 frame (or a single orchestrator pass for a true
+  one-liner).
+- **Narrow — one flow, one stage, one plugin** → 2–3 frames.
+- **Standard subsystem or component** → 4 frames.
+- **Broad — whole repo, multi-repo, or a sweeping product/architecture question** → all 6 frames.
+
+Default per-frame target is ~6–8 raw candidates; volume overrides adjust it.
+
+### 0.5 Cost notice
+
+Before dispatching, state the agent count in one line so multi-agent cost is not invisible. Count
+= grounding agents (current-repo scan + journal-learnings, always; named-repo reader, one per
+repo the gate recorded for a multi-repo or "name the repos" ask; context-library reader when a
+relevant library exists; issue read+cluster only on backlog intent; web only for the cross-domain
+frame or on request) + N frame agents. When backlog intent fires (Source 5), the frame count is the
+theme-frame count (≤4 — see Phase 2's backlog override), not the adaptive N above; state that count.
+The line is informational; the operator need not ack it.
+
+> Example: "Will dispatch ~7 agents: current-repo scan + journal-learnings + context-library
+> reader + 4 frame agents. Skip phrases: 'no web research'."
+> Example (multi-repo): "Will dispatch ~8 agents: current-repo scan + journal-learnings +
+> named-repo reader x2 (campps-auth, campps-identity-access) + 4 frame agents."
+> Example (tactical): "Will dispatch ~3 agents: current-repo scan + journal-learnings + 1 frame
+> agent."
+
+---
+
+## Phase 1: Grounding
+
+Generate a `<run-id>` once (8 hex chars). Create the scratch directory and capture its absolute
+path for every checkpoint write this run:
+
+```bash
+SCRATCH_DIR=".claude/infiquetra-lifecycle/ideate/<run-id>"
+mkdir -p "$SCRATCH_DIR"
+echo "$SCRATCH_DIR"
+```
+
+Use the echoed path as `<scratch-dir>`. Scratch lives under `.claude/infiquetra-lifecycle/` — it
+is ignored local state, never `/tmp` and never a durable doc.
+
+Dispatch the grounding agents **in parallel, in the foreground** (results are needed before Phase
+2). Each agent below carries its **verbatim tuned prompt** — dispatch it with that prompt body, not
+a generic "scan the repo" instruction. The prompt body is the repeatability guarantee.
+
+### Source 1 — Current-repo scan (always)
+
+Dispatch an `Explore` (or general-purpose) sub-agent on the cheapest capable model with this
+prompt verbatim, substituting `{focus_hint}`:
+
+> Read the project's `AGENTS.md` (or `CLAUDE.md` as a compatibility fallback, then `README.md` if
+> neither exists). Read `STRATEGY.md` if present — it captures the repo's target problem, wedge,
+> persona, non-goals, and success criteria. Discover the top-level directory layout with the
+> native glob tool (`Glob` pattern `*` then `*/*`). Read `docs/engineering-journal/` if present
+> for the project's own record of how it thinks.
+>
+> For other root-level `*.md` files: if the focus hint names one specifically (e.g. "ideate based
+> on FEEDBACK.md"), fully read it and include its substantive content under a heading
+> `User-named references` — Phase 2 treats these as *constraint*, so quote real content, not a
+> gist. For any other root-level `*.md` files, read briefly and give a one-line gist under
+> `Additional context` — Phase 2 treats these as *background*.
+>
+> Return a concise summary (under 40 lines, longer only if user-named references carry substantive
+> content) covering:
+>
+> - project shape (language, framework, top-level layout)
+> - notable patterns or conventions
+> - obvious pain points or gaps
+> - likely leverage points for improvement
+> - product/technical strategy summary if `STRATEGY.md` was present — include the wedge and active
+>   direction verbatim so ideation can weight toward strategy-aligned moves
+> - `User-named references` section (when the focus named root-level `*.md` files)
+> - `Additional context` section (when other root-level `*.md` files exist)
+>
+> Keep the scan shallow otherwise — top-level docs and directory structure only. Do not analyze
+> GitHub issues, templates, or contribution guidelines. Do not do deep code search.
+>
+> Focus hint: {focus_hint}
+
+### Source 2 — Journal-learnings (always)
+
+Read the current repo's own engineering journal directly (no separate agent needed if the
+current-repo scan already loaded it; otherwise dispatch a sub-agent with this prompt verbatim):
+
+> Read `docs/engineering-journal/LEARNINGS.md` and `docs/engineering-journal/DECISIONS.md` in this
+> repo. Return only the entries relevant to this ideation focus: prior empirical findings, the
+> mechanisms behind them, and any architecture/convention/tooling decisions (with their "revisit
+> when" conditions) that bear on the focus. For each, give the one-line generalizable rule and a
+> `file:line` or entry-date reference. Skip everything unrelated to the focus. If either file is
+> absent, say so and return nothing for it.
+>
+> Focus hint: {focus_hint}
+
+Surfaced learnings/decisions become `direct:` basis material for Phase 2 — an idea that
+contradicts a recorded decision must engage that decision's "revisit when" condition or be cut.
+
+### Source 3 — Named-repo reader (when the gate recorded named repos)
+
+Trigger when Phase 0's gate recorded named repos — a multi-repo ask (`how campps-auth and
+campps-identity-access should share session state`) or the Case B "name the repos it should span"
+offer. This is the source that makes the gate's multi-repo promise real: it reads each named repo
+the operator actually named, not just the current repo. Dispatch **one reader sub-agent per named
+repo** in parallel, each with this prompt verbatim, substituting the repo name and focus:
+
+> You are reading the `{repo_name}` infiquetra repo for material relevant to this ideation focus —
+> this repo is in scope because the operator named it. Prefer the local clone at
+> `~/workspace/infiquetra/{repo_name}` when it exists (faster and matches the working tree);
+> otherwise read via `gh api` / `gh repo view`. Read the repo's `AGENTS.md` (or `CLAUDE.md` as a
+> compatibility fallback, then `README.md`), `STRATEGY.md` if present, and the top-level directory
+> layout relevant to the focus. Keep the scan shallow — top-level docs and the layout that bears on
+> the focus only; do not do deep code search. Return: (1) the repo's shape, conventions, and the
+> part of it the focus touches; (2) any constraint or contract this repo imposes that a cross-repo
+> idea would have to honor (e.g., the session-token shape it already emits); (3) `file:line` or
+> doc-name references so Phase 2 can cite `direct:` basis. If the repo cannot be reached (no clone
+> and `gh` fails), say so plainly and return nothing for it.
+>
+> Repo: {repo_name}
+> Focus hint: {focus_hint}
+
+The returned repo shapes and cross-repo constraints become `direct:` basis material for Phase 2 —
+a cross-repo idea that violates a contract a named repo already imposes must engage it or be cut.
+On a per-repo read failure, follow **warn and proceed** ("Could not ground against {repo}: {reason}.
+Proceeding with the repos that read.") — never block on one unreachable repo.
+
+### Source 4 — Context-library reader (when a relevant library exists)
+
+**Current-repo short-circuit.** When Phase 0's gate flagged that the current repo is itself a
+`*-context-library` (the in-library branch of Outcome 1), that library is the primary grounding and
+is already in the working tree. Do **not** re-fetch it over `gh` — read it locally in place: point a
+reader sub-agent at the current working directory using the verbatim prompt below with
+`{library_name}` set to the current repo and the local-clone path being `.` (the current repo), and
+treat its output as the primary context-library context. Reserve `gh`-based discovery and remote
+reads for OTHER topic-relevant libraries. This keeps the explicit library framing the gate said was
+"exactly the substance the idea needs" and avoids a slower, staler remote double-read of the repo
+you are standing in.
+
+Then discover any OTHER libraries by pattern (skip the current repo in the results when it is itself
+a context-library — it is already covered by the short-circuit above):
+
+```bash
+gh repo list infiquetra --limit 300 --json name --jq '.[].name' | grep -i context-library
+```
+
+Pick the topic-relevant ones (e.g. `mimir-context-library` for mimir/routing topics,
+`campps-context-library` for campps topics, `infiquetra-context-library` for org-wide
+conventions). For each relevant library, dispatch a reader sub-agent with this prompt verbatim,
+substituting the library name and focus:
+
+> You are reading the `{library_name}` context-library repo for material relevant to this
+> ideation focus. Prefer the local clone at `~/workspace/infiquetra/{library_name}` when it exists
+> (faster); otherwise read via `gh api` / `gh repo view`. Read the library's `README.md` and
+> top-level layout first to understand what domain it grounds, then read only the documents
+> relevant to the focus. Return: (1) the context this library establishes that bears on the focus
+> — conventions, taxonomies, prior analyses, constraints; (2) any explicit guidance the library
+> gives that an idea would have to honor; (3) `file:line` or doc-name references so Phase 2 can
+> cite `direct:` basis. Skip everything unrelated. If nothing in the library bears on the focus,
+> say so plainly and return nothing.
+>
+> Library: {library_name}
+> Focus hint: {focus_hint}
+
+If no `*-context-library` is topic-relevant, skip this source and note it in the cost notice.
+
+### Source 5 — Issue read + cluster (ONLY on backlog intent)
+
+Trigger only when the topic is explicitly about the backlog — phrasings like `open issues`, `issue
+themes`, `issue patterns`, `what users are reporting`, `bug reports`. Do **not** trigger on a focus
+that merely mentions a bug (`bug in auth`, `the signup bug`). There is **no sdlc-manager
+dependency** — this is a read-only `gh` read plus local clustering. Dispatch a sub-agent with this
+prompt verbatim, substituting the repo and focus:
+
+> Run this read-only command and cluster the results — do not mutate any issue, do not call
+> sdlc-manager:
+>
+> ```bash
+> gh issue list --repo {repo} --state open --json number,title,body,labels --limit 200
+> ```
+>
+> Group the open issues into 3–6 coherent themes by what they are actually about (not by label
+> alone). For each theme return: a short theme name, the issue numbers in it, a one-line
+> description of the shared problem, and a rough sense of how many issues and how recent. If fewer
+> than 5 open issues exist, say "insufficient issue signal for theme analysis" and return the raw
+> list. Each theme becomes candidate Phase 2 material, so make the shared problem concrete enough
+> to ideate against.
+>
+> Repo: {repo}
+> Focus hint: {focus_hint}
+
+When usable themes return, they seed the Phase 2 frames (see Phase 2). On error (gh missing, no
+remote, auth failure) warn "Issue analysis unavailable: {reason}. Proceeding with standard
+ideation." and continue.
+
+### Source 6 — Web (smart-auto)
+
+Off by default for internal topics. Engage **only** for the cross-domain-analogy frame (Frame 5)
+or on explicit request. **Never pass repo contents, journal entries, or context-library material
+out.** When engaged, dispatch a web-research sub-agent with this prompt verbatim:
+
+> Research external prior art and cross-domain analogies for this ideation focus. Do not assume
+> any private repository context — operate purely from the focus description below. Return: named
+> prior art and adjacent solutions (with sources), and 2–3 structurally analogous problems from
+> unrelated fields (other industries, biology, games, infrastructure, history) with a one-line
+> note on how each solved it. Cite every source so Phase 2 can use it as `external:` basis. Push
+> past the obvious first analogy.
+>
+> Focus hint (no private context): {focus_hint}
+
+Honor skip phrases ("no web research"); note the skip in the grounding summary.
+
+### Consolidate
+
+Merge all results into one **grounding summary** with these sections (omit any that produced
+nothing): **Repo context** (project shape, patterns, pain points, leverage points, strategy);
+**User-named references** (constraint); **Additional context** (background); **Journal learnings**;
+**Named-repo context** (per named repo, with its cross-repo constraints — when the gate recorded
+named repos); **Context-library context** (per library); **Issue themes** (when backlog intent
+fired); **External context** (when web ran). Grounding failures follow **warn and proceed** — never
+block on a grounding miss. Phase 1.5 appends a `Topic axes` section to this same summary.
+
+---
+
+## Phase 1.5: Topic-surface decomposition
+
+Decompose the subject into 3–5 orthogonal **axes** naming *what aspects to think about*. Frames
+(Phase 2) determine *how to think*; axes determine *what to think on*. Without an explicit axis
+list, parallel frames converge on whichever interpretation is most salient at first read and the
+rest of the surface goes unexamined — lens diversity alone does not produce surface coverage.
+
+This is a single orchestrator-side analysis against the grounding summary already in context. No
+sub-agent, no extra grounding read, no user-facing question.
+
+**Axis criteria:** 3–5 axes; **orthogonal** (one idea falls on one axis — merge heavy overlaps);
+**derived from the actual grounding**, not a generic template; at the **same level** (don't mix
+"the whole plugin" with "one frontmatter field"); **named in the topic's language** a reader would
+recognize.
+
+Worked examples (illustrative — derive yours from real grounding):
+
+| Topic | Axes |
+|---|---|
+| Improve the test-suite plugin | Coverage enforcement; fixture ergonomics; mocking patterns; CI integration; reporting/feedback |
+| mimir routing taxonomy | Route definitions; classification signals; fallback behavior; observability of routing decisions |
+| campps session-state sharing across services | Token shape; storage/replication; invalidation triggers; cross-service contract |
+
+**Skip condition (atomic subjects).** Some subjects resist meaningful decomposition: a single
+string output (a name, a tagline), a narrow tactical fix ("the typo on line 47"), or a topic where
+the candidate axes *are* the deliverable. When 3+ orthogonal axes passing the criteria cannot be
+generated, **skip** decomposition and note `Decomposition skipped — atomic subject` in the
+grounding summary so the artifact records the choice.
+
+Append the axis list (or skip-reason) under a `Topic axes` section. Phase 2 threads axes into
+frame prompts; Phase 3 uses them for axis-spread scoring; Phase 5's artifact records them.
+
+---
+
+## Phase 2: Divergent ideation
+
+Generate the full candidate list before critiquing anything.
+
+Dispatch the **N frame agents chosen in Phase 0.4** in parallel, on the **inherited model (no
+tier-down)**. Omit any `mode` parameter so the operator's permission settings apply. Each agent
+targets ~6–8 raw candidates (adjust for volume overrides). Each frame is a **starting bias, not a
+cage** — begin from the assigned lens but follow any promising thread; cross-cutting ideas that
+span frames are valuable.
+
+**The six frames** (select the adaptive subset; for partial counts take them in this order):
+
+1. **Pain & friction** — what is consistently slow, broken, or annoying for the user, operator, or
+   maintainer.
+2. **Inversion / removal / automation** — invert a painful step, remove it entirely, or automate
+   it away.
+3. **Assumption-breaking & reframing** — what is treated as fixed that is actually a choice;
+   reframe one level up or sideways.
+4. **Leverage & compounding** — choices that make many future moves cheaper or stronger;
+   second-order effects.
+5. **Cross-domain analogy** — how a structurally analogous problem is solved in an unrelated field
+   (other industries, biology, games, infrastructure, history). This is the frame that may engage
+   web (Source 6). Push past the obvious analogy.
+6. **Constraint-flipping** — invert the obvious constraint to its opposite or extreme (budget 10x
+   or 0; team of 100 or 1; 0 users or 1M). Use the resulting design as a candidate even if the
+   flip itself is unrealistic.
+
+**Backlog-intent override.** When Source 5 returned usable issue themes, turn each high-signal
+theme into a frame; pad from the six-frame pool (in the order above) if fewer than 3 theme-frames
+exist; cap at 4 frames total.
+
+**Frame-agent prompt (verbatim — dispatch each frame agent with this, substituting its frame, the
+grounding summary, the axis list, the per-agent target, the captured user seeds, and whether the
+run is tactical scope):**
+
+> You are generating raw ideation candidates for this Infiquetra topic through ONE assigned lens.
+> Generate candidates only — do not critique, rank, or filter. Your first few ideas will be the
+> obvious ones; push past them to the non-obvious. Target ~{per_agent_target} candidates.
+>
+> **Your frame (starting bias, not a cage):** {frame_name} — {frame_description}. Begin from this
+> lens but follow any promising thread; a strong idea that spans frames is welcome.
+>
+> **Grounding summary (your substance — every idea must be grounded in it):**
+> {grounding_summary}
+>
+> **Focus:** {focus_hint}
+>
+> **Topic axes (the surface map — distribute your ideas across them; tag each idea with the one
+> axis it most centrally targets; reach a plausible axis at least once before doubling up):**
+> {axis_list}      ← omit this whole block when decomposition was skipped; do not invent axes
+>
+> **User seed ideas — engage these directly, do not just restate them.** For each seed, do at
+> least one of: build on it (extend or strengthen it through your lens), challenge it (surface a
+> flaw or a better alternative your lens reveals), or combine it (merge it with another seed or one
+> of your own into something stronger). Treat seeds as peers to generate against, not as fixed
+> requirements and not as answers:
+> {user_seeds}      ← when there are no seeds, state "No user seeds — generate freely."
+>
+> **Constraint vs background:** the focus hint, the operator's prompt, and any `User-named
+> references` are CONSTRAINTS — an idea that violates them is out regardless of basis. The rest of
+> the grounding (repo context, additional context, journal learnings, context-library context,
+> external context) is BACKGROUND — it can support a basis and inform direction but must not pull
+> ideation toward whatever was loudest in the corpus.
+>
+> **Per-idea contract — every idea returns exactly this, and an idea with no articulated basis
+> does NOT surface:**
+> - **title**
+> - **summary** (2–4 sentences)
+> - **axis** — required when an axis list was given above; pick the single axis this idea most
+>   centrally targets; do not span. Omit only when decomposition was skipped.
+> - **basis** (required, tagged — one of):
+>   - `direct:` a quoted line / specific file / named issue / explicit user-supplied context or
+>     seed it builds on
+>   - `external:` named prior art / domain research / adjacent pattern, with its source
+>   - `reasoned:` an explicit, written-out first-principles argument for why this move applies —
+>     not a hand-wave; the argument is spelled out
+> - **why_it_matters** — connects the basis to why the move is significant
+> - **meeting_test** — one line confirming this would warrant team discussion. **Tactical scope:
+>   {tactical_scope}** — when this is "yes", waive the meeting-test and state "tactical —
+>   meeting-test waived" for each idea. The orchestrator sets this flag from Phase 0.4; do not try
+>   to infer tactical scope yourself.
+>
+> Bias toward the basis type your frame naturally produces (pain/inversion/leverage → `direct:`;
+> analogy/constraint-flipping → `reasoned:` or `external:`; assumption-breaking → mixed) but do not
+> exclude other types. Stay within the subject's identity: expansions, new surfaces, and pivots are
+> fair game when the basis supports them, but moves that abandon or replace the subject are out
+> regardless of basis. When the focus names a slice (one flow, one plugin, one stage), ideate at
+> full ambition *within that slice* — do not widen the surface to the whole product.
+
+**After all frame agents return:**
+
+1. **Merge and dedupe** every frame agent's candidates into one master candidate list, keeping
+   sub-agent (frame) attribution.
+2. **Add the user seeds to the pool** as `user-seed` candidates (if not already absorbed by a
+   frame agent that built on them). A seed a frame only *challenged* or rejected — rather than
+   building into a promoted idea — still enters the pool as its own peer candidate; never drop a
+   seed because a frame rejected a variant of it. Seeds face the identical Phase 3 critique — they
+   are peers in the pool, never auto-promoted.
+3. **Synthesize cross-cutting combinations** — scan for ideas from different frames that combine
+   into something stronger; expect roughly 3–5 additions. Tag combined ideas with their source
+   frames.
+4. **Axis-coverage check** (when Phase 1.5 produced axes; skip otherwise) — count ideas per axis
+   after dedupe. For any axis with zero ideas, dispatch **one** recovery frame agent (an unused
+   frame, or the frame whose lens best fits the missing axis) targeting that axis with the same
+   per-idea contract and ~3–5 ideas. **Cap recovery at 2 axes** — beyond that, accept thin
+   coverage and note empty axes as `axis: <name> — recovery skipped (cap reached)` for the
+   rejection summary. Merge recovery output and dedupe again.
+5. If a focus was given, weight the merged list toward it without excluding stronger adjacent
+   ideas. Spread across dimensions when justified: workflow/DX, reliability, extensibility, missing
+   capabilities, docs/knowledge compounding, quality/maintenance, leverage on future work.
+
+**Checkpoint — raw candidates.** Immediately after cross-cutting synthesis, write
+`<scratch-dir>/raw-candidates.md` with the full candidate list and frame attribution (and the
+captured user seeds). This protects the most expensive output (N parallel frame dispatches +
+dedupe) before Phase 3 critique compacts context. Best-effort — if the write fails, warn and
+proceed; the checkpoint is not load-bearing. Do not delete the run directory at the end of the run.
+
+---
+
+**End of Phase 2.** Load `infiquetra-lifecycle/skills/ideate/references/convergence-and-partnership.md`
+and follow Phases 3–6 (adversarial filter → present survivors + revivable cut → persist → refine /
+co-ideate / revive / interview / hand off), then the quality-bar self-check. This load is
+non-optional — the critique rubric, revival state machine, persistence template, the Phase 6 menu,
+and the quality bar live there, not in this file. Do not improvise them from memory.

--- a/plugins/infiquetra-lifecycle/skills/ideate/references/convergence-and-partnership.md
+++ b/plugins/infiquetra-lifecycle/skills/ideate/references/convergence-and-partnership.md
@@ -1,0 +1,309 @@
+# Ideate — Convergence and Partnership (Phases 3-6)
+
+Load this after Phase 2 (in `infiquetra-lifecycle/skills/ideate/SKILL.md`) returns and the
+orchestrator has merged, deduped, and cross-cut the frame-agent outputs plus the user seeds into one
+candidate pool. Do not load before Phase 2 completes. The user seeds are already in the pool and were
+already engaged by the frame agents — here they are critiqued by the identical rubric, never
+rubber-stamped, never silently dropped.
+
+The orchestrator runs Phases 3-6 directly. Do not dispatch sub-agents for critique, presentation, or
+persistence.
+
+## Phase 3 — Adversarial filtering
+
+Review every candidate critically, one at a time. Generate no replacement ideas in this phase unless
+the operator is explicitly refining (Phase 6). For each rejected idea, write a one-line reason.
+
+### Rejection criteria (verbatim-adapted)
+
+Reject an idea for any of:
+
+- too vague
+- not actionable
+- duplicates a stronger idea
+- not grounded in the stated context (repo + context-libraries + named repos from Phase 1)
+- too expensive relative to likely value
+- already covered by existing workflows, skills, or docs
+- interesting but better handled as a `/brainstorm` variant or `/office-hours` thread, not a product
+  or engineering improvement
+- **unjustified — no articulated basis.** The basis contract is hard: a frame agent (or a user seed)
+  failed to attach `direct:`, `external:`, or `reasoned:`, OR the stated basis does not actually
+  support the claimed move. An idea with no articulated basis does NOT surface — cut it here.
+- **below ambition floor (meeting-test).** Would not warrant team discussion. Waived only when Phase 0
+  detected tactical / narrow focus signals, in which case this criterion does not apply.
+- **subject-replacement.** Abandons or replaces the subject of ideation rather than operating on it
+  (e.g., "pivot the repo to an unrelated domain," "rebuild as a different service"). Always reject.
+- **scope overrun.** Expands beyond the asked scope rather than ideating within it (e.g., proposes
+  changes to the whole platform when the operator asked about one flow, plugin, or stage). Allowed
+  only when the basis explicitly justifies the expansion; default is reject or downgrade.
+
+### Survivor scoring rubric (verbatim-adapted)
+
+Score every survivor on a consistent rubric weighing:
+
+- groundedness in the stated context;
+- **basis strength** — `direct:` > `external:` > `reasoned:`. None is excluded, but a direct-evidence
+  idea (quoted file/line/issue/user-context) outscores an equally-good reasoned idea, all else equal;
+- expected value;
+- novelty;
+- pragmatism;
+- leverage on future work (compounding);
+- implementation burden;
+- overlap with stronger ideas;
+- **axis spread** — when Phase 1.5 produced an axis list, survivor sets that cover the topic's surface
+  outscore sets that cluster on one axis, all else equal.
+
+**Axis coverage is a list-level concern, not per-idea.** After per-idea filtering, inspect the survivor
+set as a whole: if coverage is uneven and stronger candidates exist on under-represented axes, prefer
+the spread when promoting borderline candidates. If an axis ends up with zero survivors, note it in the
+rejection summary as a deliberate gap rather than letting it vanish silently.
+
+### Survivor target
+
+- Keep **5-7 survivors** by default.
+- If too many survive, run a second, stricter pass.
+- If fewer than 5 survive, report that honestly rather than lowering the bar.
+- Tactical / narrow scope (Phase 0) may legitimately yield fewer survivors; that is not a failure.
+
+Carry forward, for each survivor, the SURVIVOR SCHEMA fields populated in Phase 4. Assign every cut
+idea worth keeping a stable REVIVABLE-CUT id (`R1`, `R2`, ...).
+
+## Phase 4 — Present the survivors and the revivable cut
+
+Checkpoint before presenting: write the survivor set plus key context (focus hint, grounding summary,
+rejection summary, the `R#`-keyed revivable cut) to `.claude/infiquetra-lifecycle/ideate/<run-id>/survivors.md`,
+reusing the `<run-id>` and run directory created in Phase 2. Best-effort: if the write fails, log a
+warning and proceed — the checkpoint is not load-bearing.
+
+The terminal review loop is a complete ideation cycle in itself. Persistence is opt-in (Phase 5) and
+refinement happens in conversation with no file cost (Phase 6). Keep the presentation concise; allow
+brief follow-up questions and lightweight clarification.
+
+### SURVIVOR SCHEMA
+
+Present only the surviving ideas, each in this exact shape (field names identical to the artifact
+template in `infiquetra-lifecycle/skills/ideate/references/ideation-artifact.md`):
+
+- **title** — short, concrete.
+- **description** — concrete explanation of the move.
+- **axis** — the topic axis this idea targets. Include only when Phase 1.5 produced an axis list; omit
+  when decomposition was skipped.
+- **basis** — tagged exactly one of `direct:` (quoted file/line/issue/user-context), `external:`
+  (named prior art / source), or `reasoned:` (written-out first-principles argument). This is the same
+  basis contract the frame agents carried in Phase 2.
+- **rationale** — how the basis connects to the move's significance.
+- **downsides** — tradeoffs or costs.
+- **confidence** — 0-100.
+- **complexity** — Low / Med / High.
+- **status** — `Unexplored` / `Explored`.
+
+Order survivors by the rubric score (strongest first).
+
+### REVIVABLE-CUT SCHEMA
+
+After the survivors, present a **"Did not survive (revivable)"** section. Explicit rejection IS the
+quality mechanism; cut ideas are first-class and kept visible so the operator can see what was
+considered. Each cut idea worth recording uses this exact shape:
+
+- **id** — stable `R1`, `R2`, ... (stable across the run; do not renumber when revival changes a
+  status).
+- **title** — short.
+- **summary** — one line.
+- **reason** — the Phase 3 rejection reason (one line).
+- **status** — one of `rejected` / `revived` / `revisited`. Starts at `rejected`. A `revived` idea
+  has been promoted into the survivor set above — render it under Ranked Survivors, and either omit it
+  here or leave it with status `revived` for history; never present a `revived` idea as a current
+  non-survivor.
+
+Then a brief rejection summary so the operator sees the shape of what was cut, including any
+zero-survivor axis noted as a deliberate gap.
+
+## Phase 5 — Persist (opt-in)
+
+Persistence is opt-in. The terminal review loop is already a complete cycle. Persist only when the
+operator explicitly chooses to save, dig deeper, or hand off (selected in Phase 6). When a Phase 6
+choice needs a durable record (dig-deeper → `/brainstorm`, handoff → `idea-ready`, save and end),
+ensure a record exists first. When the operator keeps refining, write nothing unless asked.
+
+To persist:
+
+1. Ensure `docs/ideation/` exists.
+2. Choose the path:
+   - `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`
+   - `docs/ideation/YYYY-MM-DD-open-ideation.md` when no focus exists.
+3. Write or update the ideation document using the template in
+   `infiquetra-lifecycle/skills/ideate/references/ideation-artifact.md`. The template's field names
+   match the SURVIVOR SCHEMA and REVIVABLE-CUT SCHEMA above exactly — keep them aligned.
+
+When resuming an existing run: update the file in place and preserve `Explored` markers and the
+stable `R#` ids and their statuses.
+
+There is no Proof / HITL path and no cloud doc-review in this skill. File save under `docs/ideation/`
+is the only destination.
+
+## Phase 6 — Refine, co-ideate, revive, interview, or hand off
+
+Ask what should happen next. Use the platform's blocking question tool (`AskUserQuestion`; call
+`ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded). If no blocking tool
+exists or the call errors, fall back to numbered options in chat. Never silently skip the question.
+
+**Question:** "What should ideate do next?"
+
+Offer these routes:
+
+1. **Refine in conversation (or stop here — no save)** — tighten, re-evaluate, or deepen analysis. No
+   file side effects; ending the conversation after this pick is a valid no-save exit.
+2. **Add an idea (co-ideate)** — fold a new operator seed into the pool.
+3. **Revive a cut idea (`R#`)** — re-enter the Phase 3 filter with new evidence (state machine below).
+4. **Dig deeper on a survivor → `/brainstorm`** — write a durable record first, mark the chosen idea
+   `Explored`, then load `infiquetra-lifecycle/skills/brainstorm/SKILL.md` with that idea as the seed.
+5. **Re-evaluate / raise the bar** — return to Phase 3 and re-run the rubric, stricter.
+6. **Interview me (I'm stuck)** — conditional tactic; see Interview below.
+7. **Hand off → `idea-ready`** — write a durable record, then graduate to `/handoff` (which routes to
+   `sdlc-manager`) or to `/plan`. The ideation artifact is `idea-ready` maturity.
+
+A no-save exit needs no dedicated option: pick route 1 and stop, or use the question tool's free-text
+escape. Persistence stays opt-in.
+
+### 6.1 Refine in conversation
+
+Route refinement by intent:
+
+- `add more ideas` / `explore new angles` → return to Phase 2 (re-dispatch frame agents, or a single
+  targeted frame on the new angle).
+- `re-evaluate` / `raise the bar` → return to Phase 3.
+- `dig deeper on survivor #N` → expand only that idea's analysis in conversation.
+
+No persistence triggers during refinement. Ending here — with or without refinement — is a valid
+no-save exit that leaves no durable artifact, matching the opt-in contract.
+
+### 6.2 Add an idea (co-ideate)
+
+Partnership runs both ways through the whole run, not just at the start. A new operator seed offered in
+Phase 6:
+
+1. enters the candidate pool as a `user-seed` candidate with its provenance recorded;
+2. must carry (or be helped to articulate) a basis under the same `direct:` / `external:` / `reasoned:`
+   contract;
+3. is critiqued by the **identical** Phase 3 rubric against the current survivor set — never
+   rubber-stamped because it came from the operator, never silently dropped if it loses;
+4. if it beats the bar, it joins survivors (displacing the weakest if the 5-7 cap is exceeded, same as
+   revival Outcome B — the displaced survivor enters the cut with status `rejected` and a reason string
+   recording its provenance, e.g. `"displaced by R#"`); if it does not, it lands in the revivable cut
+   with a stable `R#`, status `rejected`, and reason.
+
+Record the seed and its outcome in the co-ideation log when the run is persisted (Phase 5).
+
+### 6.3 Revive a cut idea — the revival state machine
+
+Revival re-enters the filter. An easy "revive" button would gut "explicit rejection is the quality
+mechanism" and let pet ideas back in unexamined. The state machine is the anti-pet-idea guardrail.
+
+To revive `R#`:
+
+1. **New-evidence gate.** The operator MUST supply NEW evidence or a NEW perspective that the original
+   critique did not weigh. If none is supplied, **DECLINE** the revival and ask for the specific angle
+   the critique missed — name what the original rejection reason was so the operator can answer it. Do
+   not re-score on the same evidence; that just relitigates the original verdict. **Adjudicate novelty
+   yourself:** judge whether what the operator offered is genuinely new, not a restatement of what the
+   critique already weighed dressed up as a new angle. If it restates the original basis, decline as
+   "same evidence" and name the original reason. The operator asserting "this is new" does not make it
+   new — you decide.
+
+2. **Re-run BOTH Phase 3 stages on `R#`, in order, incorporating the new evidence.** "The Phase 3
+   rubric" means the full Phase 3, not just the scoring subheader — re-scoring alone is a soft-promote
+   loophole that would let a categorically-cut idea back in unexamined.
+   - **2a. Re-test the rejection criteria first (Phase 3 "Rejection criteria", above).** Re-apply the
+     categorical gate with the new evidence. If `R#` still trips a categorical criterion — unjustified
+     basis (no `direct:`/`external:`/`reasoned:`, or a basis that does not support the move),
+     subject-replacement, scope overrun, or duplicates a stronger current survivor — it **cannot be
+     promoted regardless of any score** and goes straight to Outcome A. Explicit rejection IS the
+     quality mechanism: a high re-score does not make a subject-replacement or unjustified idea
+     admissible. Only an idea that now *clears* the gate proceeds to 2b.
+   - **2b. Re-score against the survivor rubric (Phase 3 "Survivor scoring rubric", above).** Only for
+     `R#` ideas that cleared the gate in 2a, re-run the scoring rubric incorporating the new evidence,
+     judged against the **CURRENT** survivor set (not the original pool — survivors may have changed
+     since the cut).
+
+3. **Outcome A — still excluded.** `R#` either still trips a categorical rejection criterion in 2a
+   (cannot be promoted regardless of score) or cleared the gate but still scored below the bar in 2b.
+   Either way, set `R#` status → `revisited`. Record what the gate or score turned on — which criterion
+   it still trips, or how the new evidence was weighed and why it still falls short. `R#` stays in the
+   revivable cut — it is never silently re-dropped, and its id and history persist.
+
+4. **Outcome B — clears the gate and now beats the bar.** `R#` passed 2a and scored above the bar in
+   2b. Set `R#` status → `revived`. Promote it into the survivor set with full SURVIVOR SCHEMA fields.
+   If promotion would push the survivor set above 7 — growing 5→6 or 6→7 needs **no** displacement; 7
+   is the ceiling — **DISPLACE the weakest survivor**: move it to the
+   revivable cut with a fresh `R#` id, status `rejected`, and a reason string recording its provenance
+   (`"displaced by revived R#"`). Status stays inside the closed enum `{rejected, revived, revisited}`;
+   the provenance lives in the reason. The cap holds; the set never silently grows past 7.
+
+Statuses are sticky on the stable id. A `revisited` idea can be revived again later if the operator
+brings genuinely different new evidence the second time.
+
+### 6.4 Re-evaluate / raise the bar
+
+Return to Phase 3 and re-run the rubric with a stricter pass. Survivors that no longer clear the bar
+move to the revivable cut with a stable `R#` id, status `rejected`, and a reason string recording the
+provenance (e.g. `"fell below raised bar"`). Status stays inside the closed enum
+`{rejected, revived, revisited}`; the demotion history lives in the reason. This is the inverse of
+revival and uses the same schema.
+
+### 6.5 Interview when stuck
+
+Conditional tactic — NOT the default. The default engine generates; it does not interview. Fire the
+interview only when:
+
+- the operator's input is circling, stuck, or contradictory; or
+- the operator explicitly asks for it; or
+- it is offered as an optional final gate before handoff.
+
+Run it as one open-ended question at a time (office-hours register). Every answer that produces a
+concrete idea becomes a `user-seed` candidate and re-enters Phase 2/Phase 3 like any other seed —
+drawn-out ideas do not bypass the filter. If the interview reveals the subject is genuinely unframed,
+recommend `/office-hours` rather than forcing survivors out of a vibe.
+
+### 6.6 Dig deeper → `/brainstorm`
+
+1. Write or update the durable record (Phase 5).
+2. Mark the chosen survivor `Explored` in the saved record.
+3. Load `infiquetra-lifecycle/skills/brainstorm/SKILL.md` with the chosen idea as the seed.
+
+Do not skip `/brainstorm` and route a raw survivor straight to `/plan` — `/plan` wants
+brainstorm-grounded, `requirements-ready` material. Ideation output is `idea-ready`, one rung below.
+
+### 6.7 Hand off → `idea-ready`
+
+1. Write or update the durable record (Phase 5).
+2. Graduate to `/handoff`, which builds the handoff envelope and routes to `sdlc-manager`; the
+   `docs/ideation/` artifact carries `idea-ready` maturity. `/plan <issue>` also consumes `idea-ready`.
+
+Leave the run scratch directory (`.claude/infiquetra-lifecycle/ideate/<run-id>/`) in place on
+completion; the OS handles eventual cleanup and the checkpoints are cheap to keep.
+
+## Quality-bar self-check
+
+Before finishing, verify (verbatim-adapted from CE — this is the only behavioral guard available, so
+run it honestly):
+
+- the idea set is **grounded in the stated context** (current repo + relevant `*-context-library`
+  repos + any named infiquetra repos from Phase 1);
+- **every survivor has an articulated basis** (`direct:` / `external:` / `reasoned:`) that actually
+  supports the claimed move — speculation dressed as ambition was rejected, with reasons;
+- **every survivor passes the meeting-test** unless Phase 0 detected tactical / narrow focus signals
+  that waived the floor;
+- **no survivor replaces the subject** rather than operating on it;
+- when Phase 1.5 produced an axis list, the survivor set **spreads across axes** rather than clustering
+  on one — and any zero-survivor axis is noted as a deliberate gap in the rejection summary, not
+  silently absent;
+- the **candidate list was generated before filtering** (many → critique → survivors), not curated
+  into existence;
+- the original **many-ideas → critique → survivors** mechanism was preserved;
+- **every rejected idea has a reason** and a stable `R#` id if it is worth reviving;
+- survivors are **materially better than a naive "give me ideas" list**;
+- **persistence followed the operator's choice** — terminal-only sessions wrote no file;
+- **USER SEEDS were engaged by the generators in Phase 2** (built on / challenged / combined inside the
+  frame-agent reasoning), not merely judged at merge — and were critiqued by the identical rubric.
+
+If any check fails, fix it before presenting or persisting — do not ship a degraded run.

--- a/plugins/infiquetra-lifecycle/skills/ideate/references/ideation-artifact.md
+++ b/plugins/infiquetra-lifecycle/skills/ideate/references/ideation-artifact.md
@@ -1,0 +1,98 @@
+# Ideation artifact template
+
+The persisted markdown document `/ideate` writes to `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`
+(or `docs/ideation/YYYY-MM-DD-open-ideation.md` when no focus exists). Phase 5 of
+`infiquetra-lifecycle/skills/ideate/references/convergence-and-partnership.md` uses this template.
+
+Field names here are IDENTICAL to the SURVIVOR SCHEMA and REVIVABLE-CUT SCHEMA in that file — keep
+them aligned. Omit a clearly irrelevant field only when necessary. On resume, update in place and
+preserve `Explored` markers, stable `R#` ids, and their statuses.
+
+The artifact carries `idea-ready` handoff maturity (feeds `/handoff` → `sdlc-manager` and `/plan`).
+
+```markdown
+---
+date: YYYY-MM-DD
+topic: <kebab-case-topic>
+focus: <optional focus hint — omit when open ideation>
+scope: <tactical | narrow | standard | broad>
+repo: <current repo name>
+maturity: idea-ready
+---
+
+# Ideation: <Title>
+
+## Grounding Context
+
+**Repo:** [project shape, conventions, pain points, leverage points, strategy summary — from the
+Phase 1 current-repo scan + journal-learnings sources]
+
+**Context-libraries:** [relevant `*-context-library` repos read in Phase 1 and what each contributed.
+One line per library, or `None consulted` when the topic did not touch a library.]
+
+**Named repos:** [other infiquetra repos consulted when the topic spanned repos, and what each
+contributed. Omit this section when the run was single-repo.]
+
+## Topic Axes
+
+[3-5 axes from Phase 1.5, one per line. OR a single line `Decomposition skipped — atomic subject`
+when Phase 1.5 was skipped. Omit this section entirely if not applicable.]
+
+## Ranked Survivors
+
+### 1. <Idea Title>
+**title:** <short, concrete>
+**description:** [Concrete explanation of the move]
+**axis:** [Topic axis this idea targets — omit when decomposition was skipped]
+**basis:** [`direct:` quoted file/line/issue/user-context | `external:` named prior art/source |
+`reasoned:` written-out first-principles argument]
+**rationale:** [How the basis connects to the move's significance]
+**downsides:** [Tradeoffs or costs]
+**confidence:** [0-100]
+**complexity:** [Low | Med | High]
+**status:** [Unexplored | Explored]
+
+### 2. <Idea Title>
+[... same fields, strongest-first by rubric score ...]
+
+## Did not survive (revivable)
+
+Explicit rejection is the quality mechanism. Cut ideas keep stable ids so they can be revived (which
+re-enters the Phase 3 filter with new evidence). Never renumber on a status change.
+
+| id | title | summary | reason | status |
+|----|-------|---------|--------|--------|
+| R1 | <short title> | <one-line summary> | <Phase 3 rejection reason> | rejected |
+| R2 | <short title> | <one-line summary> | <Phase 3 rejection reason> | revisited |
+| R3 | <short title> | <one-line summary> | displaced by revived R5 | rejected |
+
+[status is one of: rejected | revived | revisited. A `revived` id is promoted into Ranked Survivors
+above and may be omitted from this table or left with status `revived` for history. Append any
+zero-survivor axis as its own row, e.g. `| - | axis: <name> | no survivors on this axis | deliberate
+gap | — |`.]
+
+## Co-ideation log
+
+Records partnership provenance: which ideas came from the operator (seeds) vs. the frame agents, and
+how each seed fared under the identical critique. Seeds were passed INTO the Phase 2 frame agents to
+build on / challenge / combine, AND entered the merged pool — never rubber-stamped, never silently
+dropped.
+
+| source | entered | idea / seed | outcome |
+|--------|---------|-------------|---------|
+| user-seed | Phase 0 | <operator's seed idea> | survived as #2 (built on by frame 4) |
+| user-seed | Phase 6 co-ideate | <added mid-run> | cut → R4 (basis did not support the move) |
+| frame-agent | Phase 2 | <generated idea> | survived as #1 |
+| interview | Phase 6 | <drawn-out idea> | cut → R6 (below ambition floor) |
+
+[source is one of: user-seed | frame-agent | interview. `entered` notes where it joined the run.
+`outcome` records the survivor rank or the revivable `R#` and reason.]
+```
+
+## Notes
+
+- Title case the H1; kebab-case the `topic` frontmatter.
+- `scope` mirrors the Phase 0 adaptive-frame-count decision: tactical → 1 frame; narrow → 2-3;
+  standard → 4; broad → full 6-frame fan-out.
+- Keep the survivor count to 5-7 unless tactical scope or an honest under-5 result says otherwise.
+- This is the only persistence destination — no Proof, no cloud doc-review.


### PR DESCRIPTION
## What

Rebuilds `infiquetra-lifecycle`'s `/ideate` and `/brainstorm` from thin facilitative stubs into full
engines ported from **compound-engineering (CE)** and adapted to the infiquetra world — **self-contained**,
no runtime dependency on CE. Bumps the plugin to **0.3.0** (marketplace metadata **2.4.0**).

## Why

The stubs biased toward facilitation ("produce a small option set; lead the user through choices"), so
ideation felt like the operator supplied all the ideas — and once Claude declared `/ideate` "too
lightweight" and improvised its own fan-out. The fix puts the engine (and its tuned sub-agent prompts)
back so behavior is repeatable, and improves on CE with a two-way partnership.

## `/ideate` (13-line stub → ~530-line engine + 2 reference files)

- **Generate many → critique all → survivors only**, with cut ideas first-class and **revivable**.
- **Two-way partnership** — operator seed ideas feed *into* the parallel frame agents (build on /
  challenge / combine) and face the identical critique; never rubber-stamped, never silently dropped.
- **Revival state machine** — re-enters the filter with *new evidence the agent adjudicates as genuinely
  new* → re-tests the rejection gate, then re-scores; promotes (displacing the weakest survivor) or stays
  cut as `revisited`. Preserves "explicit rejection is the quality mechanism."
- **infiquetra grounding** with verbatim tuned prompts: grounding-fit gate (proceed / decline /
  `/office-hours` / ask, with worked examples), context-library reader (`*-context-library` via `gh`,
  local-clone short-circuit), named-repo reader (multi-repo), read-only `gh` issue-theme clustering,
  smart-auto web for the cross-domain frame. Adaptive frame count 1–6.

## `/brainstorm` (20-line stub → ~340-line engine + 1 reference file)

Thinking-partner engine deep-diving one chosen idea (a `/ideate` survivor or a named topic) into a
right-sized `requirements-ready` doc: scope assessment, product pressure-test, one-question-at-a-time
dialogue, 2–3 approaches with a non-obvious angle.

## How it was built & verified

- ultracode workflow: author → adversarial-verify → remediate (13 agents). **25 findings: 0 blocking,
  5 major (all remediated), 12 minor, 8 nit.**
- All five files then read in full and **14 surgical polish edits** applied for the worthwhile minors/nits.
- Validation: `marketplace/validator/validate.py` → **0 errors**; `marketplace.json` + `plugin.json`
  valid JSON; all touched frontmatters parse; 18 plugins intact.

## Notes

- No behavioral test harness exists for prompt-based skills; "validated" = structure + JSON + frontmatter
  + adversarial review + full read, not a live `/ideate` run.
- DECISIONS / LEARNINGS reference `commit pending`; will be pointed at the squash SHA in a follow-up,
  matching the prior rename-decision pattern.
- Deferred (QUEUED P3): symmetric producer-side `/ideate` → `/brainstorm` handoff field contract.
