### PR TITLE
feat(saga): make generated documents human-readable — shared formatting contract (#201)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -296,7 +296,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,18 @@
 
 ---
 
+## 2026-06-07
+
+### Saga document formatting contract — one shared reference, table-rendered schema (#201)  {#saga-doc-formatting-contract}
+
+**Decision.** All nine saga doc-writing skills (ideate, plan, brainstorm, spec, strategy, retro, doc-review, code-review, founder-review) link one shared reference, `saga/references/formatting-style.md`, which mandates: ≤3-sentence blank-line-separated paragraphs; a one-line summary opening each ranked item/section; comparative or ranked data as a table; the compact engineer-facing schema fields (basis/confidence/complexity/axis/status, findings severity/file/line) rendered as a table while narrative fields stay prose; no-hard-wrap soft-wrap for generated output; and dropping a field a heading already carries. A pytest (`tests/test_saga_doc_formatting.py`) enforces the no-stacked-bold-label rule and the link-presence rule across the templates.
+**Rejected alternatives.** Per-template duplication (drifts — `plan` fixed the CommonMark collapse once at `plan-sections.md` and `ideate` regressed into the stack anyway); a two-file `.fields.yaml` sidecar or a full doc serializer (both serve a field-level parser that does not exist, and a serializer cannot author narrative prose); fenced-block-for-all-fields (loses the at-a-glance scannability of the compact fields).
+**Rationale.** A single referenced contract means one edit improves every skill and the next new one; the table render kills the CommonMark collapse, scans at a glance, and — since the schema consumer is an LLM reader plus a human, not a regex — is *more* legible, not a parse risk; the pytest makes the format unable to silently regress.
+**Revisit when.** A real field-level parser is introduced for ideation/review schemas (a structured sidecar like the rejected R1 may then earn its place), or the pytest's stacked-bold-label heuristic proves too narrow or too noisy in practice.
+**Refs.** `docs/plans/2026-06-07-saga-doc-readability-plan.md`; `docs/ideation/2026-06-07-saga-doc-readability-ideation.md`; `docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md`; LEARNINGS {#saga-doc-schema-no-field-parser}.
+
+---
+
 ## 2026-06-05
 
 ### Whole-family plugin rename — Scheme Y: functional names + a shared `saga` category, drop the `infiquetra-` prefix, fold `blueprint-reviewer` into `saga` (squash `b6a03e0`, PR #199)  {#plugin-family-rename-scheme-y}

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,20 @@
 
 ---
 
+## 2026-06-07
+
+### Saga ideation/review schema fields are not machine-parsed — the consumer is an LLM + a human  {#saga-doc-schema-no-field-parser}
+
+**Context.** Issue #201 (make saga docs readable) carried a constraint "keep the schema machine-parseable for `/handoff` and `/plan`," and the templates' own comments asserted those consumers "parse" `basis`/`confidence`/`complexity`. That constraint drove two early heavyweight ideas (a YAML field sidecar, a full doc serializer).
+**Evidence.** `plugins/saga/scripts/parse_issue.py` parses issue *bodies* only (ADR/AC refs, keyword flags, H3 headings, handoff maturity) — never ideation-doc fields. `handoff/SKILL.md:53-57` routes by directory → maturity plus frontmatter `maturity:`; `brainstorm`/`plan` consume the doc as an LLM reader, with the human naming the survivor by title or `R#`. No code regexes `**basis:**` / `**confidence:**` / `**complexity:**`.
+**Mechanism.** The "machine-parseable" contract was aspirational template prose, never an implemented parser. The real consumers are a model reading the markdown and a human — both of which read a table or fenced block *better* than a run-on bold-label stack.
+**Fix.** Rendered the compact schema fields as a table (#201) and kept the field names stable for legibility and future-proofing; dropped the YAML-sidecar and serializer ideas.
+**What surprised.** A constraint stated as load-bearing ("must stay parseable") was satisfied — and improved — by the human-readability fix itself, because the asserted parser did not exist. Reading the consumer code flipped two heavyweight options straight into the reject pile.
+**Generalizable rule.** Before honoring a "must stay machine-parseable" constraint, grep for the actual parser. If the consumer is an LLM plus a human with no regex, optimize for legibility — a table beats a field stack on both the human and the model axis — and do not pay for a structured-data split that serves a parser that is not there.
+**Refs.** DECISIONS {#saga-doc-formatting-contract}; `docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md`.
+
+---
+
 ## 2026-06-04
 
 ### "X shipped" can be TRUE on origin yet INVISIBLE in a stale local tree — verify against origin/<tip> + `gh pr view`, not the checkout, before concluding "X didn't ship"  {#shipped-on-origin-not-in-stale-local-tree}

--- a/docs/work-sessions/2026-06-07-saga-doc-readability.md
+++ b/docs/work-sessions/2026-06-07-saga-doc-readability.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-07
+issue: 201
+plan: docs/plans/2026-06-07-saga-doc-readability-plan.md
+review: docs/reviews/2026-06-07-saga-doc-readability-plan-doc-review.md
+status: pr-ready
+---
+
+# Work Session: Saga Document Readability (#201)
+
+Built the shared formatting contract and rolled it across all nine doc-writing skills, with a pytest gate so it can't regress.
+
+The triggering bug — ideate's stacked-bold-label SURVIVOR SCHEMA — is fixed; the other eight skills now link the contract and apply the lead-in/short-paragraph/table rules.
+
+## What was built (by U-ID)
+
+| unit | what | how |
+|------|------|-----|
+| U1 | Shared contract `saga/references/formatting-style.md` + golden specimen | authored directly |
+| U2 | ideate: `ideation-artifact.md` schema → table + lead-in (drop `**title:**`); `convergence-and-partnership.md` present-phase aligned; SKILL link | ultracode agent |
+| U3 | plan: lead-in rule + contract link; kept prose-heavy per-unit branch | ultracode agent |
+| U4 | brainstorm/spec/strategy: contract link + light rules | ultracode agent |
+| U5 | retro/doc-review/code-review/founder-review: contract link + light rules (code-review findings left as the existing table) | ultracode agent |
+| U6 | `tests/test_saga_doc_formatting.py` — collapse + link-presence gate (25 tests) | authored directly |
+| U7 | DECISIONS + LEARNINGS entries; CHANGELOG 0.20.0 + 0.19.0 backfill; plugin.json + marketplace.json → 0.20.0; version-pin test | authored directly |
+
+## Key decisions
+
+The schema renders as a table for compact fields with narrative kept as prose — verified safe because nothing machine-parses the fields (the consumer is an LLM + a human), recorded in LEARNINGS `{#saga-doc-schema-no-field-parser}`.
+
+The rules live in one shared reference all skills link, enforced by pytest — recorded in DECISIONS `{#saga-doc-formatting-contract}`.
+
+Execution used the `cc-workflows-ultracode` backend: U1/U6/U7 authored directly; U2–U5 ran as a four-agent parallel fan-out over disjoint files, then every diff was verified and the agents' clickable-link style was normalized to the repo's bare `saga/references/...` convention.
+
+## Files modified
+
+14 skill template/SKILL files (the 9 doc-writing skills) + `plugins/saga/references/formatting-style.md` (new) + `tests/test_saga_doc_formatting.py` (new) + `plugins/saga/CHANGELOG.md` + `plugins/saga/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` + `tests/test_saga_plugin.py` + `docs/engineering-journal/{DECISIONS,LEARNINGS}.md`.
+
+## Checks run
+
+`pytest` (709 passed), `ruff format --check` + `ruff check` (clean), `validate_plugins.py` (exit 0), `marketplace/validator/validate.py` (0 errors), `json.tool` on marketplace.json (valid).
+
+## Next step
+
+Open the PR, confirm CI green, squash-merge (destination = merge); post-merge, fill the journal SHAs and route to `/qa` advisorily.

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.20.0 - 2026-06-07
+
+- Add a shared formatting contract, `saga/references/formatting-style.md`, linked by all nine
+  doc-writing skills (ideate, plan, brainstorm, spec, strategy, retro, doc-review, code-review,
+  founder-review). It mandates scannable output: ≤3-sentence blank-line-separated paragraphs, a
+  one-line summary opening each ranked item/section, comparative data as tables, the compact
+  engineer-facing schema fields rendered as a table (narrative fields stay prose), no-hard-wrap
+  soft-wrap for generated output, and dropping fields a heading already carries. (#201)
+- Fix the triggering case: `ideate`'s `ideation-artifact.md` SURVIVOR SCHEMA no longer stacks
+  bold-label lines (the CommonMark collapse that read as "all jumbled together") — it now leads with
+  a one-line summary and renders the schema as a table.
+- Enforce it: `tests/test_saga_doc_formatting.py` fails CI on a stacked-bold-label collapse and on
+  any doc-writing skill that does not link the contract.
+
+## 0.19.0 - 2026-06-05
+
+- Rename the engine plugin to `saga` (Scheme Y plugin-family rename) and fold `blueprint-reviewer`
+  into it. Metadata/marketplace change; no command behavior change. (#199)
+
 ## 0.18.0 - 2026-06-04
 
 - Rebuild `/optimize` from a 20-line stub into a **metric-driven optimization engine** — the

--- a/plugins/saga/references/formatting-style.md
+++ b/plugins/saga/references/formatting-style.md
@@ -1,0 +1,73 @@
+# Saga Document Formatting Style
+
+The shared formatting contract every saga doc-writing skill links to.
+
+It governs how durable saga documents *look* — the visual structure that makes them scannable. It does not change what those documents *say*; analytical content, schemas, and section sets are each skill's own concern.
+
+Skills link this file by path (`saga/references/formatting-style.md`) from their template or present-phase reference, the same way skills already link `saga/references/...`. One edit here updates every skill's output convention at once.
+
+## Why this exists
+
+Consecutive `**label:**` lines with no blank line between them collapse into a single paragraph in CommonMark — the "all jumbled together" failure. The `plan` skill learned this once (`plan/references/plan-sections.md`: units are `###` headings, not list-item fields), but the lesson lived in one skill and `ideate` regressed into the stacked-label form anyway. This file is the shared home so the lesson cannot fail to propagate.
+
+## The rules
+
+Every generated saga document follows these.
+
+1. **Short paragraphs.** ≤3 sentences each, separated by blank lines. No 4+ sentence blocks.
+
+2. **Lead with a summary.** Each ranked item and each major section opens with a one-line, plain-language summary before any fields or detail.
+
+3. **Comparative data is a table.** Ranked, scored, or compared data (survivors, options, findings, tradeoffs) renders as a table or a bullet list — never a prose wall.
+
+4. **Machine fields stay distinct.** Engineer-facing schema fields stay present but visually separated from the narrative (a compact table or block), and keep stable field names so consumers stay reliable.
+
+5. **Soft-wrap generated prose.** No hard line wrap inside a paragraph — let the viewer wrap it — with blank lines between paragraphs. This is a *generated-output* rule; the template source files in this repo stay editor-friendly and may hard-wrap.
+
+6. **No redundant fields.** Drop a field the structure already carries — e.g. a `title:` field directly under a `### N. Title` heading.
+
+7. **Never stack bold labels.** Two or more `**label:**` lines with no blank line between them is the fatal collapse; a structural test (`tests/test_saga_doc_formatting.py`) enforces this across the templates.
+
+## Which structure to use
+
+Pick the render shape by the *kind* of data, not by habit.
+
+| Data kind | Use | Example |
+|-----------|-----|---------|
+| Compact, comparable, scored fields | A table | idea `basis`/`confidence`/`complexity`/`axis`/`status`; code-review finding `severity`/`file`/`line` |
+| Narrative fields | Short prose paragraphs | `description`, `rationale`, `downsides`, problem framing |
+| Prose-heavy per-unit fields that don't tabularize | Blank-line-separated `**label:**` lines under a `### heading` | plan unit `Goal` / `Files` / `Approach` / `Test scenarios` |
+
+The table form solves three things at once: it never collapses in CommonMark, it scans at a glance, and — since the consumers are an LLM reading the doc plus a human, not a regex parser — it is *more* legible than a stacked-label run, not a parse risk.
+
+## Worked example — the golden specimen
+
+This is the shape a ranked item should take: a heading, a one-line summary, short prose, then a compact field table. The few-shot skills imitate, and the structural test asserts against it.
+
+### 2. Render the schema as a table
+
+One-line plain-language summary of the idea goes here, before any fields.
+
+A short narrative paragraph carries the reasoning — rationale and downsides as prose, ≤3 sentences, soft-wrapped, blank-line separated.
+
+| field | value |
+|-------|-------|
+| basis | direct: path/to/file.md:42 |
+| confidence | 88 |
+| complexity | Low |
+| status | Unexplored |
+
+And ranked or compared items render as one scannable table, not N prose blocks:
+
+| # | item | confidence | complexity |
+|---|------|:----------:|:----------:|
+| 1 | First option | 90 | Low |
+| 2 | Second option | 80 | Med |
+
+## For skill authors
+
+When you add or edit a doc-writing skill, do two things.
+
+Link this file from your template or present-phase reference so the rules reach your output. Then apply the render decision above to your artifact's shape — table the compact fields, keep narrative as short prose, and lead every ranked item or section with a one-liner.
+
+Do not reflow this repo's template *source* prose to satisfy rule 5 — the soft-wrap rule is for the documents skills *generate*, not for the hard-wrapped reference files you are editing.

--- a/plugins/saga/skills/brainstorm/references/requirements-sections.md
+++ b/plugins/saga/skills/brainstorm/references/requirements-sections.md
@@ -9,6 +9,12 @@ User-facing behavior, scope boundaries, and success criteria belong in this doc.
 file layouts, and code-level design do not — unless the brainstorm is itself about that technical
 decision, in which case those details are the subject and belong here.
 
+**Formatting contract.** The generated requirements doc follows the shared
+`saga/references/formatting-style.md`: open each section and
+each ranked item with a one-line plain-language summary, keep narrative fields as short
+(≤3-sentence) blank-line-separated paragraphs, and render any comparative, scored, or enumerated data
+(option comparisons, requirement groups, tradeoffs) as a table or bullet list rather than a prose wall.
+
 ## The outcome
 
 A great requirements doc lets three audiences act:

--- a/plugins/saga/skills/code-review/references/findings-schema.md
+++ b/plugins/saga/skills/code-review/references/findings-schema.md
@@ -4,6 +4,13 @@ Every review lens returns findings in this schema. It is adopted from CE's findi
 are **agent-consumable** — `autofix_class` and `owner` are routing metadata a downstream fixer reads.
 `/code-review` itself only reports, classifies, and routes; it never applies a fix.
 
+**Formatting contract.** The output below already tables findings (the pipe-delimited interactive table);
+that satisfies the shared contract in
+`saga/references/formatting-style.md`. When the report carries
+any surrounding narrative (the Coverage section, the verdict blockquote), keep it as short (≤3-sentence)
+blank-line-separated prose and lead each block with a one-line summary. Do **not** re-table the findings —
+the schema and its table are canonical.
+
 ## Per-finding fields
 
 | Field | Required | Description |

--- a/plugins/saga/skills/doc-review/SKILL.md
+++ b/plugins/saga/skills/doc-review/SKILL.md
@@ -181,6 +181,12 @@ For issue-attached work, summarize:
 
 ## Output Shape
 
+The generated readiness report and the `docs/reviews/` artifact follow the shared formatting contract
+in `saga/references/formatting-style.md`: lead the readiness
+summary and each section with a one-line plain-language verdict, render the by-priority findings as a
+table (one row per finding, with its `P0`-`P3` priority and status), and keep narrative fields as short
+(≤3-sentence) blank-line-separated prose.
+
 Use this structure:
 
 1. Applied fixes, if any.

--- a/plugins/saga/skills/founder-review/references/review-modes.md
+++ b/plugins/saga/skills/founder-review/references/review-modes.md
@@ -4,6 +4,11 @@ This reference is the operational spine of `/founder-review`: the 4 scope modes,
 pre-review system audit, the Step-0 sub-steps (with the **target-conditional** ceremonies), the
 expansion-framing and opt-in ceremonies, and the scope-decision artifact format.
 
+**Formatting contract.** The generated `docs/founder-reviews/` scope-decision artifact follows the shared
+contract in `saga/references/formatting-style.md`: lead each
+section with a one-line summary, keep the Scope Decisions data as a table (the format below), and keep
+narrative fields (Vision, Premise findings, verdict) as short (≤3-sentence) blank-line-separated prose.
+
 ---
 
 ## The 4 scope modes

--- a/plugins/saga/skills/ideate/SKILL.md
+++ b/plugins/saga/skills/ideate/SKILL.md
@@ -527,3 +527,12 @@ and follow Phases 3–6 (adversarial filter → present survivors + revivable cu
 co-ideate / revive / interview / hand off), then the quality-bar self-check. This load is
 non-optional — the critique rubric, revival state machine, persistence template, the Phase 6 menu,
 and the quality bar live there, not in this file. Do not improvise them from memory.
+
+## Reference files
+
+- `saga/skills/ideate/references/convergence-and-partnership.md` — Phases 3–6 (critique, present,
+  persist, refine/revive/hand off) and the quality bar.
+- `saga/skills/ideate/references/ideation-artifact.md` — the persisted artifact template.
+- `saga/references/formatting-style.md` — the canonical formatting contract that governs how the
+  presented survivors and the persisted artifact look (lead-in summaries, short prose, compact fields
+  as a table).

--- a/plugins/saga/skills/ideate/references/convergence-and-partnership.md
+++ b/plugins/saga/skills/ideate/references/convergence-and-partnership.md
@@ -81,21 +81,26 @@ brief follow-up questions and lightweight clarification.
 
 ### SURVIVOR SCHEMA
 
-Present only the surviving ideas, each in this exact shape (field names identical to the artifact
-template in `saga/skills/ideate/references/ideation-artifact.md`):
+Present only the surviving ideas. The render follows the canonical formatting contract,
+`saga/references/formatting-style.md`, and matches the artifact template in
+`saga/skills/ideate/references/ideation-artifact.md` exactly (same field names). Each survivor takes
+this shape:
 
-- **title** — short, concrete.
-- **description** — concrete explanation of the move.
-- **axis** — the topic axis this idea targets. Include only when Phase 1.5 produced an axis list; omit
-  when decomposition was skipped.
-- **basis** — tagged exactly one of `direct:` (quoted file/line/issue/user-context), `external:`
-  (named prior art / source), or `reasoned:` (written-out first-principles argument). This is the same
-  basis contract the frame agents carried in Phase 2.
-- **rationale** — how the basis connects to the move's significance.
-- **downsides** — tradeoffs or costs.
-- **confidence** — 0-100.
-- **complexity** — Low / Med / High.
-- **status** — `Unexplored` / `Explored`.
+- a `### N. <title>` heading — the **title** (short, concrete) lives in the heading, not a separate
+  field;
+- a one-line plain-language summary of the move;
+- the **description** (concrete explanation of the move) as short prose, then **rationale** (how the
+  basis connects to the move's significance) and **downsides** (tradeoffs or costs) as a separate
+  short paragraph — blank-line-separated, ≤3 sentences each;
+- a small two-column table for the compact fields:
+  - **basis** — tagged exactly one of `direct:` (quoted file/line/issue/user-context), `external:`
+    (named prior art / source), or `reasoned:` (written-out first-principles argument). This is the
+    same basis contract the frame agents carried in Phase 2.
+  - **confidence** — 0-100.
+  - **complexity** — Low / Med / High.
+  - **axis** — the topic axis this idea targets. Include this row only when Phase 1.5 produced an axis
+    list; omit it when decomposition was skipped.
+  - **status** — `Unexplored` / `Explored`.
 
 Order survivors by the rubric score (strongest first).
 

--- a/plugins/saga/skills/ideate/references/ideation-artifact.md
+++ b/plugins/saga/skills/ideate/references/ideation-artifact.md
@@ -8,6 +8,11 @@ Field names here are IDENTICAL to the SURVIVOR SCHEMA and REVIVABLE-CUT SCHEMA i
 them aligned. Omit a clearly irrelevant field only when necessary. On resume, update in place and
 preserve `Explored` markers, stable `R#` ids, and their statuses.
 
+The visual shape of the generated artifact follows the canonical formatting contract,
+`saga/references/formatting-style.md`: lead each ranked survivor with a one-line summary, keep
+`description` / `rationale` / `downsides` as short blank-line-separated prose, and render the compact
+fields (`basis` / `confidence` / `complexity` / `axis` / `status`) as a small two-column table.
+
 The artifact carries `idea-ready` handoff maturity (feeds `/handoff` → `mission-control` and `/plan`).
 
 ```markdown
@@ -41,19 +46,24 @@ when Phase 1.5 was skipped. Omit this section entirely if not applicable.]
 ## Ranked Survivors
 
 ### 1. <Idea Title>
-**title:** <short, concrete>
-**description:** [Concrete explanation of the move]
-**axis:** [Topic axis this idea targets — omit when decomposition was skipped]
-**basis:** [`direct:` quoted file/line/issue/user-context | `external:` named prior art/source |
-`reasoned:` written-out first-principles argument]
-**rationale:** [How the basis connects to the move's significance]
-**downsides:** [Tradeoffs or costs]
-**confidence:** [0-100]
-**complexity:** [Low | Med | High]
-**status:** [Unexplored | Explored]
+
+[One-line plain-language summary of the move, before any fields.]
+
+[Concrete explanation of the move — the `description`. Short prose, ≤3 sentences.]
+
+[How the basis connects to the move's significance — the `rationale` — then the `downsides`
+(tradeoffs or costs), as a separate short paragraph. Blank-line separated, ≤3 sentences each.]
+
+| field | value |
+|-------|-------|
+| basis | [`direct:` quoted file/line/issue/user-context \| `external:` named prior art/source \| `reasoned:` written-out first-principles argument] |
+| confidence | [0-100] |
+| complexity | [Low \| Med \| High] |
+| axis | [Topic axis this idea targets — omit this row when decomposition was skipped] |
+| status | [Unexplored \| Explored] |
 
 ### 2. <Idea Title>
-[... same fields, strongest-first by rubric score ...]
+[... same shape — summary, prose, then the field table — strongest-first by rubric score ...]
 
 ## Did not survive (revivable)
 

--- a/plugins/saga/skills/plan/SKILL.md
+++ b/plugins/saga/skills/plan/SKILL.md
@@ -172,6 +172,13 @@ Push twice, then respect the answer. Escape hatches are in `references/interroga
 Write the plan to `docs/plans/YYYY-MM-DD-<topic>-plan.md` per `references/plan-sections.md`. Right-size
 by the Phase-0.5 scope class. **Never code during this phase** — research, decide, and write the plan.
 
+Follow the shared formatting contract in `saga/references/formatting-style.md` for the plan's visual
+structure: lead each unit and major section with a one-line summary, keep narrative fields as short
+(≤3-sentence) blank-line-separated prose, render comparative/scored data as a table, and never stack
+bold labels without a blank line between them. Per-unit fields stay as blank-line-separated
+`**label:**` lines under each `### U<N>.` heading (the contract's prose-heavy per-unit branch) — not a
+table.
+
 **Hard floor (every warranted plan carries these):**
 
 - **Summary** — what the plan proposes, in 1-3 lines.

--- a/plugins/saga/skills/plan/references/plan-sections.md
+++ b/plugins/saga/skills/plan/references/plan-sections.md
@@ -4,6 +4,12 @@ This reference describes WHAT a great Infiquetra implementation plan contains. T
 markdown only (the HTML output branch is not used here). Sections earn their place by serving one of
 the plan's three audiences; omit padding.
 
+**Formatting authority.** The generated plan's visual structure follows the shared formatting
+contract in `saga/references/formatting-style.md` — that file is canonical for how saga documents
+*look* (short paragraphs, lead-with-a-summary, comparative data as a table, never stack bold labels).
+This reference governs WHAT a plan contains and how its units are shaped; the formatting contract
+governs the render rules they share.
+
 ## The outcome — three audiences
 
 A great plan enables three audiences to act:
@@ -114,6 +120,16 @@ than forcing the content where it doesn't belong.
   machines, worktrees, and teammates.
 
 ### Per implementation unit
+
+**Lead with a one-liner.** Each unit (and each major plan section) opens with a one-line,
+plain-language summary before any fields or detail — the reader grasps the unit's intent in a single
+glance, then drops into the fields. This is rule 2 of `saga/references/formatting-style.md`.
+
+**Field shape — blank-line-separated bold labels.** Per-unit fields render as `**label:**` lines under
+the `### U<N>.` heading, each separated by a blank line — this is the contract's "prose-heavy per-unit
+fields that don't tabularize" branch (`saga/references/formatting-style.md`, "Which structure to use").
+Do **not** convert plan units to a table, and **never** stack two `**label:**` lines without a blank
+line between them (the fatal CommonMark collapse — rule 7 of the formatting contract).
 
 Each `### U<N>. [Name]` includes:
 

--- a/plugins/saga/skills/retro/references/retro-report.md
+++ b/plugins/saga/skills/retro/references/retro-report.md
@@ -2,6 +2,12 @@
 
 The shape of the `docs/retros/` writeup and the journal entry templates `/retro` promotes into.
 
+**Formatting contract.** The generated retro doc follows the shared
+`saga/references/formatting-style.md`: open each report
+section with a one-line summary, render comparative or enumerated data (findings, scope decisions) as a
+table or bullet list rather than a prose wall, keep narrative fields as short (≤3-sentence)
+blank-line-separated paragraphs, and never stack `**label:**` lines without a blank line between them.
+
 ---
 
 ## The `docs/retros/` writeup shape

--- a/plugins/saga/skills/spec/SKILL.md
+++ b/plugins/saga/skills/spec/SKILL.md
@@ -166,6 +166,8 @@ register) nor `/brainstorm`'s divergent exploration job. It reads the repo but d
 - `references/spec-template.md` — the locked `docs/specs/` artifact: frontmatter + sections, the
   post-write checklist, and the `/handoff` routing note (the artifact is a `/handoff` source mapping to
   `requirements-ready`; `mission-control` owns the issue body).
+- `saga/references/formatting-style.md` — the shared formatting contract the written spec follows
+  (one-line section summaries, short blank-separated paragraphs, comparative data as tables/bullets).
 
 ## Learn more
 

--- a/plugins/saga/skills/spec/references/spec-template.md
+++ b/plugins/saga/skills/spec/references/spec-template.md
@@ -16,6 +16,12 @@ answers and write to `docs/specs/<YYYY-MM-DD>-<slug>-spec.md`. Template structur
   `issue:#N`, or the repo-relative upstream doc path).
 - **Optional sections (Open Questions): delete the section entirely if unused. Never leave an empty
   header.**
+- **Formatting.** Follow the shared
+  `saga/references/formatting-style.md`: open `Context`,
+  `Proposed Change`, and each filled section with a one-line summary, keep narrative fields as short
+  (≤3-sentence) blank-line-separated paragraphs, and render comparative or scored data as a table or
+  bullets — the `Failure Modes & Rollback` and `Files Reference` tables and the numbered `Acceptance
+  Criteria` already follow this.
 
 ## Template
 

--- a/plugins/saga/skills/strategy/SKILL.md
+++ b/plugins/saga/skills/strategy/SKILL.md
@@ -141,6 +141,8 @@ does **NOT** write the saga — no `saga.py` invocation, no `--review-paths`. Re
 - `references/strategy-template.md` — the locked `STRATEGY.md` template: YAML frontmatter + the 8
   sections in locked order, the 3-5 metrics / 2-4 tracks constraints, delete-optional-if-unused, and
   the post-write checklist.
+- `saga/references/formatting-style.md` — the shared formatting contract the written `STRATEGY.md`
+  follows (short blank-separated sections leading with the point, comparative data as bullets/tables).
 
 ## Learn more
 

--- a/plugins/saga/skills/strategy/references/strategy-template.md
+++ b/plugins/saga/skills/strategy/references/strategy-template.md
@@ -12,6 +12,11 @@ to the repository root `STRATEGY.md`. Locked template ported from Compound-Engin
 - **Optional sections: delete the section entirely if unused. Never leave an empty header.**
 - Set `last_updated` in the YAML frontmatter to today's ISO date (YYYY-MM-DD); do not duplicate it in
   prose. Set `name` to the product or initiative name (the same value used in the H1 title).
+- **Formatting.** Follow the shared
+  `saga/references/formatting-style.md`: keep each section a
+  short (≤3-sentence) blank-line-separated paragraph, lead with the plain-language point, and render
+  any comparative or enumerated data as the bullet lists the template already prescribes (`Key metrics`,
+  `Milestones`, `Not working on`) rather than a prose wall.
 
 ## Template
 

--- a/tests/test_saga_doc_formatting.py
+++ b/tests/test_saga_doc_formatting.py
@@ -1,0 +1,145 @@
+"""Structural formatting gate for saga doc-writing skills (issue #201).
+
+This test enforces the shared formatting contract in
+``plugins/saga/references/formatting-style.md`` so the generated-document
+formatting cannot silently regress. It only reads markdown, so it adds no
+``plugins/`` line coverage — that is expected; there is no ``--cov-fail-under``
+gate (see ``pyproject.toml``).
+
+What it checks:
+
+1. No template/format file stacks bold-label lines without a blank line between
+   them (the CommonMark collapse that produced "all jumbled together").
+2. Each of the nine doc-writing skills links the shared contract somewhere in
+   its skill directory.
+3. The shared contract's golden specimen passes the same collapse check.
+
+It deliberately does NOT check soft-wrap: rule 5 is a generated-output rule, and
+the template *source* files in this repo stay hard-wrapped and editor-friendly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAGA_ROOT = REPO_ROOT / "plugins" / "saga"
+SHARED_CONTRACT = SAGA_ROOT / "references" / "formatting-style.md"
+
+# A line that *begins* (after optional indent) with a bold label, e.g.
+# ``**basis:** direct: ...``. A bullet (``- **basis:**``) does NOT match — those
+# are list items, which render fine. Two or more of these on adjacent non-blank
+# lines is the fatal collapse.
+BOLD_LABEL_LINE = re.compile(r"^[ \t]*\*\*[^*\n]+:\*\*")
+
+# The nine skills that write durable documents, mapped to the file(s) that carry
+# their output format (the collapse-checked set). doc-review carries its report
+# format in SKILL.md (no references dir).
+DOC_OUTPUT_FILES: dict[str, list[str]] = {
+    "ideate": [
+        "references/ideation-artifact.md",
+        "references/convergence-and-partnership.md",
+    ],
+    "plan": ["references/plan-sections.md"],
+    "brainstorm": ["references/requirements-sections.md"],
+    "spec": ["references/spec-template.md"],
+    "strategy": ["references/strategy-template.md"],
+    "retro": ["references/retro-report.md"],
+    "doc-review": ["SKILL.md"],
+    "code-review": ["references/findings-schema.md"],
+    "founder-review": ["references/review-modes.md"],
+}
+
+DOC_SKILLS = sorted(DOC_OUTPUT_FILES)
+
+# The repo-relative link every doc-writing skill must reference.
+CONTRACT_LINK = "saga/references/formatting-style.md"
+
+
+def find_collapse(text: str) -> int | None:
+    """Return the 1-based line number where a bold-label collapse begins.
+
+    A collapse is two or more adjacent non-blank lines that each begin with a
+    bold label. Returns ``None`` when no collapse is present.
+    """
+    previous_was_label = False
+    for index, line in enumerate(text.splitlines(), start=1):
+        is_label = bool(BOLD_LABEL_LINE.match(line))
+        if is_label and previous_was_label:
+            return index
+        previous_was_label = is_label
+    return None
+
+
+def _collapse_target_files() -> list[Path]:
+    files: list[Path] = [SHARED_CONTRACT]
+    for skill, rel_paths in DOC_OUTPUT_FILES.items():
+        for rel in rel_paths:
+            files.append(SAGA_ROOT / "skills" / skill / rel)
+    return files
+
+
+# --- the collapse detector itself (gives the gate teeth + documents the rule) ---
+
+
+def test_collapse_detector_flags_stacked_labels() -> None:
+    bad = "**basis:** direct: x\n**confidence:** 88\n**complexity:** Low\n"
+    assert find_collapse(bad) == 2
+
+
+def test_collapse_detector_allows_blank_separated_labels() -> None:
+    good = "**basis:** direct: x\n\n**confidence:** 88\n\n**complexity:** Low\n"
+    assert find_collapse(good) is None
+
+
+def test_collapse_detector_ignores_bulleted_bold_labels() -> None:
+    # Bullets render fine and are the legitimate per-unit form.
+    bulleted = "- **Goal** — do the thing\n- **Files** — a.md\n- **Approach** — x\n"
+    assert find_collapse(bulleted) is None
+
+
+# --- the contract exists and is self-consistent ---
+
+
+def test_shared_contract_exists() -> None:
+    assert SHARED_CONTRACT.is_file(), f"missing shared contract: {SHARED_CONTRACT}"
+
+
+def test_shared_contract_specimen_has_no_collapse() -> None:
+    line = find_collapse(SHARED_CONTRACT.read_text())
+    assert line is None, f"{SHARED_CONTRACT} has a bold-label collapse at line {line}"
+
+
+# --- every doc-output file is collapse-free ---
+
+
+@pytest.mark.parametrize(
+    "path",
+    _collapse_target_files(),
+    ids=lambda p: str(p.relative_to(SAGA_ROOT)),
+)
+def test_doc_output_file_has_no_collapse(path: Path) -> None:
+    assert path.is_file(), f"expected doc-output file is missing: {path}"
+    line = find_collapse(path.read_text())
+    assert line is None, (
+        f"{path.relative_to(REPO_ROOT)} stacks bold-label lines at line {line} "
+        f"(CommonMark collapse). Separate them with blank lines or use a table "
+        f"per saga/references/formatting-style.md."
+    )
+
+
+# --- every doc-writing skill links the shared contract ---
+
+
+@pytest.mark.parametrize("skill", DOC_SKILLS)
+def test_doc_skill_links_shared_contract(skill: str) -> None:
+    skill_dir = SAGA_ROOT / "skills" / skill
+    assert skill_dir.is_dir(), f"missing skill dir: {skill_dir}"
+    linked = any(CONTRACT_LINK in md.read_text() for md in skill_dir.rglob("*.md"))
+    assert linked, (
+        f"skill '{skill}' does not link {CONTRACT_LINK} anywhere in its dir; "
+        f"add the link so its generated docs follow the formatting contract."
+    )

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.19.0"
+    assert plugin_json["version"] == "0.20.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]


### PR DESCRIPTION
Closes #201. Implements `docs/plans/2026-06-07-saga-doc-readability-plan.md` (cleared `/doc-review`, PR #204).

## What
A shared formatting contract — `saga/references/formatting-style.md` — linked by all nine doc-writing skills, so every durable saga document is scannable: ≤3-sentence blank-separated paragraphs, a one-line summary opening each ranked item/section, comparative data as tables, compact engineer-facing schema fields rendered as a table (narrative stays prose), no-hard-wrap soft-wrap, and no redundant fields.

## Units
- **U1** `saga/references/formatting-style.md` + golden specimen.
- **U2** ideate — the triggering bug: `ideation-artifact.md` SURVIVOR SCHEMA no longer stacks bold-label lines (the CommonMark collapse) → table + lead-in, `**title:**` dropped; `convergence-and-partnership.md` present-phase aligned.
- **U3–U5** plan, brainstorm, spec, strategy, retro, doc-review, code-review, founder-review — link the contract + apply the rules (code-review findings already a table, left as-is; plan units stay the prose-heavy bold-label branch).
- **U6** `tests/test_saga_doc_formatting.py` — fails CI on a stacked-bold-label collapse and on a skill that doesn't link the contract (25 tests).
- **U7** journal DECISIONS + LEARNINGS, CHANGELOG 0.20.0 + 0.19.0 backfill, saga 0.19.0→0.20.0.

## Notable finding
Nothing machine-parses the schema fields (consumer = LLM + human, not a regex), so the table render satisfies the 'keep it parseable' constraint *and* improves legibility — which killed the two heavyweight options (YAML sidecar, serializer). Recorded in LEARNINGS `{#saga-doc-schema-no-field-parser}`.

## Checks
709 pytest passed · ruff format+check clean · plugin + marketplace validators 0 errors.

Execution: `cc-workflows-ultracode` — U2–U5 ran as a 4-agent parallel fan-out over disjoint files, every diff verified, link style normalized to the repo convention.