### PR TITLE
docs(journal): fill /optimize rebuild SHAs (PR #197, squash d00a506)

### DIFF
--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -12,7 +12,7 @@
 
 ### `/optimize` — the metric-driven optimization engine (CE `ce-optimize` single-source port + infiquetra-native agent-usability metric class, NOT a merge, off-chain, saga UNTOUCHED) — and the engine-merge campaign CAPSTONE  {#optimize-engine-rebuild-shipped}
 
-**SHIPPED 2026-06-04** (`infiquetra-lifecycle` `0.18.0`, PR #TBD, squash #TBD). Was QUEUED `#optimize-engine-merge`.
+**SHIPPED 2026-06-04** (`infiquetra-lifecycle` `0.18.0`, PR #197, squash d00a506). Was QUEUED `#optimize-engine-merge`.
 
 **Summary.** Thirteenth and **FINAL command** rebuild of the engine-merge campaign (after `/office-hours`, `/plan`, `/code-review`, `/founder-review`, `/work`, `/loop`, `/resume`, `/qa`, `/strategy`, `/retro`, `/investigate`, `/spec`). Rebuilt `/optimize` from a 20-line stub into the lifecycle's **metric-driven optimization engine** — a **bounded-experiment loop** toward a measurable target: pick a metric, baseline, hypothesize, run a bounded experiment, measure the delta, keep or discard, repeat until the target is hit or the budget is spent. A **CE `ce-optimize` SINGLE-SOURCE PORT** (NOT a merge); the agent-usability metric class is an infiquetra-native angle. Off-chain, saga-UNTOUCHED; the run is recorded narratively. The five settled Qs, decisions a–e, the honest single-source attribution, and rejected alternatives are recorded in DECISIONS [#optimize-engine-rebuild](DECISIONS.md#optimize-engine-rebuild).
 
@@ -32,7 +32,7 @@
 
 ### Engine-merge campaign — COMPLETE (all 13 command rebuilds shipped; `#lifecycle-engine-merge-campaign` closed)  {#lifecycle-engine-merge-campaign-complete}
 
-**COMPLETE 2026-06-04** (`infiquetra-lifecycle` `0.18.0`, PR #TBD, squash #TBD). Closes the campaign decision DECISIONS [#lifecycle-engine-merge-campaign](DECISIONS.md#lifecycle-engine-merge-campaign).
+**COMPLETE 2026-06-04** (`infiquetra-lifecycle` `0.18.0`, PR #197, squash d00a506). Closes the campaign decision DECISIONS [#lifecycle-engine-merge-campaign](DECISIONS.md#lifecycle-engine-merge-campaign).
 
 **What this closes.** The **command-rebuild** half of the engine-merge campaign is **done**: all **13 lifecycle commands** have been rebuilt from thin stubs (or adopted net-new) into self-contained infiquetra engines, each an interview-driven design settled 1-by-1:
 

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-06-04
 
-### Rebuild `/optimize` as the lifecycle's metric-driven optimization engine — CE `ce-optimize` SINGLE-SOURCE port + infiquetra-native agent-usability metric class (NOT a merge), off-chain, saga UNTOUCHED (PR #TBD)  {#optimize-engine-rebuild}
+### Rebuild `/optimize` as the lifecycle's metric-driven optimization engine — CE `ce-optimize` SINGLE-SOURCE port + infiquetra-native agent-usability metric class (NOT a merge), off-chain, saga UNTOUCHED (PR #197, squash d00a506)  {#optimize-engine-rebuild}
 
 **Decision.** Rebuild `/optimize` from a 20-line stub into a **metric-driven optimization engine** — the **thirteenth and FINAL command rebuild** of the engine-merge campaign (after `/office-hours`, `/plan`, `/code-review`, `/founder-review`, `/work`, `/loop`, `/resume`, `/qa`, `/strategy`, `/retro`, `/investigate`, `/spec`). It runs a **bounded-experiment loop** toward a measurable target: pick a metric, baseline it, hypothesize, run a bounded experiment, measure the delta, keep or discard, repeat until the target is hit or the budget is spent. The five settled interview answers:
 

--- a/plugins/infiquetra-lifecycle/CHANGELOG.md
+++ b/plugins/infiquetra-lifecycle/CHANGELOG.md
@@ -31,7 +31,7 @@
   loop-toward-target); `operator-choice.md` `/optimize` row "at its rebuild" → "now, offers";
   README `/optimize` command-summary line tightened to the bounded-experiment loop + 8 metric
   classes. Dispatch-table command count stays **17** (`/optimize` was already counted).
-- Documented in the engineering journal (PR #TBD): DECISIONS `#optimize-engine-rebuild`, ARCHIVE
+- Documented in the engineering journal (PR #197): DECISIONS `#optimize-engine-rebuild`, ARCHIVE
   `#optimize-engine-rebuild-shipped` + the campaign-complete capstone (closes
   `#lifecycle-engine-merge-campaign`), LEARNINGS `#shipped-on-origin-not-in-stale-local-tree` +
   the third firing of `#campaign-brief-merge-is-a-provenance-hypothesis`; consumed
@@ -80,7 +80,7 @@
   Two deferral closures: `operator-choice.md` `/spec` row "at its rebuild" → "never offers";
   office-hours `frame-diagnostic.md` `/spec` moved from "campaign-queued" to an active routing-rubric
   row.
-- Documented in the engineering journal (PR #TBD): DECISIONS
+- Documented in the engineering journal (PR #195): DECISIONS
   `#spec-interrogation-engine-rebuild`, ARCHIVE `#spec-interrogation-engine-shipped` +
   `#brainstorm-spec-interrogation-seam-resolved`, LEARNINGS
   `#campaign-brief-merge-is-a-provenance-hypothesis`; consumed both `#spec-interrogation-engine` and


### PR DESCRIPTION
Post-merge SHA-fill for the `/optimize` 0.18.0 rebuild (PR #197, squash `d00a506`): fills the `PR #TBD`/`squash #TBD` placeholders in DECISIONS `#optimize-engine-rebuild`, ARCHIVE `#optimize-engine-rebuild-shipped` + the engine-merge campaign-complete capstone, and the CHANGELOG 0.18.0 journal-doc note. Also fills a stale `/spec` (0.17.0) CHANGELOG `PR #TBD` that the /spec SHA-fill (#196) missed -> PR #195. Docs-only.