### PR TITLE
feat(team-scaffold): emit Ansible collection deploy harnesses

### DIFF
--- a/plugins/home-lab-ops/skills/team-scaffold/SKILL.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/SKILL.md
@@ -20,8 +20,8 @@ in `scripts/`) with the **two irreducible human gates** that cannot be
 API-automated.
 
 > Native `hermes profile install` packaging is DEFERRED. The deploy artifact is
-> the Ansible harness (`deploy/<team>.yml`) that reuses home-lab roles via
-> `ANSIBLE_ROLES_PATH` — the supported independent-deploy mechanism.
+> the Ansible harness (`deploy/<team>.yml`) that installs reusable role code from
+> `infiquetra.hermes_team` and takes inventory/shared secrets as explicit inputs.
 
 ## Mental model
 
@@ -74,9 +74,10 @@ Full detail in [references/runbook.md](references/runbook.md); spec schema in
 9. **Register the host** (the ONLY home-lab write):
    `team-scaffold register-host team-spec.yaml` (dry-run) →
    `... --apply`, then commit home-lab's `hosts.yml` as a single revertible commit.
-10. **Dry-run the deploy:** `cd <clone>/deploy && ansible-playbook -i
-    <home-lab-inventory> --limit <host> <team>.yml --check --diff
-    --vault-password-file ~/.vault_pass.txt`, then deploy for real.
+10. **Dry-run the deploy:** install collections, set
+    `INFIQUETRA_SHARED_INFRA_VAULT`, then run `ansible-playbook -i
+    <inventory-artifact> --limit <host> deploy/<team>.yml --check --diff
+    --vault-password-file ~/.vault_pass.txt`.
 
 ## Guardrails
 
@@ -96,8 +97,9 @@ Full detail in [references/runbook.md](references/runbook.md); spec schema in
 
 ```bash
 cd scripts
-uv run pytest -q                 # 39 tests: golden byte-parity (12 teams) + validators + modules
+uv run pytest -q                 # generator contract + validators + modules
 uv run team-scaffold golden      # re-derive the 12 known teams vs frozen fixtures
 ```
-The golden gate proves the generator still reproduces every live team
-byte-for-byte — run it after any change to `harness_gen.py` or the specs.
+The harness tests prove the generator emits collection install, explicit
+inventory/shared-vault inputs, and no legacy roles-path dependency. Run them
+after any change to `harness_gen.py` or the specs.

--- a/plugins/home-lab-ops/skills/team-scaffold/references/input-contract.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/references/input-contract.md
@@ -43,10 +43,10 @@ profiles:                         # NAMES + token vars only (dir stamping + vaul
 
 ## How the 12 existing teams map
 
-`specs/team-*.yaml` are materialized from the migration generator's TEAMS dict
-(harness block) + the live `team_profiles.yml` (profile refs) + `hosts.yml`
-(inventory). They are the golden fixtures: `team-scaffold golden` proves each one
-re-derives its live `deploy/` files byte-for-byte. Use them as worked examples:
+`specs/team-*.yaml` are materialized from the migration generator's TEAMS dict,
+the live `team_profiles.yml` profile refs, and `hosts.yml` inventory. They feed
+the generated deploy fixtures checked by `team-scaffold golden`. Use them as
+worked examples:
 
 - `specs/team-themis.yaml` — single-profile legacy agent (minimal)
 - `specs/team-apollo.yaml` — multi-profile dev team (`hermes_team_listener`)

--- a/plugins/home-lab-ops/skills/team-scaffold/references/runbook.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/references/runbook.md
@@ -42,7 +42,7 @@ mutation** — keep it last, emit it as one commit, and never run it before step
 
 ## After scaffolding
 
