### PR TITLE
docs(review): doc-review of saga doc readability plan + safe fixes (#201)

### DIFF
--- a/docs/plans/2026-06-07-saga-doc-readability-plan.md
+++ b/docs/plans/2026-06-07-saga-doc-readability-plan.md
@@ -64,7 +64,7 @@ KTD3 — Soft-wrap is "no hard wrap within a paragraph + mandatory blank lines b
 
 KTD4 — Enforcement is a pytest, `tests/test_saga_doc_formatting.py`, in the existing Tests job; no new top-level script. Rationale: matches the recent "zero new top-level Python" saga pattern and reuses the harness. Rejected: a new `scripts/validate_doc_formatting.py` in the Validate job (adds a script); deferring enforcement (risks drift in the gap).
 
-KTD5 — Rollout covers all nine doc-writing skills (ideate, plan, brainstorm, spec, strategy, retro, doc-review, code-review, founder-review). Rejected: ideate-only exemplar (leaves the recurrence unsolved elsewhere); the seven issue-named skills only (code-review and founder-review also produce jumbled review docs).
+KTD5 — Rollout covers all nine doc-writing skills (ideate, plan, brainstorm, spec, strategy, retro, doc-review, code-review, founder-review) for *consistency* — every skill links the one shared reference. Verified reality (do not over-edit): only `ideation-artifact.md` actually carries the bold-label collapse (9 consecutive `**label:**` lines); the other eight templates already use headings/prose/tables (spec/strategy/brainstorm/retro/founder-review have zero bold-label stacks; plan uses `###` headings; code-review already renders findings as a pipe-delimited table per `findings-schema.md:105`). So the per-skill work is: ideate = the real collapse fix; everyone else = link the shared reference + apply the lead-in/short-paragraph/soft-wrap rules and table any comparative data, with U6 standing guard against future regressions. Rejected: ideate-only exemplar (leaves the shared contract unenforced elsewhere); the seven issue-named skills only (code-review and founder-review docs deserve the same shared contract even though their current collapse risk is low).
 
 KTD6 — The golden specimen is a worked EXAMPLE block embedded in `formatting-style.md`, not a separate fixture file. Rationale: one artifact serves as the few-shot the templates point to, the human reference, and the test oracle — nothing extra to drift.
 
@@ -99,6 +99,8 @@ tests/test_saga_doc_formatting.py  (collapse pattern + structural rules + link p
 ```
 
 ## Implementation Units
+
+**Execution guard (read before U2-U5, especially under the parallel fan-out).** "Apply the rules" to a template means two things: (1) encode the rules as *prescriptions/instructions* the skill gives the model, and (2) render the template's own EXAMPLE / specimen blocks in the target format. It does **NOT** mean reflowing the template file's editorial source prose to no-hard-wrap — the template `.md` files stay editor-friendly and hard-wrapped (KTD3). Do not produce a whitespace-only reflow diff of a template's prose.
 
 ### U1. Author the shared formatting reference + golden specimen
 
@@ -150,8 +152,8 @@ tests/test_saga_doc_formatting.py  (collapse pattern + structural rules + link p
 - **Requirements:** R1, R2, R3, R4, R5, R6.
 - **Dependencies:** U1.
 - **Files:** `plugins/saga/skills/retro/references/retro-report.md`, `plugins/saga/skills/doc-review/SKILL.md` (the findings/readiness report format, ~lines 128-156 — no references dir), `plugins/saga/skills/code-review/references/findings-schema.md`, `plugins/saga/skills/founder-review/references/review-modes.md`, plus each skill's `SKILL.md` shared-ref link where the format lives elsewhere.
-- **Approach:** Render findings (severity/priority/confidence/location) as a table per KTD2; lead each report section with a one-liner; apply short-paragraph + soft-wrap rules; link the shared reference. Keep the P0–P3 priority semantics and findings-schema field names intact.
-- **Patterns to follow:** the shared reference (U1); the existing findings table conventions in `code-review/references/findings-schema.md`.
+- **Approach:** code-review already renders findings as a pipe-delimited table (`findings-schema.md:105`) — do NOT re-table findings. For code-review, scope is: link the shared reference + apply the lead-in/short-paragraph/soft-wrap rules to the durable review artifact's *narrative* sections. For retro/doc-review/founder-review, lead each report section with a one-liner, table any comparative/findings data per KTD2, and apply short-paragraph + soft-wrap rules. Keep the P0–P3 priority semantics and `findings-schema` field names intact.
+- **Patterns to follow:** the shared reference (U1); the existing pipe-delimited findings output at `code-review/references/findings-schema.md:105`.
 - **Test scenarios:** `Test expectation: none -- template/format content; validated by U6.`
 - **Verification:** All four outputs link the shared ref and U6 passes.
 
@@ -161,7 +163,7 @@ tests/test_saga_doc_formatting.py  (collapse pattern + structural rules + link p
 - **Requirements:** R8, R9.
 - **Dependencies:** U1, U2, U3, U4, U5 (the templates must conform before the gate goes green).
 - **Files:** `tests/test_saga_doc_formatting.py` (new); `tests/conftest.py` (only if a shared fixture helps).
-- **Approach:** Enumerate the saga template/format files; assert none contains 2+ consecutive `**label:**` lines with no intervening blank line (the fatal collapse pattern); assert each of the nine doc-writing skills links `saga/references/formatting-style.md`; assert the `formatting-style.md` specimen block itself passes the collapse check; where cheaply checkable, assert ranked-survivor/findings sections use a table. Do NOT assert no-hard-wrap on template source (KTD3).
+- **Approach:** Enumerate the saga template/format files; assert none contains 2+ consecutive `**label:**` lines with no intervening blank line (the fatal collapse pattern); assert each of the nine doc-writing skills links `saga/references/formatting-style.md` *somewhere in its skill dir* (in the template file for skills that have one; in `SKILL.md` for doc-review, which has no references dir); assert the `formatting-style.md` specimen block itself passes the collapse check; where cheaply checkable, assert ranked-survivor/findings sections use a table. Do NOT assert no-hard-wrap on template source (KTD3). Coverage note: this test only reads markdown, so it adds no `plugins/` line coverage — that is fine, there is no `--cov-fail-under` gate (`pyproject.toml:76` reports coverage, does not gate it); do not add a coverage workaround.
 - **Patterns to follow:** `tests/test_saga_plugin.py`, `tests/test_saga_saga.py` for harness/style; ruff 100-char, pytest.
 - **Test scenarios:**
   - **Happy path:** all conforming templates → test passes.

--- a/docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md
+++ b/docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md
@@ -1,0 +1,62 @@
+---
+date: 2026-06-07
+review_of: docs/plans/2026-06-07-saga-doc-readability-plan.md
+reviewed_revision: f6c87d4 (plan as merged) + safe fixes in this PR
+issue: 201
+type: doc-review
+blocked: false
+---
+
+# Doc Review: Saga Document Readability Plan
+
+## Readiness summary
+
+The plan is ready to drive implementation — no P0/P1 findings, no blocking issues.
+
+It carries a clear problem frame, stable R-IDs and U-IDs, ordered dependencies, repo-relative paths,
+and per-unit test scenarios. The KTDs are settled with rationale and rejected alternatives.
+
+The readiness-skeptic pass found five issues, all P2/P3, every one of them an over-statement or
+mis-location the parallel ultracode fan-out would have tripped on. All five were evidence-backed and
+fixed in place — none required inventing scope or resolving a product decision.
+
+## Applied fixes (safe, in-place)
+
+| id | priority | finding | fix |
+|----|:--------:|---------|-----|
+| F1 | P2 | Rollout over-stated: plan implied a uniform "fix the collapse" across all 9 skills, but only `ideation-artifact.md` has the bug (9 bold-label lines); the other 8 templates already use headings/prose/tables (verified: spec/strategy/brainstorm/retro/founder-review = 0 bold-label stacks; plan = headings; code-review already tables findings). | KTD5 rewritten to state the verified per-skill reality: ideate = real fix, others = link + light rules + regression-guard. |
+| F2 | P2 | U5 pointed code-review's "render findings as a table" at `findings-schema.md`, which is the field *definition* (already a table) — not the render site. code-review already renders findings as a pipe-delimited table (`findings-schema.md:105`). | U5 approach corrected: code-review scope is link + narrative prose rules; do not re-table findings. |
+| F3 | P2 | "Apply the soft-wrap rule" (U2-U5) could be read by the 4 parallel fan-out agents as "reflow the template's editorial source prose to no-hard-wrap," producing a huge whitespace-only diff against KTD3's intent. | Added an Execution guard under Implementation Units: "apply the rules" = encode prescriptions + render EXAMPLE blocks; never reflow template source. |
+| F4 | P3 | U6's "each skill links the shared ref" did not say *where* (doc-review has no references dir). | U6 clarified: assert the link exists somewhere in the skill dir (template file, or `SKILL.md` for doc-review). |
+| F5 | P3 | U6's markdown-only test adds no `plugins/` coverage; risk of a spurious coverage workaround. | U6 note added: no `--cov-fail-under` gate exists (`pyproject.toml:76` reports, does not gate) — no workaround needed. |
+
+## Remaining findings
+
+None. All five findings were resolved by safe in-place fixes.
+
+## Verification performed
+
+Each finding was confirmed against the repo, not inferred:
+
+- `rg -c '^\*\*[a-z_]+:\*\*'` across all rollout-target templates → only `ideation-artifact.md` returns non-zero (9); the rest return 0 (F1).
+- `findings-schema.md:9-18` is a field-definition table; `:105` specifies pipe-delimited findings output (F2).
+- `pyproject.toml:75-76` → `testpaths = ["tests", "plugins/*/tests"]`, `addopts` has `--cov=plugins` with no `--cov-fail-under` (F5).
+- `doc-review/SKILL.md` has no `references/` dir; report format lives in `SKILL.md` (F4).
+
+## Residual risk from limited evidence
+
+Low. The plan is a docs/templates change with one markdown-reading test; no runtime, auth, deploy, or
+data surface. The main execution risk (parallel agents over-editing clean templates) is now addressed
+by the Execution guard and the corrected KTD5.
+
+## Result contract
+
+- **Target:** `docs/plans/2026-06-07-saga-doc-readability-plan.md`
+- **Reviewed revision:** `f6c87d4` (plan as merged) + safe fixes in this PR
+- **Blocked:** no
+- **Findings:** 5 total (3× P2, 2× P3) — all resolved by safe fixes; 0 remaining
+- **Applied fixes:** F1–F5 (see table)
+- **Review artifact:** `docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md`
+- **Linked issue / plan:** #201 / `docs/plans/2026-06-07-saga-doc-readability-plan.md`
+
+`/work` may proceed — no override needed (no unresolved P0/P1).


### PR DESCRIPTION
`/doc-review` of `docs/plans/2026-06-07-saga-doc-readability-plan.md`. **Not blocked** — no P0/P1.

5 findings (3 P2, 2 P3), all evidence-backed and **safe-fixed in place**:
- **F1 (P2):** rollout over-stated — verified only ideate has the bold-label collapse; 8 other templates already use headings/prose/tables. KTD5 rewritten with the per-skill reality.
- **F2 (P2):** code-review already renders findings as a pipe-delimited table (findings-schema.md:105) — U5 corrected to link + narrative rules, not re-table.
- **F3 (P2):** added an Execution guard so the parallel fan-out doesn't reflow template source prose to no-hard-wrap.
- **F4/F5 (P3):** U6 link-assertion target + coverage-gate note clarified.

Adds the durable review artifact under docs/reviews/. /work may proceed without override.