### PR TITLE
fix(saga): correct ultracode framing + reach docs/confidence shapes in backend recommender

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -296,7 +296,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,44 @@
 
 ---
 
+## 2026-06-13
+
+### Correct the operator-choice ultracode framing; add `adversarial_confidence` + `has_code_surface` to the backend recommender (PR #TBD)  {#operator-choice-docs-and-confidence}
+
+**Decision.** (1) Document `cc-workflows-ultracode` as deterministic fan-out **and** independent/adversarial
+verification; the line to `team-execution` is **governance** (consensus + named scanner gates + guarded
+deploy), framed as *artifact kind* — a throwaway signal vs a standing blocking verdict (operator-choice §3.2).
+(2) Add `adversarial_confidence` as a second ultracode trigger beside `broad_independent_fanout` (default
+False). (3) Add `has_code_surface` (default True): pure docs/spec/research neutralizes the output-blind
+code-shaped proxies (`file_count`, `phase_count`, `has_infra`, `has_security`, `deployment_sensitive`);
+`cross_repo` + `needs_consensus` survive as output-agnostic governance signals; the ultracode risk-suppressor
+is itself gated by it. (4) Keep the lean precedence `team-execution > cc-workflows-ultracode > inline`
+unchanged.
+
+**Rejected alternatives.** *Plain reaffirm* — the §3.2 sentence is provably false against the Workflow tool
+spec + official docs, and the `inline` reachability gap is real. *A new decision mechanism (rebuild the
+ladder)* — it maps onto the existing `if/elif` and would churn the locked assertions for no behavioral gain.
+*An `output_kind` enum (code|docs|research) as a primary chooser* — the code/docs correlation breaks (trivial
+code, contested specs, broad code migrations); keying on the label misroutes those. *Keep a docs size-backstop
+to team-execution* (Agent 1's caution) — the real governance docs go off-chain (`/strategy`, `/spec` don't
+call the recommender); a governance doc that reaches it carries `needs_consensus` or breadth; forcing consensus
+ceremony on uncontested docs is the misfire being fixed. *Names `no_deploy_surface` / `is_docs`* —
+double-negative / too narrow; `has_code_surface` (positive, default True) names the real discriminator and
+makes the safe default the conservative one.
+
+**Rationale.** The routing was ~80% right (the code's risk gate already encoded governance); this makes the
+prose true and reaches the two shapes the helper couldn't — adversarial confidence, and docs de-escalation.
+Minimal blast radius: two default-safe kwargs + one predicate clause; every locked assertion is unchanged.
+
+**Revisit when.** `has_code_surface` gets mis-set often in practice (it is a looser caller judgment than the
+others — revisit toward deriving it, or folding `cross_repo` into the neutralizer); OR `parse_issue.py` gains a
+real file-touch signal for infra/security (then neutralizing those two for docs is redundant); OR
+`adversarial_confidence` wants a magnitude gate (many-independent-attempts vs a few lenses — currently
+categorical).
+
+**Refs.** LEARNINGS [#operator-choice-ultracode-framing-and-docs-proxies](LEARNINGS.md#operator-choice-ultracode-framing-and-docs-proxies);
+refines [#operator-choice-framework](#operator-choice-framework).
+
 ## 2026-06-09
 
 ### Saga documentation source model and generated SVG visual kit (commit `2f9f2f2`)  {#saga-docs-source-model}
@@ -514,6 +552,11 @@ The five decisions a–e:
 **Refs.** Plugin `0.6.0`. Part of the engine-merge campaign — see [#lifecycle-engine-merge-campaign](#lifecycle-engine-merge-campaign). Ship record: ARCHIVE [#office-hours-engine-rebuild-shipped](ARCHIVE.md#office-hours-engine-rebuild-shipped). Frame-note home: `docs/office-hours/`.
 
 ### Operator-choice framework ships doc-only; CLI helper deferred to `/work` (PR `#171`)  {#operator-choice-framework}
+
+> **Update (2026-06-13).** The §3.2 "deterministic fan-out, not review depth" framing introduced here was
+> corrected, and `adversarial_confidence` + `has_code_surface` were added to the recommender — see
+> [#operator-choice-docs-and-confidence](#operator-choice-docs-and-confidence). The doc-only-then-helper
+> sequencing, the three-backend enum, and the always-confirm/capability-gate properties below all stand.
 
 **Decision.** Ship the operator-choice framework as a **DOC-ONLY foundation**: `references/operator-choice.md` — the decision contract for the three execution backends `inline` | `team-execution` | `cc-workflows-ultracode` (these enum strings are the contract; prose labels like "CC workflows"/"ultracode" are not) — plus short prose **offer hooks** in `/loop` and `/work`. Lifecycle owns the **choice**, not execution. No code/helper ships this PR. The four interview answers settled:
 

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-06-13
 
-### Correct the operator-choice ultracode framing; add `adversarial_confidence` + `has_code_surface` to the backend recommender (PR #TBD)  {#operator-choice-docs-and-confidence}
+### Correct the operator-choice ultracode framing; add `adversarial_confidence` + `has_code_surface` to the backend recommender (PR #215)  {#operator-choice-docs-and-confidence}
 
 **Decision.** (1) Document `cc-workflows-ultracode` as deterministic fan-out **and** independent/adversarial
 verification; the line to `team-execution` is **governance** (consensus + named scanner gates + guarded

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -37,7 +37,7 @@ the Workflow tool's own spec and official Anthropic docs against the contract.
 depth"); `recommend_execution_backend()` in `plugins/saga/scripts/lifecycle_state.py`; `parse_issue.py:108-110`
 (`INFRA_RE` / `SECURITY_RE` are bare keyword regexes — `terraform|lambda|...`, `auth|iam|...` — over the issue
 *body text*); official docs (code.claude.com/docs/en/workflows: "independent agents adversarially review each
-other's findings… a more trustworthy result than a single pass"). PR #TBD (saga 0.22.0).
+other's findings… a more trustworthy result than a single pass"). PR #215 (saga 0.22.0).
 
 **Mechanism.** Three things. (1) ultracode HAS review depth — *confidence* is one of the tool's three stated
 purposes, and adversarial-verify / judge-panel / perspective-diverse verify are built-in patterns; "Review" is
@@ -48,7 +48,7 @@ deploy/security signal had **no trigger**, so it fell to `inline`. (3) `has_infr
 *mention-not-touch* keyword matches, so a docs change merely *mentioning* terraform/auth set the flag and
 force-escalated to `team-execution`, whose scanners are inert on docs.
 
-**Fix.** PR #TBD. Added `adversarial_confidence` (2nd ultracode trigger) + `has_code_surface` (default True;
+**Fix.** PR #215. Added `adversarial_confidence` (2nd ultracode trigger) + `has_code_surface` (default True;
 neutralizes the five output-blind code-shaped proxies for docs — `cross_repo` + `needs_consensus` survive as
 the output-agnostic governance signals; the ultracode risk-suppressor is itself gated by it). Reworded §3.1
 (`PLUS` → `OR`) + §3.2 (the artifact-kind boundary).

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -25,6 +25,49 @@
 
 ---
 
+## 2026-06-13
+
+### Saga mis-framed ultracode as "fan-out, not review depth"; keyword risk-proxies over-escalate docs  {#operator-choice-ultracode-framing-and-docs-proxies}
+
+**Context.** A challenge to the operator-choice contract: does saga correctly model Claude Code Workflows
+("ultracode") vs `team-execution` vs `inline`? A multi-agent research + adversarial-review workflow checked
+the Workflow tool's own spec and official Anthropic docs against the contract.
+
+**Evidence.** `operator-choice.md` §3.2 (the sentence "ultracode's value is deterministic fan-out, not review
+depth"); `recommend_execution_backend()` in `plugins/saga/scripts/lifecycle_state.py`; `parse_issue.py:108-110`
+(`INFRA_RE` / `SECURITY_RE` are bare keyword regexes — `terraform|lambda|...`, `auth|iam|...` — over the issue
+*body text*); official docs (code.claude.com/docs/en/workflows: "independent agents adversarially review each
+other's findings… a more trustworthy result than a single pass"). PR #TBD (saga 0.22.0).
+
+**Mechanism.** Three things. (1) ultracode HAS review depth — *confidence* is one of the tool's three stated
+purposes, and adversarial-verify / judge-panel / perspective-diverse verify are built-in patterns; "Review" is
+a canonical shape. The real `team-execution` boundary is **governance** (reviewer consensus + named scanner
+gates + guarded deploy), i.e. *artifact kind*: ultracode yields a throwaway statistical signal, team-execution
+a standing blocking verdict. (2) A behavioral gap, not just wording: adversarial-confidence work with no
+deploy/security signal had **no trigger**, so it fell to `inline`. (3) `has_infra` / `has_security` are
+*mention-not-touch* keyword matches, so a docs change merely *mentioning* terraform/auth set the flag and
+force-escalated to `team-execution`, whose scanners are inert on docs.
+
+**Fix.** PR #TBD. Added `adversarial_confidence` (2nd ultracode trigger) + `has_code_surface` (default True;
+neutralizes the five output-blind code-shaped proxies for docs — `cross_repo` + `needs_consensus` survive as
+the output-agnostic governance signals; the ultracode risk-suppressor is itself gated by it). Reworded §3.1
+(`PLUS` → `OR`) + §3.2 (the artifact-kind boundary).
+
+**Validation.** 31 saga tests green incl. 3 new (`adversarial_confidence`; docs `has_code_surface`; CLI
+round-trip); `ruff` + both plugin validators clean.
+
+**What surprised.** The routing *behavior* was ~80% right — the helper's risk gate already encoded governance —
+while the *justifying sentence* was false. A leaky abstraction can route correctly yet document itself wrongly.
+
+**Generalizable rule.** When a router's prose and its code disagree, the **code's behavior is ground truth** —
+re-derive the doc from the code, not the reverse. And a size/risk proxy (a file count, or a keyword flag like
+`has_infra`) is **necessary-not-sufficient**: it stands in for a real need (governance) that diverges from the
+proxy on off-axis inputs (docs that *mention* infra; big *uncontested* docs) — gate the proxy on the actual
+discriminator (is there a code/ship surface the gate can act on?).
+
+**Refs.** DECISIONS [#operator-choice-docs-and-confidence](DECISIONS.md#operator-choice-docs-and-confidence);
+the contract it refines — DECISIONS [#operator-choice-framework](DECISIONS.md#operator-choice-framework).
+
 ## 2026-06-09
 
 ### `ruff check` does not prove formatter compliance  {#ruff-check-vs-format-check}

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.22.0 - 2026-06-13
+
+- Correct the execution-backend recommender (`recommend_execution_backend`) and the operator-choice contract
+  so `cc-workflows-ultracode` (ultracode) is no longer framed as "fan-out, not review depth": ultracode
+  delivers deterministic fan-out **and** independent/adversarial verification. The line to `team-execution`
+  is GOVERNANCE (reviewer consensus + named scanner gates + guarded deploy), not review depth.
+- Add `adversarial_confidence` as a second `cc-workflows-ultracode` trigger beside `broad_independent_fanout`
+  (CLI `--adversarial-confidence`): prove-by-refutation / judge-panel work with no deploy/security signal now
+  reaches ultracode instead of silently falling to `inline`.
+- Add `has_code_surface` (default True; CLI `--no-code-surface`) so pure docs/spec/research output neutralizes
+  the output-blind team-execution proxies — `file_count`, `phase_count`, and the `parse_issue.py` keyword
+  flags `has_infra` / `has_security` / `deployment_sensitive` that fire on a doc merely *mentioning* infra or
+  auth. `cross_repo` (ownership boundary) and `needs_consensus` (contested) survive as the output-agnostic
+  governance signals; the ultracode risk-suppressor is itself gated by `has_code_surface` so broad infra/
+  security DOCS still fan out.
+- Reword operator-choice §3.1 (`PLUS` -> `OR`, matching the code's sufficient-on-its-own consensus) and §3.2
+  (the corrected ultracode framing + the throwaway-signal-vs-standing-verdict mechanical boundary).
+
 ## 0.21.0 - 2026-06-09
 
 - Add a comprehensive Saga documentation system: README atlas, manual pages under

--- a/plugins/saga/references/operator-choice.md
+++ b/plugins/saga/references/operator-choice.md
@@ -31,7 +31,7 @@ cc-workflows-ultracode` — these strings are the contract (they match `ORCHESTR
 |---|---|---|---|
 | `inline` | The agent does the work itself, single-context / serial. **The default.** | the agent | always |
 | `team-execution` | The team-execution plugin: a `## Team Structure` plan section + worker / reviewer / validator agents with consensus + gates. | yes — team-execution owns its own run | plugin installed |
-| `cc-workflows-ultracode` | The Claude Code **Workflow** tool: deterministic multi-agent fan-out (ultracode). | yes — the Workflow runtime owns its own run | **Claude Code only** (§4) |
+| `cc-workflows-ultracode` | The Claude Code **Workflow** tool: deterministic multi-agent orchestration (ultracode) — broad fan-out **and** independent/adversarial verification. | yes — the Workflow runtime owns its own run | **Claude Code only** (§4) |
 
 **Ownership boundary.** Lifecycle **chooses**; the backends **execute**. `team-execution` and
 `deploy` are **offered, not vendored** — lifecycle never reimplements their machinery, it points
@@ -61,7 +61,8 @@ The operator decides; lifecycle makes the cheapest-correct path one keystroke aw
 
 This mirrors `should_offer_team_execution` in
 [`scripts/lifecycle_state.py`](../scripts/lifecycle_state.py) — **that function is the canonical trigger
-source; keep these numbers identical to its constants.** Offer `team-execution` when **ANY** of:
+source; keep these numbers — and the `has_code_surface` docs-gating below — identical to its constants.**
+Offer `team-execution` when **ANY** of:
 
 | Signal | Threshold |
 |---|---|
@@ -72,20 +73,39 @@ source; keep these numbers identical to its constants.** Offer `team-execution` 
 | `cross_repo` | true |
 | `deployment_sensitive` | true |
 
-**PLUS** a needs-consensus signal: multiple reviewer lenses are warranted, a decision is contested, or
+**OR** a needs-consensus signal: multiple reviewer lenses are warranted, a decision is contested, or
 validator gates should bound the work. team-execution's whole value is *review consensus + gates*, so a job
-that wants those is a team-execution job even if it is small.
+that wants those is a team-execution job even if it is small — the consensus signal is **sufficient on its
+own**, not an additive PLUS (this matches `recommend_execution_backend`, which ORs it in).
+
+**Docs exception (`has_code_surface=False`).** team-execution's scanners + deploy gate are code-shaped and
+inert on pure docs/spec/research output, so the **output-blind** rows above — `file_count`, `phase_count`,
+`has_security`, `has_infra`, `deployment_sensitive` (the last two are `parse_issue.py` keyword matches that
+fire on a doc merely *mentioning* terraform or auth) — are neutralized when the work has no code/ship
+surface. Two rows survive because they signal governance, not code: **`cross_repo`** (crossing a repo =
+crossing an ownership boundary = a multi-party coordination need) and the **needs-consensus** signal. A big
+docs change with neither stays `inline`/ultracode, not team-execution.
 
 ### 3.2 `inline` -> `cc-workflows-ultracode` (Claude Code only)
 
-Offer when the work is **broad and independent** — breadth **WITHOUT** elevated risk:
+Offer in **either** of two ungoverned-multiplicity modes, both without elevated risk:
 
-- high-parallelism — many independent units of work that do not share output;
-- broad independent fan-out — the same operation applied across many targets;
-- exhaustive sweep — search-all / probe-all style coverage where missing a target is the failure mode.
+- **Breadth / scale** — high-parallelism, broad independent fan-out (the same operation across many
+  targets), or an exhaustive search-all / probe-all sweep where missing a target is the failure mode.
+- **Adversarial confidence** (`adversarial_confidence`) — prove-by-refutation, a judge panel over N
+  independent attempts, or perspective-diverse verifiers each applying a distinct lens. This is real review
+  depth; the Workflow tool names *confidence* as a first-class purpose.
 
-ultracode's value is deterministic fan-out, not review depth. If the work is risky rather than merely wide,
-that is a `team-execution` signal (§3.1), not an ultracode one.
+So ultracode is **not** "fan-out, not review depth" — it delivers deterministic fan-out **and** independent
+adversarial verification. What it lacks is **governance**: no reviewer-CONSENSUS gate, no named scanner
+registry, no guarded deploy. That — not "review depth" — is the line to `team-execution` (§3.1).
+
+**The mechanical boundary** (artifact kind, not ceremony level): ultracode gives a *throwaway* confidence
+signal on a finding you then act on yourself — N votes, the run ends, nothing is recorded or blocks.
+team-execution gives a *standing* verdict — a consensus score that blocks downstream scanners and the deploy
+and persists as evidence. Want independent cross-checking of a read-only finding → ultracode. Need the review
+to gate a merge/deploy or be recorded → team-execution. (A job that is both risky **and** wide offers both —
+§3.3.)
 
 ### 3.3 Overlap (both fire)
 

--- a/plugins/saga/scripts/lifecycle_state.py
+++ b/plugins/saga/scripts/lifecycle_state.py
@@ -49,19 +49,38 @@ def should_offer_team_execution(
     has_infra: bool,
     cross_repo: bool,
     deployment_sensitive: bool,
+    has_code_surface: bool = True,
 ) -> bool:
-    """Decide whether the loop should offer team-execution."""
+    """Decide whether the loop should offer team-execution.
 
-    return any(
+    ``has_code_surface`` defaults True, so every existing caller is unchanged.
+    Set it False for pure docs/spec/research/journal work (no code, no IaC, no
+    API contract, no deployable artifact). It neutralizes the OUTPUT-BLIND
+    proxies — the ones that fire on the *mention* or *volume* of risk rather than
+    a real ship/scanner surface that team-execution's gates can act on:
+
+    * ``file_count`` / ``phase_count`` — volume and sequencing, not governance.
+    * ``has_infra`` / ``has_security`` — ``parse_issue.py`` keyword regexes
+      (terraform, lambda, auth, iam, ...) trip on infra/security DOCS that touch
+      nothing deployable.
+    * ``deployment_sensitive`` — cannot truthfully hold when there is no deploy.
+
+    ``cross_repo`` SURVIVES the neutralizer: crossing a repo boundary crosses an
+    OWNERSHIP boundary, a multi-party coordination/consensus need that holds even
+    for docs. (``needs_consensus`` survives in ``recommend_execution_backend`` for
+    the same reason.)
+    """
+
+    code_shaped = any(
         (
             file_count >= 8,
             phase_count >= 4,
             has_security,
             has_infra,
-            cross_repo,
             deployment_sensitive,
         )
     )
+    return (code_shaped and has_code_surface) or cross_repo
 
 
 def should_prompt_for_issue(*, has_issue: bool, is_trivial: bool, user_declined: bool) -> bool:
@@ -87,6 +106,8 @@ def recommend_execution_backend(
     deployment_sensitive: bool = False,
     needs_consensus: bool = False,
     broad_independent_fanout: bool = False,
+    adversarial_confidence: bool = False,
+    has_code_surface: bool = True,
     workflow_available: bool = True,
 ) -> dict[str, object]:
     """Recommend an execution backend, mirroring operator-choice.md section 3.
@@ -102,6 +123,19 @@ def recommend_execution_backend(
     needs_consensus``) — a small-but-contested job is a team-execution job even
     without a size/risk trigger, which is the more useful behavior for a real
     caller. This is intentional, not a transcription error.
+
+    ``has_code_surface`` (default True) neutralizes the code-shaped team-execution
+    proxies for pure docs/spec/research work (see ``should_offer_team_execution``).
+    It also gates the ultracode RISK SUPPRESSOR below: ``has_infra`` /
+    ``has_security`` are ``parse_issue.py`` keyword matches (mention, not touch),
+    so on a docs change they are false positives that must not block an ultracode
+    fan-out any more than they force team-execution.
+
+    ``adversarial_confidence`` (default False) is the second ultracode trigger
+    beside ``broad_independent_fanout``: prove-by-refutation / judge-panel /
+    perspective-diverse verification is an ultracode shape (deterministic
+    INDEPENDENT verification, not merely breadth). Without it, "stress-test this
+    from many angles" work with no deploy/security signal would fall to inline.
 
     ``alternatives`` lists every *reachable* backend (capability-gated by
     ``workflow_available``) computed INDEPENDENTLY of which backend won
@@ -119,17 +153,24 @@ def recommend_execution_backend(
             has_infra=has_infra,
             cross_repo=cross_repo,
             deployment_sensitive=deployment_sensitive,
+            has_code_surface=has_code_surface,
         )
         or needs_consensus
     )
-    ultracode = broad_independent_fanout and not (has_security or has_infra or deployment_sensitive)
+    # The risk suppressor only bites when there is a real code/scanner surface:
+    # has_infra / has_security are keyword matches that false-positive on docs.
+    elevated_risk = (has_security or has_infra or deployment_sensitive) and has_code_surface
+    ultracode = (broad_independent_fanout or adversarial_confidence) and not elevated_risk
 
     if team:
         recommended = "team-execution"
         rationale = "size/risk or consensus signal -> review consensus + gates fit"
     elif ultracode and workflow_available:
         recommended = "cc-workflows-ultracode"
-        rationale = "broad independent fan-out without elevated risk -> deterministic fan-out"
+        rationale = (
+            "broad fan-out or adversarial-confidence pass without elevated risk"
+            " -> deterministic independent verification"
+        )
     else:
         recommended = "inline"
         rationale = "no escalation signal -> the agent does the work itself"
@@ -165,6 +206,8 @@ def _build_parser() -> argparse.ArgumentParser:
     backend.add_argument("--deployment-sensitive", action="store_true")
     backend.add_argument("--needs-consensus", action="store_true")
     backend.add_argument("--broad-fanout", action="store_true")
+    backend.add_argument("--adversarial-confidence", action="store_true")
+    backend.add_argument("--no-code-surface", action="store_true")
     backend.add_argument("--no-workflow", action="store_true")
 
     return parser
@@ -189,6 +232,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             deployment_sensitive=args.deployment_sensitive,
             needs_consensus=args.needs_consensus,
             broad_independent_fanout=args.broad_fanout,
+            adversarial_confidence=args.adversarial_confidence,
+            has_code_surface=not args.no_code_surface,
             workflow_available=not args.no_workflow,
         )
         print(json.dumps(result))

--- a/plugins/saga/skills/work/references/execution-strategy.md
+++ b/plugins/saga/skills/work/references/execution-strategy.md
@@ -123,13 +123,18 @@ backend, pre-select it, and surface the alternatives so escalation is one keystr
 python3 plugins/saga/scripts/lifecycle_state.py recommend-backend \
   --file-count <N> --phase-count <N> \
   [--has-security] [--has-infra] [--cross-repo] [--deployment-sensitive] \
-  [--needs-consensus] [--broad-fanout] [--no-workflow]
+  [--needs-consensus] [--broad-fanout] [--adversarial-confidence] \
+  [--no-code-surface] [--no-workflow]
 ```
 
 It returns JSON: `{recommended, rationale, alternatives, omit_ultracode}`. The recommendation reuses
 `should_offer_team_execution`'s thresholds (file_count ≥ 8, phase_count ≥ 4, security, infra, cross-repo,
 deployment-sensitive) **or** a needs-consensus signal for `team-execution`; broad-independent-fanout
-without elevated risk for `cc-workflows-ultracode`; `inline` otherwise. `alternatives` lists every
+**or** an adversarial-confidence pass (prove-by-refutation / judge-panel) without elevated risk for
+`cc-workflows-ultracode`; `inline` otherwise. Pass `--no-code-surface` for pure docs/spec/research output:
+it voids the code-shaped proxies (size, and the `has_infra` / `has_security` keyword flags that
+false-positive on docs) so a big docs change isn't conscripted into team-execution — only `--cross-repo`
+and `--needs-consensus` keep it there. `alternatives` lists every
 reachable backend **independent of which one won precedence**, so an overlap job (consensus AND
 fan-out) still offers both — escalation stays one step (operator-choice §3.3).
 

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.21.0"
+    assert plugin_json["version"] == "0.22.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]
@@ -2515,6 +2515,112 @@ def test_lifecycle_state_cli_subcommands(capsys: pytest.CaptureFixture[str]) -> 
     with pytest.raises(SystemExit) as exc_info:
         lifecycle.main(["deploy"])
     assert exc_info.value.code != 0
+
+
+def test_recommend_execution_backend_adversarial_confidence() -> None:
+    """adversarial_confidence is the SECOND ultracode trigger beside broad fan-out.
+
+    Prove-by-refutation / judge-panel work with no deploy/security signal is an
+    ultracode shape (deterministic INDEPENDENT verification), not an inline one.
+    It rides the same risk gate and the same capability gate as broad fan-out.
+    """
+    lifecycle = _load_module("lifecycle_state.py")
+    rec = lifecycle.recommend_execution_backend
+
+    # adversarial_confidence alone, no risk -> cc-workflows-ultracode.
+    assert rec(adversarial_confidence=True)["recommended"] == "cc-workflows-ultracode"
+
+    # The risk gate still suppresses it: an elevated-risk signal routes to team.
+    assert rec(adversarial_confidence=True, has_security=True)["recommended"] == "team-execution"
+
+    # Capability gate: with the Workflow tool absent it degrades to inline and
+    # drops ultracode from the offer (mirrors the broad-fanout degrade).
+    gated = rec(adversarial_confidence=True, workflow_available=False)
+    assert gated["recommended"] == "inline"
+    assert gated["omit_ultracode"] is True
+
+    # Overlap: adversarial_confidence (ultracode) AND needs_consensus (team wins)
+    # still lists ultracode as a one-keystroke alternative.
+    overlap = rec(adversarial_confidence=True, needs_consensus=True)
+    assert overlap["recommended"] == "team-execution"
+    assert "cc-workflows-ultracode" in overlap["alternatives"]
+
+
+def test_recommend_execution_backend_docs_no_code_surface() -> None:
+    """has_code_surface=False neutralizes the OUTPUT-BLIND proxies for docs.
+
+    team-execution's scanners + deploy gate are code-shaped and inert on pure
+    docs/spec/research. So size (file/phase) and the parse_issue.py keyword flags
+    (has_infra/has_security/deployment_sensitive) must NOT force team-execution on
+    a docs change. The two output-AGNOSTIC governance signals survive: cross_repo
+    (ownership boundary) and needs_consensus (contested).
+    """
+    lifecycle = _load_module("lifecycle_state.py")
+    rec = lifecycle.recommend_execution_backend
+
+    # Default (has_code_surface=True): the size proxy still trips team-execution.
+    assert rec(file_count=12)["recommended"] == "team-execution"
+
+    # Docs: the size/sequencing proxies are voided -> inline.
+    assert rec(file_count=12, has_code_surface=False)["recommended"] == "inline"
+    assert rec(phase_count=6, has_code_surface=False)["recommended"] == "inline"
+
+    # Docs: the keyword risk proxies are voided too (mention != touch). An infra
+    # runbook or a threat-model doc must not be conscripted into team-execution.
+    assert rec(has_infra=True, has_code_surface=False)["recommended"] == "inline"
+    assert rec(has_security=True, has_code_surface=False)["recommended"] == "inline"
+    assert rec(deployment_sensitive=True, has_code_surface=False)["recommended"] == "inline"
+
+    # Broad docs (many files) fan out via ultracode even with a keyword risk flag
+    # set, because the suppressor is itself gated by has_code_surface.
+    assert (
+        rec(file_count=12, broad_independent_fanout=True, has_code_surface=False)["recommended"]
+        == "cc-workflows-ultracode"
+    )
+    assert (
+        rec(has_infra=True, broad_independent_fanout=True, has_code_surface=False)["recommended"]
+        == "cc-workflows-ultracode"
+    )
+
+    # The output-AGNOSTIC governance signals SURVIVE the neutralizer: cross_repo
+    # (ownership boundary) and needs_consensus (contested) still fire on docs.
+    assert rec(cross_repo=True, has_code_surface=False)["recommended"] == "team-execution"
+    assert rec(needs_consensus=True, has_code_surface=False)["recommended"] == "team-execution"
+
+    # Overlap still lists ultracode: docs breadth + consensus -> team recommended,
+    # ultracode an alternative.
+    overlap = rec(
+        file_count=12,
+        broad_independent_fanout=True,
+        needs_consensus=True,
+        has_code_surface=False,
+    )
+    assert overlap["recommended"] == "team-execution"
+    assert "cc-workflows-ultracode" in overlap["alternatives"]
+
+
+def test_recommend_backend_cli_new_flags(capsys: pytest.CaptureFixture[str]) -> None:
+    """--adversarial-confidence and --no-code-surface round-trip through main().
+
+    Without a runnable CLI surface the new triggers are unreachable from the
+    markdown callers, so the flags must flow end-to-end, not just exist in Python.
+    """
+    lifecycle = _load_module("lifecycle_state.py")
+
+    # --adversarial-confidence -> cc-workflows-ultracode.
+    assert lifecycle.main(["recommend-backend", "--adversarial-confidence"]) == 0
+    adv = json.loads(capsys.readouterr().out)
+    assert adv["recommended"] == "cc-workflows-ultracode"
+
+    # --no-code-surface voids the size proxy: a 12-file docs change -> inline.
+    assert lifecycle.main(["recommend-backend", "--file-count", "12", "--no-code-surface"]) == 0
+    docs = json.loads(capsys.readouterr().out)
+    assert docs["recommended"] == "inline"
+
+    # --no-code-surface keeps cross_repo live (the ownership-boundary signal).
+    assert lifecycle.main(["recommend-backend", "--cross-repo", "--no-code-surface"]) == 0
+    cross = json.loads(capsys.readouterr().out)
+    assert cross["recommended"] == "team-execution"
 
 
 def test_issue_progress_comments_include_required_evidence() -> None:


### PR DESCRIPTION
## What

Corrects saga's execution-backend decision logic after a multi-agent research + adversarial-review pass found the operator-choice contract **mis-models Claude Code Workflows (ultracode)**.

### The category error (fixed)
`operator-choice.md` §3.2 said *"ultracode's value is deterministic fan-out, **not review depth**."* That's false against the Workflow tool's own spec (CONFIDENCE is one of three stated purposes; adversarial-verify, judge-panel, perspective-diverse verify are built-in) and official docs (*"independent agents adversarially review each other's findings… a more trustworthy result than a single pass"*). The real `team-execution` boundary is **governance** (reviewer consensus + named scanner gates + guarded deploy), framed as *artifact kind*: ultracode = a throwaway statistical signal; team-execution = a standing blocking verdict.

### Two reachability fixes in `recommend_execution_backend()`
- **`adversarial_confidence`** (2nd ultracode trigger; CLI `--adversarial-confidence`) — prove-by-refutation / judge-panel work with no deploy/security signal previously fell silently to `inline`.
- **`has_code_surface`** (default True; CLI `--no-code-surface`) — pure docs/spec/research neutralizes the **output-blind** code-shaped proxies: `file_count`, `phase_count`, and the `parse_issue.py` keyword flags `has_infra`/`has_security`/`deployment_sensitive` that fire on a doc merely *mentioning* terraform/auth (mention ≠ touch). `cross_repo` (ownership boundary) and `needs_consensus` (contested) survive as output-agnostic governance signals. The ultracode risk-suppressor is itself gated by `has_code_surface`, so broad infra/security **docs** still fan out.

### Unchanged
Lean precedence `team-execution > cc-workflows-ultracode > inline`. All locked recommender assertions pass untouched (both new kwargs default-safe).

## Why it was ~80% right already
The helper's risk gate already encoded the true discriminator (governance); only the *prose* narrated the wrong reason. This makes the doc tell the truth and reaches the two shapes the helper couldn't.

## Files
- `lifecycle_state.py` — predicate + 2 CLI flags
- `operator-choice.md` §3.1 (`PLUS`→`OR`) + §3.2 (reword) + §1 table
- `execution-strategy.md` — `/work`'s CLI reference learns both flags
- `test_saga_plugin.py` — 3 new tests (adversarial_confidence, docs has_code_surface, CLI round-trip)
- saga `0.21.0 → 0.22.0` (plugin.json + marketplace.json + CHANGELOG)
- `LEARNINGS.md` + `DECISIONS.md` entries

## Gate (local)
`ruff format --check` ✓ · `ruff check` ✓ · both plugin validators ✓ · 31 saga tests ✓ (3 new). The one repo-wide failure (`test_suite_does_not_create_claude_dir_under_repo_root`) is the documented local-only flake — verified pre-existing (fails identically with this branch stashed).