-Run the golden gate to confirm nothing regressed the generator:
+Run the generator checks to confirm nothing regressed the scaffold output:
 
 ```bash
 cd scripts && uv run pytest -q && uv run team-scaffold golden

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/materialize_specs.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/materialize_specs.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Build helper (run once): materialize specs/team-*.yaml for the 12 existing teams.
 
-Imports the TEAMS dict from the preserved migration generator so the harness
-block is transcription-free, enriches each spec with profile refs (from the live
-team_profiles.yml fixtures) + an inventory block (from home-lab hosts.yml), and
-writes specs/team-<name>.yaml. Those specs feed the golden test: harness_gen of
-each spec must reproduce the live deploy/ files byte-for-byte.
+Imports the TEAMS dict from the preserved migration generator, enriches each
+spec with profile refs (from the live team_profiles.yml fixtures) + an inventory
+block (from home-lab hosts.yml), and writes specs/team-<name>.yaml. Those specs
+feed the generated deploy fixture parity check.
 
 Usage:
   python3 materialize_specs.py \

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/cli.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/cli.py
@@ -10,7 +10,7 @@ Everything here is scriptable + idempotent:
   team-scaffold stamp              team-spec.yaml --out <dir> [--context-library PATH]
   team-scaffold vault-wire         team-spec.yaml --source <home-lab all.yml> --out <dir>
   team-scaffold register-host      team-spec.yaml [--hosts PATH] [--apply]
-  team-scaffold golden             # re-derive 12 known teams vs frozen fixtures
+  team-scaffold golden             # re-derive 12 known teams vs generated fixtures
 """
 
 from __future__ import annotations
@@ -120,7 +120,7 @@ def _cmd_golden(_args: argparse.Namespace) -> int:
     if fails:
         print(f"{fails} divergence(s)")
         return 1
-    print(f"✓ golden: {len(specs)} teams reproduce byte-for-byte")
+    print(f"✓ golden: {len(specs)} teams match generated deploy fixtures")
     return 0
 
 

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
@@ -12,6 +12,9 @@ COLLECTION_ROLES = {
     "hermes_dm_listener": "infiquetra.hermes_team.hermes_dm_listener",
     "hermes_mint_broker": "infiquetra.hermes_team.hermes_mint_broker",
     "deploy_skill": "infiquetra.hermes_team.deploy_skill",
+    "ollama": "infiquetra.hermes_team.ollama",
+    "hermes_team_listener": "infiquetra.hermes_team.hermes_team_listener",
+    "hermes_orchestrator": "infiquetra.hermes_team.hermes_orchestrator",
 }
 
 REQUIREMENTS = """---
@@ -32,6 +35,17 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"
 """
 
 
@@ -195,7 +209,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `{hosts}` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -234,9 +249,6 @@ ansible-galaxy collection install \\
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \\
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.
 """
 
 

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/harness_gen.py
@@ -1,30 +1,62 @@
-"""Render a team's deploy harness (deploy/{<team>.yml,requirements.yml,README.md}).
+"""Render a team's deploy harness.
 
-Promoted verbatim from the one-off migration generator
-(home-lab `/tmp/journal-partition/gen_harness.py`, 2026-05-31). The template
-strings below are byte-identical to that generator's output — proven by the
-golden test, which reproduces all 12 live team repos exactly. Do NOT reflow or
-"clean up" these templates: any whitespace change breaks byte parity. In
-particular keep `requirements.yml`'s ``src`` pointing at
-``git+https://github.com/namredips/home-lab.git`` (personal account, not
-``infiquetra``) — parity depends on it.
-
-The only change from the migration script is the data source: instead of a
-hardcoded ``TEAMS`` dict it takes a spec ``cfg`` dict (see ``spec.py``), so new
-teams render from a ``team-spec.yaml`` rather than a code edit.
+The harness is collection-first: reusable Hermes team roles are referenced by
+their ``infiquetra.hermes_team`` fully qualified collection names, while
+inventory and shared runtime secrets are explicit operator inputs.
 """
 
 from __future__ import annotations
 
+COLLECTION_ROLES = {
+    "hermes": "infiquetra.hermes_team.hermes",
+    "hermes_dm_listener": "infiquetra.hermes_team.hermes_dm_listener",
+    "hermes_mint_broker": "infiquetra.hermes_team.hermes_mint_broker",
+    "deploy_skill": "infiquetra.hermes_team.deploy_skill",
+}
+
 REQUIREMENTS = """---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0
 """
+
+SHARED_INFRA_VAULT_EXAMPLE = """---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"
+"""
+
+
+def _format_tags(tags: str) -> str:
+    parts = [p.strip() for p in tags.split(",") if p.strip()]
+    return "[" + ", ".join(repr(p) for p in parts) + "]"
+
+
+def _render_role(role: str, tags: str) -> str:
+    rendered_role = COLLECTION_ROLES.get(role, role)
+    return f"    - {{ role: {rendered_role}, tags: {_format_tags(tags)} }}"
+
+
+def _render_inventory_example(cfg: dict) -> str:
+    lines = [
+        "---",
+        "all:",
+        "  children:",
+        f"    {cfg['hosts']}:",
+        "      hosts:",
+        f"        {cfg['limit']}:",
+    ]
+    for key, value in (cfg.get("inventory") or {}).items():
+        lines.append(f"          {key}: {value}")
+    return "\n".join(lines) + "\n"
 
 
 def render_play(name: str, cfg: dict) -> str:
@@ -36,17 +68,18 @@ def render_play(name: str, cfg: dict) -> str:
         else " Only this team's profiles are touched."
     )
     pin = "    hermes_update: false  # runtime pinned (shared host)\n" if cfg["pin"] else ""
-    roles = "\n".join(f"    - {{ role: {r}, tags: ['{t}'] }}" for r, t in cfg["roles"])
+    roles = "\n".join(_render_role(r, t) for r, t in cfg["roles"])
     return f"""---
-# Deploy the {cfg["team"]} — and ONLY this team — from this repo.
+# Deploy the {cfg["team"]} - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \\
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \\
 #     --limit {cfg["limit"]} {name} --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -56,27 +89,62 @@ def render_play(name: str, cfg: dict) -> str:
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{{{ (playbook_dir + '/..') | realpath }}}}"
     hermes_souls_source: "{{{{ _team_repo_root }}}}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{{{ lookup('ansible.builtin.env', 'HOME') }}}}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}}}"
 {pin}  vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{{{ _team_repo_root }}}}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{{{ homelab_root }}}}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{{{ _team_repo_root }}}}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          {cfg["team"]} deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{{{ shared_infra_vault_path }}}}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{{{ shared_infra_vault_path }}}}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{{{ shared_infra_vault_path }}}}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{{{ _team_repo_root }}}}/profiles"
@@ -98,7 +166,7 @@ def render_play(name: str, cfg: dict) -> str:
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{{{ _team_repo_root }}}}/profiles —
+          Derived an EMPTY profile filter from {{{{ _team_repo_root }}}}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -115,57 +183,85 @@ def render_play(name: str, cfg: dict) -> str:
 
 README_TMPL = """# Deploying {team} independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.{coresident_line}
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.{coresident_line}
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `{hosts}` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \\
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \\
-  --limit {limit} \\
-  {play} \\
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \\
+  ansible-playbook \\
+    -i /path/to/team-or-shared-inventory.yml \\
+    --limit {limit} \\
+    deploy/{play} \\
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \\
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \\
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.
 """
 
 
 def render_readme(cfg: dict) -> str:
     coresident_line = (
-        f"\n\n**Note:** this team shares its host with {cfg['coresident']}; "
-        f"the filter ensures {cfg['coresident']} is never touched by this deploy."
+        f"\n\nThis team shares its host with {cfg['coresident']}. "
+        f"The profile filter ensures {cfg['coresident']} is never touched by this deploy."
         if cfg.get("coresident")
         else ""
     )
     return README_TMPL.format(
-        team=cfg["team"], limit=cfg["limit"], play=cfg["play"], coresident_line=coresident_line
+        team=cfg["team"],
+        hosts=cfg["hosts"],
+        limit=cfg["limit"],
+        play=cfg["play"],
+        coresident_line=coresident_line,
     )
 
 
 def render_harness(cfg: dict) -> dict[str, str]:
-    """Return {filename: content} for the 3 generated deploy/ files."""
+    """Return {filename: content} for generated deploy/ files."""
     return {
         cfg["play"]: render_play(cfg["play"], cfg),
         "requirements.yml": REQUIREMENTS,
         "README.md": render_readme(cfg),
+        "inventory.example.yml": _render_inventory_example(cfg),
+        "shared-infra-vault.example.yml": SHARED_INFRA_VAULT_EXAMPLE,
     }

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/repo_stamp.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/repo_stamp.py
@@ -4,9 +4,9 @@ Implements the directory contract from
 ``infiquetra-context-library/docs/repositories/agent-team-archetype.md``:
 seeds AI-instruction files + the engineering journal from the context-library
 templates, and stamps the team-specific stubs (README, constitution, identity,
-orchestration, per-profile dirs). The deploy harness (3 files) is written
-separately by harness_gen; deploy/team_profiles.yml gets an authored-artifact
-template. config.yaml / distribution.yaml are labeled DEFERRED placeholders.
+orchestration, per-profile dirs). The deploy harness is written separately by
+harness_gen; deploy/team_profiles.yml gets an authored-artifact template.
+config.yaml / distribution.yaml are labeled DEFERRED placeholders.
 
 Idempotent: existing files are never overwritten (so re-runs + hand edits are
 safe). Returns the list of paths actually created.
@@ -25,6 +25,7 @@ GITIGNORE = """\
 *.vault_pass*
 .env
 .team-scaffold-state.json
+.ansible/
 # python
 __pycache__/
 *.pyc

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/spec.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/team_scaffold/spec.py
@@ -59,6 +59,7 @@ class TeamSpec:
             "roles": self.roles,
             "pin": self.pin_runtime,
             "coresident": self.coresident,
+            "inventory": self.inventory,
         }
 
     def validate(self) -> list[str]:

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
@@ -1,11 +1,4 @@
-"""Golden test: harness_gen of each materialized spec must reproduce the live
-team repos' deploy/ files byte-for-byte.
-
-This is the acceptance gate for the gen_harness -> harness_gen promotion. The
-fixtures under specs/golden/ are frozen copies of the live infiquetra/team-*
-repos (fetched 2026-06-01); all 36 (3 files x 12 teams) matched the migration
-generator byte-for-byte at promotion time.
-"""
+"""Harness contract tests for the collection-era team deploy generator."""
 
 from __future__ import annotations
 
@@ -17,24 +10,37 @@ from team_scaffold import harness_gen, spec
 
 ROOT = pathlib.Path(__file__).resolve().parents[1].parent  # skills/team-scaffold
 SPECS = ROOT / "specs"
-GOLDEN = SPECS / "golden"
 
 SPEC_FILES = sorted(SPECS.glob("team-*.yaml"))
 assert len(SPEC_FILES) == 12, f"expected 12 specs, found {len(SPEC_FILES)}"
 
 
 @pytest.mark.parametrize("spec_path", SPEC_FILES, ids=lambda p: p.stem)
-def test_harness_byte_for_byte(spec_path: pathlib.Path) -> None:
+def test_harness_uses_collection_contract(spec_path: pathlib.Path) -> None:
     ts = spec.load_spec(spec_path)
     assert ts.validate() == [], f"{ts.repo} spec is invalid"
     rendered = harness_gen.render_harness(ts.as_cfg())
-    gold_dir = GOLDEN / ts.repo / "deploy"
-    assert gold_dir.is_dir(), f"missing golden fixtures for {ts.repo}"
-    for fname, content in rendered.items():
-        expected = (gold_dir / fname).read_text()
-        assert content == expected, f"{ts.repo}/deploy/{fname} diverged from golden"
+    assert set(rendered) == {
+        "README.md",
+        "requirements.yml",
+        "inventory.example.yml",
+        "shared-infra-vault.example.yml",
+        ts.play,
+    }
+    assert "infiquetra-ansible-collections.git" in rendered["requirements.yml"]
+    assert "git+https://github.com/namredips/home-lab.git" not in rendered["requirements.yml"]
+    assert "ANSIBLE_ROLES_PATH" not in rendered["README.md"]
+    assert "homelab_root" not in rendered[ts.play]
+    assert "INFIQUETRA_SHARED_INFRA_VAULT" in rendered[ts.play]
+    assert "pin_guard" not in rendered[ts.play]
+
+    for role_name, _tags in ts.roles:
+        fqcn = harness_gen.COLLECTION_ROLES.get(role_name)
+        if fqcn:
+            assert f"role: {fqcn}" in rendered[ts.play]
 
 
-def test_requirements_src_pinned_to_namredips() -> None:
-    """Byte parity depends on the personal-account remote; guard against a 'fix'."""
-    assert "git+https://github.com/namredips/home-lab.git" in harness_gen.REQUIREMENTS
+def test_requirements_uses_collection_source() -> None:
+    assert "infiquetra-ansible-collections.git" in harness_gen.REQUIREMENTS
+    assert "type: git" in harness_gen.REQUIREMENTS
+    assert "version: v0.1.0" in harness_gen.REQUIREMENTS

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_golden.py
@@ -36,8 +36,8 @@ def test_harness_uses_collection_contract(spec_path: pathlib.Path) -> None:
 
     for role_name, _tags in ts.roles:
         fqcn = harness_gen.COLLECTION_ROLES.get(role_name)
-        if fqcn:
-            assert f"role: {fqcn}" in rendered[ts.play]
+        assert fqcn, f"{role_name} is not mapped to infiquetra.hermes_team"
+        assert f"role: {fqcn}" in rendered[ts.play]
 
 
 def test_requirements_uses_collection_source() -> None:

--- a/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_modules.py
+++ b/plugins/home-lab-ops/skills/team-scaffold/scripts/tests/test_modules.py
@@ -195,6 +195,8 @@ def test_stamp_new_single_profile_team(tmp_path: pathlib.Path):
         "deploy/nyx.yml",
         "deploy/requirements.yml",
         "deploy/README.md",
+        "deploy/inventory.example.yml",
+        "deploy/shared-infra-vault.example.yml",
         "deploy/team_profiles.yml",
         "docs/engineering-journal/LEARNINGS.md",
     ):

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Apollo dev team independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit apollo.infiquetra.com \
-  apollo.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit apollo.infiquetra.com \
+    deploy/apollo.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/apollo.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/apollo.yml
@@ -106,7 +106,7 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'apollo'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'apollo'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'apollo'] }
-    - { role: hermes_team_listener, tags: ['team_listener', 'apollo'] }
+    - { role: infiquetra.hermes_team.hermes_team_listener, tags: ['team_listener', 'apollo'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'apollo'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/apollo.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/apollo.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Apollo dev team — and ONLY this team — from this repo.
+# Deploy the Apollo dev team - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit apollo.infiquetra.com apollo.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Apollo dev team deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,7 +106,7 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,apollo'] }
-    - { role: hermes, tags: ['hermes,apollo'] }
-    - { role: hermes_team_listener, tags: ['team_listener,apollo'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,apollo'] }
+    - { role: ollama, tags: ['ollama', 'apollo'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'apollo'] }
+    - { role: hermes_team_listener, tags: ['team_listener', 'apollo'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'apollo'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        apollo.infiquetra.com:
+          ansible_host: 10.220.1.52
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-apollo/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Ares (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit ares.infiquetra.com \
-  ares.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit ares.infiquetra.com \
+    deploy/ares.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/ares.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/ares.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'ares'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'ares'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'ares'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'ares'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/ares.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/ares.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Ares (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Ares (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit ares.infiquetra.com ares.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Ares (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,ares'] }
-    - { role: hermes, tags: ['hermes,ares'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,ares'] }
+    - { role: ollama, tags: ['ollama', 'ares'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'ares'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'ares'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        ares.infiquetra.com:
+          ansible_host: 10.220.1.57
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-ares/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Artemis (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit artemis.infiquetra.com \
-  artemis.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit artemis.infiquetra.com \
+    deploy/artemis.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/artemis.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/artemis.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Artemis (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Artemis (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit artemis.infiquetra.com artemis.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Artemis (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,artemis'] }
-    - { role: hermes, tags: ['hermes,artemis'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,artemis'] }
+    - { role: ollama, tags: ['ollama', 'artemis'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'artemis'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'artemis'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/artemis.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/artemis.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'artemis'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'artemis'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'artemis'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'artemis'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        artemis.infiquetra.com:
+          ansible_host: 10.220.1.53
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-artemis/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Athena (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit athena.infiquetra.com \
-  athena.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit athena.infiquetra.com \
+    deploy/athena.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/athena.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/athena.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Athena (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Athena (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit athena.infiquetra.com athena.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Athena (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,athena'] }
-    - { role: hermes, tags: ['hermes,athena'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,athena'] }
+    - { role: ollama, tags: ['ollama', 'athena'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'athena'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'athena'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/athena.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/athena.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'athena'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'athena'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'athena'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'athena'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        athena.infiquetra.com:
+          ansible_host: 10.220.1.51
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-athena/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/README.md
@@ -14,7 +14,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `mac_minis` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -53,6 +54,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/README.md
@@ -1,36 +1,58 @@
 # Deploying Freya PA team independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-**Note:** this team shares its host with Mimir; the filter ensures Mimir is never touched by this deploy.
+This team shares its host with Mimir. The profile filter ensures Mimir is never touched by this deploy.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `mac_minis` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit jeffs-mac-mini.infiquetra.com \
-  freya.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit jeffs-mac-mini.infiquetra.com \
+    deploy/freya.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/freya.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/freya.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Freya PA team — and ONLY this team — from this repo.
+# Deploy the Freya PA team - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit jeffs-mac-mini.infiquetra.com freya.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,28 +18,63 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
     hermes_update: false  # runtime pinned (shared host)
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Freya PA team deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -60,7 +96,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -71,5 +107,5 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Co-resident team on this host (Mimir) is NOT in the filter and is left untouched.
   roles:
-    - { role: hermes, tags: ['hermes,freya'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,freya'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'freya'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'freya'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    mac_minis:
+      hosts:
+        jeffs-mac-mini.infiquetra.com:
+          ansible_host: 10.220.1.196
+          ansible_user: jefcox

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-freya/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Hephaestus (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit hephaestus.infiquetra.com \
-  hephaestus.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit hephaestus.infiquetra.com \
+    deploy/hephaestus.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/hephaestus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/hephaestus.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'hephaestus'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'hephaestus'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'hephaestus'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'hephaestus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/hephaestus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/hephaestus.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Hephaestus (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Hephaestus (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit hephaestus.infiquetra.com hephaestus.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Hephaestus (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,hephaestus'] }
-    - { role: hermes, tags: ['hermes,hephaestus'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,hephaestus'] }
+    - { role: ollama, tags: ['ollama', 'hephaestus'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'hephaestus'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'hephaestus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        hephaestus.infiquetra.com:
+          ansible_host: 10.220.1.54
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hephaestus/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Hermes delivery/plan-phase crew + orchestrator independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `orchestrator_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit hermes.infiquetra.com \
-  hermes.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit hermes.infiquetra.com \
+    deploy/hermes.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `orchestrator_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/hermes.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/hermes.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Hermes delivery/plan-phase crew + orchestrator — and ONLY this team — from this repo.
+# Deploy the Hermes delivery/plan-phase crew + orchestrator - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit hermes.infiquetra.com hermes.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Hermes delivery/plan-phase crew + orchestrator deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,8 +106,8 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,hermes_crew'] }
-    - { role: hermes, tags: ['hermes,hermes_crew'] }
-    - { role: hermes_team_listener, tags: ['team_listener,hermes_crew'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,hermes_crew'] }
-    - { role: hermes_orchestrator, tags: ['orchestrator,hermes_crew'] }
+    - { role: ollama, tags: ['ollama', 'hermes_crew'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'hermes_crew'] }
+    - { role: hermes_team_listener, tags: ['team_listener', 'hermes_crew'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'hermes_crew'] }
+    - { role: hermes_orchestrator, tags: ['orchestrator', 'hermes_crew'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/hermes.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/hermes.yml
@@ -106,8 +106,8 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'hermes_crew'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'hermes_crew'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'hermes_crew'] }
-    - { role: hermes_team_listener, tags: ['team_listener', 'hermes_crew'] }
+    - { role: infiquetra.hermes_team.hermes_team_listener, tags: ['team_listener', 'hermes_crew'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'hermes_crew'] }
-    - { role: hermes_orchestrator, tags: ['orchestrator', 'hermes_crew'] }
+    - { role: infiquetra.hermes_team.hermes_orchestrator, tags: ['orchestrator', 'hermes_crew'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    orchestrator_vms:
+      hosts:
+        hermes.infiquetra.com:
+          ansible_host: 10.220.1.69
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-hermes/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/README.md
@@ -14,7 +14,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `mac_minis` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -53,6 +54,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/README.md
@@ -1,36 +1,58 @@
 # Deploying Mimir engineering team independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-**Note:** this team shares its host with Freya; the filter ensures Freya is never touched by this deploy.
+This team shares its host with Freya. The profile filter ensures Freya is never touched by this deploy.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `mac_minis` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit jeffs-mac-mini.infiquetra.com \
-  mimir.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit jeffs-mac-mini.infiquetra.com \
+    deploy/mimir.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    mac_minis:
+      hosts:
+        jeffs-mac-mini.infiquetra.com:
+          ansible_host: 10.220.1.196
+          ansible_user: jefcox

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/mimir.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/mimir.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Mimir engineering team — and ONLY this team — from this repo.
+# Deploy the Mimir engineering team - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit jeffs-mac-mini.infiquetra.com mimir.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,28 +18,63 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
     hermes_update: false  # runtime pinned (shared host)
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Mimir engineering team deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -60,7 +96,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -71,6 +107,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Co-resident team on this host (Freya) is NOT in the filter and is left untouched.
   roles:
-    - { role: hermes, tags: ['hermes,mimir'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,mimir'] }
-    - { role: hermes_mint_broker, tags: ['mint_broker,mimir'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'mimir'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'mimir'] }
+    - { role: infiquetra.hermes_team.hermes_mint_broker, tags: ['mint_broker', 'mimir'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-mimir/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Perseus (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit perseus.infiquetra.com \
-  perseus.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit perseus.infiquetra.com \
+    deploy/perseus.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        perseus.infiquetra.com:
+          ansible_host: 10.220.1.55
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/perseus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/perseus.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Perseus (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Perseus (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit perseus.infiquetra.com perseus.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Perseus (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,perseus'] }
-    - { role: hermes, tags: ['hermes,perseus'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,perseus'] }
+    - { role: ollama, tags: ['ollama', 'perseus'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'perseus'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'perseus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/perseus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/perseus.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'perseus'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'perseus'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'perseus'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'perseus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-perseus/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Prometheus (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit prometheus.infiquetra.com \
-  prometheus.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit prometheus.infiquetra.com \
+    deploy/prometheus.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        prometheus.infiquetra.com:
+          ansible_host: 10.220.1.56
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/prometheus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/prometheus.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'prometheus'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'prometheus'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'prometheus'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'prometheus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/prometheus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/prometheus.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Prometheus (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Prometheus (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit prometheus.infiquetra.com prometheus.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Prometheus (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,prometheus'] }
-    - { role: hermes, tags: ['hermes,prometheus'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,prometheus'] }
+    - { role: ollama, tags: ['ollama', 'prometheus'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'prometheus'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'prometheus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-prometheus/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Themis (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit themis.infiquetra.com \
-  themis.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit themis.infiquetra.com \
+    deploy/themis.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        themis.infiquetra.com:
+          ansible_host: 10.220.1.68
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/themis.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/themis.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Themis (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Themis (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit themis.infiquetra.com themis.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Themis (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,themis'] }
-    - { role: hermes, tags: ['hermes,themis'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,themis'] }
+    - { role: ollama, tags: ['ollama', 'themis'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'themis'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'themis'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/themis.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-themis/deploy/themis.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'themis'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'themis'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'themis'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'themis'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/README.md
@@ -12,7 +12,8 @@ the supported independent deploy mechanism.
 2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
 4. An inventory file with a `agent_vms` group.
-5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets,
+   including Ollama Cloud SSH key material when `ollama_cloud_models` is non-empty.
 
 The playbook does not discover role code, inventory, or shared-infra secrets
 from a sibling infrastructure checkout.
@@ -51,6 +52,3 @@ ansible-galaxy collection install \
   /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
   -p .ansible/collections --force
 ```
