### PR TITLE
docs(journal): point /plan entries at PR #175 squash SHA a13ba68

### DIFF
--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -12,7 +12,7 @@
 
 ### `/plan` rebuild — CE `ce-plan` artifact engine + gstack `spec` HOW-interrogation  {#plan-engine-rebuild-shipped}
 
-**SHIPPED 2026-06-02** (`infiquetra-lifecycle` `0.7.0`, PR #___, squash ___). Was QUEUED P1 `#rebuild-plan-engine-merge`.
+**SHIPPED 2026-06-02** (`infiquetra-lifecycle` `0.7.0`, PR #175, squash a13ba68). Was QUEUED P1 `#rebuild-plan-engine-merge`.
 
 **Summary.** Second **command** rebuild of the engine-merge campaign (after `/office-hours`). Rebuilt `/plan` from a 27-line stub into a real **implementation-plan engine that merges CE's `ce-plan` structured-artifact engine (Jeff-preferred spine) with gstack `spec`'s code-grounded HOW-interrogation front end** — a self-contained infiquetra engine. Position in the lifecycle: `/plan` answers "How should it be built?". Schema, the four interview answers, the review-phase rationale, and rejected alternatives recorded in DECISIONS [#plan-engine-rebuild](DECISIONS.md#plan-engine-rebuild).
 

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-06-02
 
-### Rebuild `/plan` by merging CE `ce-plan` artifact engine + gstack `spec` HOW-interrogation (PR #___, squash ___)  {#plan-engine-rebuild}
+### Rebuild `/plan` by merging CE `ce-plan` artifact engine + gstack `spec` HOW-interrogation (PR #175, squash a13ba68)  {#plan-engine-rebuild}
 
 **Decision.** Rebuild `/plan` — the second command rebuild of the engine-merge campaign — from a 27-line stub into a **self-contained infiquetra plan engine that merges CE's `ce-plan` structured-artifact engine (Jeff-preferred spine) with gstack `spec`'s code-grounded HOW-interrogation front end**. Six numbered phases: enter + warranted-gate → ground (HOW) → interrogate (HOW) → synthesize the plan artifact → condensed deepening pass → saga + route + operator-choice. Position in the lifecycle: `/plan` answers **"How should it be built?"** (the WHAT is assumed settled upstream). The four interview answers settled:
 


### PR DESCRIPTION
Post-merge follow-up: fills the squash SHA placeholders in the `/plan` rebuild journal entries now that #175 is merged (squash `a13ba68`).

- DECISIONS `#plan-engine-rebuild` header: `(PR #175, squash a13ba68)`
- ARCHIVE `#plan-engine-rebuild-shipped`: `PR #175, squash a13ba68`

Docs-only; no code change.