### PR TITLE
docs(saga): guard adversarial_confidence to explicit requests; fill 0.22.0 SHA (0.22.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -296,7 +296,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-06-13
 
-### Correct the operator-choice ultracode framing; add `adversarial_confidence` + `has_code_surface` to the backend recommender (PR #215)  {#operator-choice-docs-and-confidence}
+### Correct the operator-choice ultracode framing; add `adversarial_confidence` + `has_code_surface` to the backend recommender (PR #215, squash `331505a`)  {#operator-choice-docs-and-confidence}
 
 **Decision.** (1) Document `cc-workflows-ultracode` as deterministic fan-out **and** independent/adversarial
 verification; the line to `team-execution` is **governance** (consensus + named scanner gates + guarded
@@ -54,8 +54,8 @@ Minimal blast radius: two default-safe kwargs + one predicate clause; every lock
 **Revisit when.** `has_code_surface` gets mis-set often in practice (it is a looser caller judgment than the
 others — revisit toward deriving it, or folding `cross_repo` into the neutralizer); OR `parse_issue.py` gains a
 real file-touch signal for infra/security (then neutralizing those two for docs is redundant); OR
-`adversarial_confidence` wants a magnitude gate (many-independent-attempts vs a few lenses — currently
-categorical).
+`adversarial_confidence` over-routes to ultracode in practice (PR #216 gated it to an **explicit**
+many-attempts request, but it still lacks a true magnitude gate — add one if it fires too readily).
 
 **Refs.** LEARNINGS [#operator-choice-ultracode-framing-and-docs-proxies](LEARNINGS.md#operator-choice-ultracode-framing-and-docs-proxies);
 refines [#operator-choice-framework](#operator-choice-framework).

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -37,7 +37,8 @@ the Workflow tool's own spec and official Anthropic docs against the contract.
 depth"); `recommend_execution_backend()` in `plugins/saga/scripts/lifecycle_state.py`; `parse_issue.py:108-110`
 (`INFRA_RE` / `SECURITY_RE` are bare keyword regexes — `terraform|lambda|...`, `auth|iam|...` — over the issue
 *body text*); official docs (code.claude.com/docs/en/workflows: "independent agents adversarially review each
-other's findings… a more trustworthy result than a single pass"). PR #215 (saga 0.22.0).
+other's findings… a more trustworthy result than a single pass"). PR #215 (saga 0.22.0, squash `331505a`);
+the `adversarial_confidence` explicit-request guard followed in PR #216 (saga 0.22.1).
 
 **Mechanism.** Three things. (1) ultracode HAS review depth — *confidence* is one of the tool's three stated
 purposes, and adversarial-verify / judge-panel / perspective-diverse verify are built-in patterns; "Review" is

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.22.1 - 2026-06-13
+
+- Tighten the `adversarial_confidence` guidance: `/work` sets `--adversarial-confidence` only on an explicit
+  operator request for many-independent-attempt verification (refute-N / judge-panel / perspective-diverse),
+  never inferred from generic "make me more confident" phrasing — closes the oversell risk the adversarial
+  review flagged. The trigger stays categorical; a true magnitude gate remains a documented revisit-when.
+- Journal bookkeeping: record the 0.22.0 squash SHA (`331505a`).
+
 ## 0.22.0 - 2026-06-13
 
 - Correct the execution-backend recommender (`recommend_execution_backend`) and the operator-choice contract

--- a/plugins/saga/references/operator-choice.md
+++ b/plugins/saga/references/operator-choice.md
@@ -94,7 +94,9 @@ Offer in **either** of two ungoverned-multiplicity modes, both without elevated 
   targets), or an exhaustive search-all / probe-all sweep where missing a target is the failure mode.
 - **Adversarial confidence** (`adversarial_confidence`) — prove-by-refutation, a judge panel over N
   independent attempts, or perspective-diverse verifiers each applying a distinct lens. This is real review
-  depth; the Workflow tool names *confidence* as a first-class purpose.
+  depth; the Workflow tool names *confidence* as a first-class purpose. Set it only on an **explicit**
+  request for many-independent-attempt verification — not inferred from a generic "be more sure," and not
+  when 1-3 lenses suffice (that is an `inline` / `team-execution` review, not an ultracode fan-out).
 
 So ultracode is **not** "fan-out, not review depth" — it delivers deterministic fan-out **and** independent
 adversarial verification. What it lacks is **governance**: no reviewer-CONSENSUS gate, no named scanner

--- a/plugins/saga/skills/work/references/execution-strategy.md
+++ b/plugins/saga/skills/work/references/execution-strategy.md
@@ -134,7 +134,10 @@ deployment-sensitive) **or** a needs-consensus signal for `team-execution`; broa
 `cc-workflows-ultracode`; `inline` otherwise. Pass `--no-code-surface` for pure docs/spec/research output:
 it voids the code-shaped proxies (size, and the `has_infra` / `has_security` keyword flags that
 false-positive on docs) so a big docs change isn't conscripted into team-execution — only `--cross-repo`
-and `--needs-consensus` keep it there. `alternatives` lists every
+and `--needs-consensus` keep it there. Set `--adversarial-confidence` ONLY on an explicit operator request
+for many-independent-attempt verification (refute-N, a judge panel, perspective-diverse lenses) — not
+inferred from generic "make me more confident" phrasing, and not when 1-3 review lenses would do; that bar
+keeps confidence work from over-routing to ultracode. `alternatives` lists every
 reachable backend **independent of which one won precedence**, so an overlap job (consensus AND
 fan-out) still offers both — escalation stays one step (operator-choice §3.3).
 

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.22.0"
+    assert plugin_json["version"] == "0.22.1"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]


### PR DESCRIPTION
Follow-up to #215 — two items raised in the wrap-up.

## 1. `adversarial_confidence` detector guard
The adversarial review flagged that `adversarial_confidence` shipped as a categorical trigger with no guard on *when a caller sets it* — the oversell vector. This adds the guard to both the contract (`operator-choice.md` §3.2) and the operative runbook (`/work` `execution-strategy.md`):

> Set `--adversarial-confidence` ONLY on an explicit operator request for many-independent-attempt verification (refute-N / judge-panel / perspective-diverse) — not inferred from generic "make me more confident" phrasing, and not when 1-3 review lenses would do.

The trigger stays categorical (no code change); a true magnitude gate remains a documented `revisit-when` in DECISIONS.

## 2. Squash-SHA fill
Records the #215 squash SHA (`331505a`) in the LEARNINGS + DECISIONS entries, matching house style.

## Version
saga `0.22.0 → 0.22.1` (guidance + bookkeeping; `recommend_execution_backend` is byte-identical).

## Gate (local)
`ruff format --check` ✓ · `ruff check` ✓ · both validators ✓ · 31 saga tests ✓ (metadata pin moved to 0.22.1).