-
-If this team's spec includes roles outside `infiquetra.hermes_team`, extract
-those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/README.md
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/README.md
@@ -1,34 +1,56 @@
 # Deploying Zeus (legacy single agent) independently
 
-Deploys **only this team** from this repo, reusing the home-lab `hermes` role
-via the per-team-deploy hooks (`hermes_team_profiles_filter` +
-`hermes_souls_source`). It does **not** fork the role.
+Deploys only this team from this repository using the pinned
+`infiquetra.hermes_team` collection.
 
-> Native Hermes profile-distribution packaging is deferred; this Ansible path is
-> the supported independent-deploy mechanism.
+Native Hermes profile-distribution packaging is deferred; this Ansible path is
+the supported independent deploy mechanism.
 
-## Prereqs
-1. Home-lab roles on the roles-path:
-   ```bash
-   export ANSIBLE_ROLES_PATH="$HOME/workspace/infiquetra/home-lab/ansible/roles"
-   ```
-   (or `ansible-galaxy install -r deploy/requirements.yml -p deploy/roles`)
-2. Inventory + secrets from home-lab until the per-team vault split lands.
+## Prerequisites
+
+1. Ansible plus `ansible-galaxy`.
+2. Git authentication that can read the private collection repository.
 3. Vault password at `~/.vault_pass.txt`.
+4. An inventory file with a `agent_vms` group.
+5. An encrypted shared-infra vault file containing cross-team runtime secrets.
+
+The playbook does not discover role code, inventory, or shared-infra secrets
+from a sibling infrastructure checkout.
+
+## Install Collections
+
+From the repository root:
+
+```bash
+ansible-galaxy collection install -r deploy/requirements.yml -p .ansible/collections --force
+```
 
 ## Deploy
-```bash
-cd deploy
-ansible-playbook \
-  -i "$HOME/workspace/infiquetra/home-lab/ansible/inventory/hosts.yml" \
-  --limit zeus.infiquetra.com \
-  zeus.yml \
-  --vault-password-file ~/.vault_pass.txt
-```
-Dry-run first with `--check --diff`. The play prints its profile scope and
-asserts the souls source exists before acting.
 
-## Not yet
-- Per-team vault split (secrets still from home-lab `group_vars/all`).
-- Native distribution install (deferred).
-- Team-owned host_vars slice (uses home-lab's today).
+```bash
+export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+
+ANSIBLE_COLLECTIONS_PATH=.ansible/collections \
+  ansible-playbook \
+    -i /path/to/team-or-shared-inventory.yml \
+    --limit zeus.infiquetra.com \
+    deploy/zeus.yml \
+    --vault-password-file ~/.vault_pass.txt
+```
+
+Dry-run first with `--check --diff`. The play prints its profile scope and
+refuses to run if it cannot derive team profiles from this repo.
+
+## Local Collection Artifact Test
+
+Before the GitHub repository exists, install a locally built collection artifact
+from `infiquetra-ansible-collections`:
+
+```bash
+ansible-galaxy collection install \
+  /path/to/infiquetra-hermes_team-0.1.0.tar.gz \
+  -p .ansible/collections --force
+```
+
+If this team's spec includes roles outside `infiquetra.hermes_team`, extract
+those roles into collections before treating the deploy as fully independent.

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/inventory.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/inventory.example.yml
@@ -1,0 +1,8 @@
+---
+all:
+  children:
+    agent_vms:
+      hosts:
+        zeus.infiquetra.com:
+          ansible_host: 10.220.1.50
+          ansible_user: agent

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/requirements.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/requirements.yml
@@ -1,8 +1,8 @@
 ---
-# Reuse the home-lab roles (native distribution packaging deferred; this Ansible
-# path is the supported independent-deploy mechanism). See deploy/README.md for
-# the roles-path setup (local checkout recommended).
-roles:
-  - name: hermes
-    src: git+https://github.com/namredips/home-lab.git
-    version: main
+# Install reusable Hermes team deployment roles from the shared collection.
+# Pin by tag or commit. Private-repository auth should come from SSH/netrc/Git
+# credential config, not credentials embedded in this URL.
+collections:
+  - name: git+https://github.com/infiquetra/infiquetra-ansible-collections.git#/ansible_collections/infiquetra/hermes_team/
+    type: git
+    version: v0.1.0

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/shared-infra-vault.example.yml
@@ -1,0 +1,8 @@
+---
+# Example shape only. Store the real file as an encrypted Ansible Vault artifact
+# supplied by the operator at deploy time via INFIQUETRA_SHARED_INFRA_VAULT.
+
+vault_redis_password: "change-me"
+vault_langfuse_public_key: "change-me"
+vault_langfuse_secret_key: "change-me"
+vault_elevenlabs_api_key: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/shared-infra-vault.example.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/shared-infra-vault.example.yml
@@ -6,3 +6,14 @@ vault_redis_password: "change-me"
 vault_langfuse_public_key: "change-me"
 vault_langfuse_secret_key: "change-me"
 vault_elevenlabs_api_key: "change-me"
+
+# Required by infiquetra.hermes_team.ollama when ollama_cloud_models is non-empty.
+ollama_cloud_ssh_private_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  change-me
+  -----END OPENSSH PRIVATE KEY-----
+ollama_cloud_ssh_public_key: "ssh-ed25519 change-me"
+
+# Required when deploying the Hermes orchestrator role.
+vault_hermes_conductor_token: "change-me"
+vault_github_webhook_secret: "change-me"

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/zeus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/zeus.yml
@@ -1,13 +1,14 @@
 ---
-# Deploy the Zeus (legacy single agent) — and ONLY this team — from this repo.
+# Deploy the Zeus (legacy single agent) - and ONLY this team - from this repo.
 #
-# Reuses the home-lab hermes role via the per-team-deploy hooks (2026-05-31):
+# Uses the infiquetra.hermes_team collection via deploy/requirements.yml:
 #   hermes_team_profiles_filter : narrows the host's profiles to this team's
 #     (derived from this repo's profiles/ dir) so co-resident teams are untouched.
 #   hermes_souls_source         : SOULs sourced from this repo's profiles/<n>/SOUL.md.
 #
 # Usage (see deploy/README.md):
-#   cd deploy && ansible-playbook -i <home-lab-inventory> \
+#   export INFIQUETRA_SHARED_INFRA_VAULT=/path/to/shared-infra-vault.yml
+#   ansible-playbook -i <inventory> \
 #     --limit zeus.infiquetra.com zeus.yml --vault-password-file ~/.vault_pass.txt
 #
 # Native distribution packaging (`hermes profile install`) is DEFERRED.
@@ -17,27 +18,62 @@
   gather_facts: true
   vars:
     # realpath normalizes the .. so the control-node find() gets an absolute dir.
-    # NOTE: ansible's fileglob lookup does NOT expand '..' — use find() instead.
+    # NOTE: ansible's fileglob lookup does NOT expand '..' - use find() instead.
     _team_repo_root: "{{ (playbook_dir + '/..') | realpath }}"
     hermes_souls_source: "{{ _team_repo_root }}/profiles"
-    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md
-    # (the team repo is authoritative). Without this the role's SOUL tasks fall
-    # back to home-lab's bundled files/souls/ (macOS ignored the source entirely).
+    # profile-dir layout = source each SOUL from <repo>/profiles/<name>/SOUL.md.
     hermes_souls_layout: profile-dir
-    # home-lab checkout (for the SHARED-INFRA vault: github-app PEMs, langfuse,
-    # elevenlabs). Override -e homelab_root=/path if your checkout differs.
-    homelab_root: "{{ lookup('ansible.builtin.env', 'HOME') }}/workspace/infiquetra/home-lab"
+    # Explicit operator-provided shared runtime secrets: Redis, Langfuse, and
+    # optional voice-tooling credentials. Keep this outside the team repo unless
+    # the file is encrypted for this consumer.
+    shared_infra_vault_path: "{{ lookup('ansible.builtin.env', 'INFIQUETRA_SHARED_INFRA_VAULT') | default('', true) }}"
   vars_files:
     # This team's OWN secrets (post vault-split): Discord tokens etc.
     - "{{ _team_repo_root }}/ansible/inventory/group_vars/all/vault.yml"
-    # Shared-infra secrets that live in home-lab (PEMs / langfuse / elevenlabs).
-    - "{{ homelab_root }}/ansible/inventory/group_vars/all/vault_shared_infra.yml"
-    # This team's hermes_team_profiles (Phase 8 Stage A — relocated FROM home-lab
-    # host_vars so the harness is self-contained and home-lab can drop per-team
-    # content). A play var, so it overrides any home-lab host_var of the same name
-    # while that dual-write window lasts, and is the sole source after deletion.
+    # This team's hermes_team_profiles. The team repo is authoritative.
     - "{{ _team_repo_root }}/deploy/team_profiles.yml"
   pre_tasks:
+    - name: Require explicit shared-infra vault input
+      ansible.builtin.assert:
+        that:
+          - shared_infra_vault_path | length > 0
+        fail_msg: >-
+          Set INFIQUETRA_SHARED_INFRA_VAULT to the encrypted shared runtime
+          secrets file before running this play.
+      tags: [always]
+
+    - name: Refuse legacy infrastructure checkout inputs
+      ansible.builtin.assert:
+        that:
+          - "'/home-lab/ansible/' not in shared_infra_vault_path"
+          - (ansible_inventory_sources | default([]) | select('search', '/home-lab/ansible/') | list | length) == 0
+        fail_msg: >-
+          Zeus (legacy single agent) deploy inputs must be independent artifacts. Do not pass
+          the legacy infrastructure checkout inventory or shared-infra vault path.
+      tags: [always]
+
+    - name: Check shared-infra vault path on the control node
+      ansible.builtin.stat:
+        path: "{{ shared_infra_vault_path }}"
+      delegate_to: localhost
+      run_once: true
+      register: _shared_infra_vault_stat
+      tags: [always]
+
+    - name: Refuse missing shared-infra vault file
+      ansible.builtin.assert:
+        that:
+          - _shared_infra_vault_stat.stat.exists
+          - _shared_infra_vault_stat.stat.isreg
+        fail_msg: "Shared-infra vault file not found: {{ shared_infra_vault_path }}"
+      tags: [always]
+
+    - name: Load shared-infra runtime secrets
+      ansible.builtin.include_vars:
+        file: "{{ shared_infra_vault_path }}"
+      no_log: true
+      tags: [always]
+
     - name: Enumerate this repo's profile dirs on the control node
       ansible.builtin.find:
         paths: "{{ _team_repo_root }}/profiles"
@@ -59,7 +95,7 @@
         that:
           - hermes_team_profiles_filter | length > 0
         fail_msg: >-
-          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles —
+          Derived an EMPTY profile filter from {{ _team_repo_root }}/profiles -
           refusing to deploy (an empty filter makes the hermes role deploy the
           host's entire profile set, including co-resident teams). Check the
           repo layout / playbook_dir.
@@ -70,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama,zeus'] }
-    - { role: hermes, tags: ['hermes,zeus'] }
-    - { role: hermes_dm_listener, tags: ['dm_listener,zeus'] }
+    - { role: ollama, tags: ['ollama', 'zeus'] }
+    - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'zeus'] }
+    - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'zeus'] }

--- a/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/zeus.yml
+++ b/plugins/home-lab-ops/skills/team-scaffold/specs/golden/team-zeus/deploy/zeus.yml
@@ -106,6 +106,6 @@
           Deploying {{ hermes_team_profiles_filter | length }} profiles
           ({{ hermes_team_profiles_filter | join(', ') }}). Only this team's profiles are touched.
   roles:
-    - { role: ollama, tags: ['ollama', 'zeus'] }
+    - { role: infiquetra.hermes_team.ollama, tags: ['ollama', 'zeus'] }
     - { role: infiquetra.hermes_team.hermes, tags: ['hermes', 'zeus'] }
     - { role: infiquetra.hermes_team.hermes_dm_listener, tags: ['dm_listener', 'zeus'] }


### PR DESCRIPTION
## Summary
- Update the team-scaffold generator to emit collection-based deploy harnesses.
- Generate `deploy/requirements.yml` entries for `infiquetra.hermes_team` pinned to `v0.1.0`.
- Refresh golden fixtures for the current 12 team specs.

## Validation
- `uv run pytest -q`
- `uv run team-scaffold golden`
