### PR TITLE
feat(mission-control): U11 — prepare compile + operator-approval gate (Phase D)

### DIFF
--- a/plugins/mission-control/scripts/sdlc_manager.py
+++ b/plugins/mission-control/scripts/sdlc_manager.py
@@ -2719,6 +2719,38 @@ _HERMES_ACTIONABLE_TYPES = frozenset(
 # additional prompts light up automatically.
 _CAPABILITY_ADAPTIVE_TYPES = frozenset({"capability", "objective"})
 
+# ---------------------------------------------------------------------------
+# Prepared-issue compile + approve machinery (U11)
+# ---------------------------------------------------------------------------
+# Two ORTHOGONAL durable axes, kept separate on purpose:
+#   - `state`          : the creation-pipeline state (blocked -> ready_to_create
+#                        -> mapping_pending -> created). UNCHANGED by U11 so the
+#                        existing readiness/create-prepared contract + tests hold.
+#   - `approval_state` : the human gate U11 adds. A cleanly-compiled draft lands
+#                        in NEEDS_OPERATOR_APPROVAL (recorded durably in BOTH the
+#                        sidecar and the draft front-matter) and is NOT
+#                        auto-created. Batch approval transitions it to APPROVED.
+# A blocked draft has approval_state=None — it never reaches the gate.
+_PREPARE_STATE_BLOCKED = "blocked"
+_PREPARE_STATE_READY = "ready_to_create"
+_APPROVAL_NEEDS_OPERATOR = "needs_operator_approval"
+_APPROVAL_APPROVED = "approved"
+# approval_state values from which a draft may be batch-approved. Approving an
+# already-approved draft is a no-op (idempotent).
+_APPROVABLE_APPROVAL_STATES = frozenset({_APPROVAL_NEEDS_OPERATOR, _APPROVAL_APPROVED})
+
+# Project FIELDS a prepared card carries, computed offline at prepare time from
+# the issue's own metadata so the later live `create` step can set them. These
+# are card VALUES (not the project's live field schema): "field-schema
+# discovery" against a real project stays behind `_resolve_project_field` (live
+# GraphQL), which `create`/`flow set-field` already use. Lifecycle Origin is the
+# auto-populated field (R10) — never author-supplied. Risk maps to the
+# `Technical Risk` single-select named in the PROJECT FIELD REALITY note above.
+_PREPARED_FIELD_RISK = "Technical Risk"
+_PREPARED_FIELD_OBJECTIVE = "Objective"
+_PREPARED_FIELD_ISSUE_TYPE = "Issue Type"
+_PREPARED_FIELD_LIFECYCLE_ORIGIN = "Lifecycle Origin"
+
 
 @dataclass
 class PreparedReadiness:
@@ -2754,8 +2786,37 @@ class PreparedIssue:
     body: str
     handoff_maturity: str | None = None
     source_artifact: dict[str, Any] | None = None
+    project_fields: dict[str, str] | None = None
     draft_path: str | None = None
     sidecar_path: str | None = None
+
+
+def _prepared_project_fields(
+    issue: PreparedIssue, source_artifact: SourceArtifact | None
+) -> dict[str, str]:
+    """Resolve the project-field values a prepared card will carry (U11).
+
+    Pure/offline: derives values from the issue's own metadata + the handoff
+    source, so tests run without a live GitHub call. The live project field
+    schema (which fields/options actually exist on the target project) is
+    discovered later by `_resolve_project_field` when `create` sets them; a
+    field the project does not yet expose is simply skipped at set time. We
+    only record non-empty values so the sidecar reflects what we can actually
+    populate.
+    """
+    fields: dict[str, str] = {_PREPARED_FIELD_ISSUE_TYPE: issue.issue_type}
+    if issue.risk:
+        fields[_PREPARED_FIELD_RISK] = issue.risk
+    # Lifecycle Origin is auto-populated from the handoff maturity that drove
+    # this draft (R10) — it is the compile step's record of "where this card
+    # came from", never an author-required input.
+    if issue.handoff_maturity:
+        fields[_PREPARED_FIELD_LIFECYCLE_ORIGIN] = issue.handoff_maturity
+    # Objective is carried only when the handoff source names one; we don't
+    # invent an Objective the operator didn't supply.
+    if source_artifact and source_artifact.ref:
+        fields[_PREPARED_FIELD_OBJECTIVE] = source_artifact.ref
+    return fields
 
 
 @dataclass
@@ -3076,7 +3137,7 @@ def _strip_draft_h1(body: str) -> tuple[str | None, str]:
     return None, body
 
 
-def _render_draft_markdown(issue: PreparedIssue) -> str:
+def _render_draft_markdown(issue: PreparedIssue, approval_state: str | None = None) -> str:
     labels = ", ".join(issue.labels)
     frontmatter = [
         "---",
@@ -3094,6 +3155,11 @@ def _render_draft_markdown(issue: PreparedIssue) -> str:
         frontmatter.append(f"mode: {issue.mode}")
     if issue.handoff_maturity:
         frontmatter.append(f"handoff_maturity: {issue.handoff_maturity}")
+    # Durably record the approval state in the draft front-matter too (U11), so
+    # the human gate survives independent of the sidecar (front-matter is what
+    # an operator reads when reviewing the draft markdown directly).
+    if approval_state:
+        frontmatter.append(f"approval_state: {approval_state}")
     frontmatter.append("---")
     return "\n".join(frontmatter) + f"\n\n# {issue.title}\n\n{issue.body.rstrip()}\n"
 
@@ -3240,6 +3306,9 @@ def _read_prepared_issue(draft_path: Path) -> PreparedIssue:
         source_artifact=sidecar.get("source_artifact")
         if isinstance(sidecar.get("source_artifact"), dict)
         else None,
+        project_fields=sidecar.get("project_fields")
+        if isinstance(sidecar.get("project_fields"), dict)
+        else None,
         draft_path=str(draft_path),
         sidecar_path=str(sidecar_path),
     )
@@ -3331,11 +3400,17 @@ def _readiness_for_prepared_issue(issue: PreparedIssue) -> PreparedReadiness:
 
 
 def _sidecar_payload(
-    issue: PreparedIssue, readiness: PreparedReadiness, state: str
+    issue: PreparedIssue,
+    readiness: PreparedReadiness,
+    state: str,
+    approval_state: str | None,
 ) -> dict[str, Any]:
     return {
         "schema_version": "1.0",
         "state": state,
+        # The U11 human gate (None when blocked — a blocked draft never reaches
+        # approval). Distinct from `state` (the creation pipeline) on purpose.
+        "approval_state": approval_state,
         "title": issue.title,
         "repo": issue.repo,
         "issue_type": issue.issue_type,
@@ -3347,6 +3422,7 @@ def _sidecar_payload(
         "mode": issue.mode,
         "handoff_maturity": issue.handoff_maturity,
         "source_artifact": issue.source_artifact,
+        "project_fields": issue.project_fields or {},
         "draft_path": issue.draft_path,
         "sidecar_path": issue.sidecar_path,
         "readiness": asdict(readiness),
@@ -3402,6 +3478,13 @@ def issue_prepare(
         handoff_maturity=maturity,
         source_artifact=_source_artifact_payload(source_artifact),
     )
+    # Record the project-field values the card will carry so the later live
+    # `create` step can set them (U11). Offline — derived from issue metadata.
+    issue.project_fields = _prepared_project_fields(issue, source_artifact)
+    # KTD9: the body produced by prepare must PASS the Phase C validator before
+    # it can reach approval. The validator runs inside readiness (the olympus
+    # profile calls validate_card_body), so a malformed body fails readiness and
+    # is forced to `blocked` below — it never reaches `needs_operator_approval`.
     readiness = _readiness_for_prepared_issue(issue)
 
     target_dir = draft_dir or _PREPARED_DRAFT_DIR
@@ -3411,10 +3494,20 @@ def issue_prepare(
     issue.draft_path = str(draft_path)
     issue.sidecar_path = str(sidecar_path)
 
-    draft_path.write_text(_render_draft_markdown(issue), encoding="utf-8")
-    state = "ready_to_create" if readiness.passed else "blocked"
+    # Creation-pipeline state is unchanged by U11 (ready_to_create / blocked).
+    # The U11 human gate is the SEPARATE approval_state: a cleanly-compiled draft
+    # lands in `needs_operator_approval` (NOT auto-created); a blocked draft has
+    # no approval gate to enter.
+    state = _PREPARE_STATE_READY if readiness.passed else _PREPARE_STATE_BLOCKED
+    approval_state = _APPROVAL_NEEDS_OPERATOR if readiness.passed else None
+    draft_path.write_text(
+        _render_draft_markdown(issue, approval_state=approval_state), encoding="utf-8"
+    )
     sidecar_path.write_text(
-        json.dumps(_sidecar_payload(issue, readiness, state), indent=2, sort_keys=True) + "\n",
+        json.dumps(
+            _sidecar_payload(issue, readiness, state, approval_state), indent=2, sort_keys=True
+        )
+        + "\n",
         encoding="utf-8",
     )
 
@@ -3712,6 +3805,78 @@ def issue_create_prepared(
         _out({**result, "mutation_plan": plan_payload}, fmt)
     else:
         print(f"Created issue: {url}")
+    return result
+
+
+def _set_draft_approval_state(draft_path: Path, approval_state: str) -> None:
+    """Rewrite the `approval_state:` front-matter line on the draft markdown.
+
+    The approval state lives in BOTH the draft front-matter and the sidecar so
+    the human gate survives whichever artifact an operator looks at. This keeps
+    the front-matter in lockstep when batch approval transitions the sidecar.
+    """
+    text = draft_path.read_text(encoding="utf-8")
+    metadata, _ = _parse_draft_frontmatter(text)
+    line = f"approval_state: {approval_state}"
+    if "approval_state" in metadata:
+        # Replace the existing line in place (front-matter only, before body).
+        end = text.find("\n---\n", 4)
+        head, tail = text[:end], text[end:]
+        head = re.sub(r"(?m)^approval_state:.*$", line, head)
+        draft_path.write_text(head + tail, encoding="utf-8")
+        return
+    if not text.startswith("---\n"):
+        # No front-matter to edit (defensive): nothing durable to rewrite.
+        return
+    end = text.find("\n---\n", 4)
+    draft_path.write_text(text[:end] + f"\n{line}" + text[end:], encoding="utf-8")
+
+
+def prepared_approve_batch(draft_paths: list[Path], fmt: str = "text") -> dict[str, Any]:
+    """Approve multiple prepared drafts at once (U11 batch approval).
+
+    Transitions each draft's `approval_state` out of `needs_operator_approval`
+    -> `approved` in both the sidecar and the draft front-matter. This is the
+    human gate clearing a batch of compiled cards for creation. Idempotent and
+    per-draft fault isolated: an unreadable / non-approvable draft (e.g. a
+    blocked draft, which has no approval gate) is reported and skipped, never
+    aborting the rest of the batch.
+    """
+    approved: list[str] = []
+    skipped: list[dict[str, str]] = []
+    for draft_path in draft_paths:
+        sidecar_path = draft_path.with_suffix(".json")
+        if not sidecar_path.exists():
+            skipped.append({"draft": str(draft_path), "reason": "missing sidecar"})
+            continue
+        try:
+            sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            skipped.append({"draft": str(draft_path), "reason": f"malformed sidecar: {e}"})
+            continue
+        current = sidecar.get("approval_state")
+        if current not in _APPROVABLE_APPROVAL_STATES:
+            skipped.append({"draft": str(draft_path), "reason": f"approval_state is {current!r}"})
+            continue
+        _update_sidecar_state(
+            draft_path,
+            {
+                "approval_state": _APPROVAL_APPROVED,
+                "approved_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        _set_draft_approval_state(draft_path, _APPROVAL_APPROVED)
+        approved.append(str(draft_path))
+
+    result = {"approved": approved, "skipped": skipped}
+    if fmt == "json":
+        _out(result, fmt)
+    else:
+        print(f"Approved {len(approved)} prepared draft(s).")
+        for path in approved:
+            print(f"  - APPROVED: {path}")
+        for entry in skipped:
+            print(f"  - SKIPPED ({entry['reason']}): {entry['draft']}")
     return result
 
 
@@ -4379,6 +4544,16 @@ def main() -> None:
         help="Create the issue before a missing project-mapping PR merges",
     )
 
+    issue_approve_p = issue_sp.add_parser(
+        "approve",
+        help="Batch-approve prepared drafts out of the Needs Operator Approval gate",
+    )
+    issue_approve_p.add_argument(
+        "drafts",
+        nargs="+",
+        help="One or more prepared draft markdown paths to approve",
+    )
+
     # ===========================
     # LABELS
     # ===========================
@@ -4638,6 +4813,8 @@ def main() -> None:
                     auto_confirm=args.yes,
                     override_mapping=args.override_mapping,
                 )
+            elif args.action == "approve":
+                prepared_approve_batch([Path(d) for d in args.drafts], fmt=fmt)
 
         elif args.resource == "labels":
             if args.action == "sync-fields":

--- a/plugins/mission-control/scripts/sdlc_manager.py
+++ b/plugins/mission-control/scripts/sdlc_manager.py
@@ -2735,17 +2735,19 @@ _PREPARE_STATE_BLOCKED = "blocked"
 _PREPARE_STATE_READY = "ready_to_create"
 _APPROVAL_NEEDS_OPERATOR = "needs_operator_approval"
 _APPROVAL_APPROVED = "approved"
-# approval_state values from which a draft may be batch-approved. Approving an
-# already-approved draft is a no-op (idempotent).
-_APPROVABLE_APPROVAL_STATES = frozenset({_APPROVAL_NEEDS_OPERATOR, _APPROVAL_APPROVED})
+# approval_state values from which a draft may be batch-approved. Only a draft
+# sitting in the gate is approvable; an already-approved draft is SKIPPED (its
+# approved_at timestamp is preserved, not rewritten) so approval is a true no-op.
+_APPROVABLE_APPROVAL_STATES = frozenset({_APPROVAL_NEEDS_OPERATOR})
 
 # Project FIELDS a prepared card carries, computed offline at prepare time from
-# the issue's own metadata so the later live `create` step can set them. These
-# are card VALUES (not the project's live field schema): "field-schema
-# discovery" against a real project stays behind `_resolve_project_field` (live
-# GraphQL), which `create`/`flow set-field` already use. Lifecycle Origin is the
-# auto-populated field (R10) — never author-supplied. Risk maps to the
-# `Technical Risk` single-select named in the PROJECT FIELD REALITY note above.
+# the issue's own metadata and RECORDED in the sidecar for a future create-time
+# consumer (consumption is a follow-up unit, not wired here). These are card
+# VALUES (not the project's live field schema): "field-schema discovery" against
+# a real project stays behind `_resolve_project_field` (live GraphQL), which
+# `flow set-field` uses. Lifecycle Origin is the auto-populated field (R10) —
+# never author-supplied. Risk maps to the `Technical Risk` single-select named
+# in the PROJECT FIELD REALITY note above.
 _PREPARED_FIELD_RISK = "Technical Risk"
 _PREPARED_FIELD_OBJECTIVE = "Objective"
 _PREPARED_FIELD_ISSUE_TYPE = "Issue Type"
@@ -2797,12 +2799,14 @@ def _prepared_project_fields(
     """Resolve the project-field values a prepared card will carry (U11).
 
     Pure/offline: derives values from the issue's own metadata + the handoff
-    source, so tests run without a live GitHub call. The live project field
-    schema (which fields/options actually exist on the target project) is
-    discovered later by `_resolve_project_field` when `create` sets them; a
-    field the project does not yet expose is simply skipped at set time. We
-    only record non-empty values so the sidecar reflects what we can actually
-    populate.
+    source, so tests run without a live GitHub call. These values are RECORDED
+    in the sidecar (`project_fields`) for a LATER create-time consumer to set on
+    the live card — that consumption is a FOLLOW-UP unit and is NOT wired here.
+    `create` does not yet read `project_fields`, and `_resolve_project_field`
+    currently RAISES on a field the live project doesn't expose (per-field
+    tolerance for not-yet-created fields is also a follow-up, not implemented
+    here). We only record non-empty values so the sidecar reflects what we could
+    populate; do not read more into the presence of this key than "recorded".
     """
     fields: dict[str, str] = {_PREPARED_FIELD_ISSUE_TYPE: issue.issue_type}
     if issue.risk:
@@ -3674,6 +3678,19 @@ def _update_sidecar_state(draft_path: Path, updates: dict[str, Any]) -> None:
     sidecar_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _read_sidecar_approval_state(draft_path: Path) -> str | None:
+    """Read just the U11 `approval_state` from a draft's sidecar.
+
+    Focused reader (the gate enforcement in issue_create_prepared needs only
+    this one field; PreparedIssue deliberately doesn't carry it). Returns None
+    when absent — i.e. legacy drafts predating the gate, which proceed unblocked.
+    """
+    sidecar_path = draft_path.with_suffix(".json")
+    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    value = payload.get("approval_state")
+    return str(value) if value is not None else None
+
+
 def _build_mutation_plan(issue: PreparedIssue, config: dict[str, Any]) -> MutationPlan:
     if not issue.draft_path:
         raise RuntimeError("Prepared issue is missing draft_path")
@@ -3730,6 +3747,7 @@ def issue_create_prepared(
     fmt: str,
     auto_confirm: bool = False,
     override_mapping: bool = False,
+    skip_approval: bool = False,
 ) -> dict[str, Any]:
     issue = _read_prepared_issue(draft_path)
     readiness = _readiness_for_prepared_issue(issue)
@@ -3741,6 +3759,24 @@ def issue_create_prepared(
             for gap in readiness.blocking_gaps:
                 print(f"  - {gap}")
         raise RuntimeError("Prepared issue has blocking readiness gaps")
+
+    # Enforce the U11 human gate (FIX 1): a draft sitting in
+    # `needs_operator_approval` is NOT created until an operator approves it (via
+    # `issue approve`) or explicitly overrides with --skip-approval. An
+    # `approved` draft proceeds; a None approval_state (legacy drafts predating
+    # the gate; blocked drafts already failed readiness above) proceeds
+    # unchanged — back-compatible, do NOT newly block None.
+    approval_state = _read_sidecar_approval_state(draft_path)
+    if approval_state == _APPROVAL_NEEDS_OPERATOR and not skip_approval:
+        message = (
+            f"Prepared draft awaits operator approval; run "
+            f"`issue approve {draft_path}` first, or pass --skip-approval."
+        )
+        if fmt == "json":
+            _out({"created": False, "reason": "needs_operator_approval"}, fmt)
+        else:
+            print(message)
+        raise RuntimeError(message)
 
     config = load_config()
     plan = _build_mutation_plan(issue, config)
@@ -3821,6 +3857,10 @@ def _set_draft_approval_state(draft_path: Path, approval_state: str) -> None:
     if "approval_state" in metadata:
         # Replace the existing line in place (front-matter only, before body).
         end = text.find("\n---\n", 4)
+        if end == -1:
+            # Opening `---` but no closing fence: never split a malformed draft
+            # (matches _parse_draft_frontmatter's contract). Safe no-op.
+            return
         head, tail = text[:end], text[end:]
         head = re.sub(r"(?m)^approval_state:.*$", line, head)
         draft_path.write_text(head + tail, encoding="utf-8")
@@ -3829,18 +3869,28 @@ def _set_draft_approval_state(draft_path: Path, approval_state: str) -> None:
         # No front-matter to edit (defensive): nothing durable to rewrite.
         return
     end = text.find("\n---\n", 4)
+    if end == -1:
+        # Opening `---` but no closing fence: refuse to truncate. Safe no-op.
+        return
     draft_path.write_text(text[:end] + f"\n{line}" + text[end:], encoding="utf-8")
 
 
 def prepared_approve_batch(draft_paths: list[Path], fmt: str = "text") -> dict[str, Any]:
     """Approve multiple prepared drafts at once (U11 batch approval).
 
-    Transitions each draft's `approval_state` out of `needs_operator_approval`
-    -> `approved` in both the sidecar and the draft front-matter. This is the
-    human gate clearing a batch of compiled cards for creation. Idempotent and
-    per-draft fault isolated: an unreadable / non-approvable draft (e.g. a
-    blocked draft, which has no approval gate) is reported and skipped, never
-    aborting the rest of the batch.
+    Transitions each draft's `approval_state` from `needs_operator_approval` ->
+    `approved` in both the sidecar and the draft front-matter. This is the human
+    gate clearing a batch of compiled cards for creation.
+
+    Per-draft fault isolated: a missing/malformed/non-gate draft is reported in
+    `skipped` and the rest of the batch still proceeds. Approving an
+    already-`approved` draft is a no-op — it is SKIPPED ("already approved") and
+    its `approved_at`/`updated_at` are preserved, not rewritten.
+
+    Self-defending: readiness is RECONSTRUCTED from disk (re-run the validator
+    on the on-disk body) before approving, so a hand-edited / forged sidecar that
+    claims `needs_operator_approval` over a body that fails validation cannot be
+    pushed to `approved`.
     """
     approved: list[str] = []
     skipped: list[dict[str, str]] = []
@@ -3855,8 +3905,23 @@ def prepared_approve_batch(draft_paths: list[Path], fmt: str = "text") -> dict[s
             skipped.append({"draft": str(draft_path), "reason": f"malformed sidecar: {e}"})
             continue
         current = sidecar.get("approval_state")
+        if current == _APPROVAL_APPROVED:
+            skipped.append({"draft": str(draft_path), "reason": "already approved"})
+            continue
         if current not in _APPROVABLE_APPROVAL_STATES:
             skipped.append({"draft": str(draft_path), "reason": f"approval_state is {current!r}"})
+            continue
+        # Re-derive readiness from the on-disk draft so a tampered sidecar can't
+        # smuggle an unvalidated body past the gate. _read_prepared_issue raises
+        # on a malformed/conflicting draft — treat that as a skip, not an abort.
+        try:
+            issue = _read_prepared_issue(draft_path)
+            readiness = _readiness_for_prepared_issue(issue)
+        except RuntimeError as e:
+            skipped.append({"draft": str(draft_path), "reason": f"unreadable draft: {e}"})
+            continue
+        if not readiness.passed:
+            skipped.append({"draft": str(draft_path), "reason": "fails validation"})
             continue
         _update_sidecar_state(
             draft_path,
@@ -4543,6 +4608,12 @@ def main() -> None:
         action="store_true",
         help="Create the issue before a missing project-mapping PR merges",
     )
+    issue_create_prepared_p.add_argument(
+        "--skip-approval",
+        action="store_true",
+        help="Bypass the Needs Operator Approval gate (operator's direct "
+        "prepare->create path); otherwise approve via `issue approve` first",
+    )
 
     issue_approve_p = issue_sp.add_parser(
         "approve",
@@ -4812,6 +4883,7 @@ def main() -> None:
                     fmt=fmt,
                     auto_confirm=args.yes,
                     override_mapping=args.override_mapping,
+                    skip_approval=args.skip_approval,
                 )
             elif args.action == "approve":
                 prepared_approve_batch([Path(d) for d in args.drafts], fmt=fmt)

--- a/plugins/mission-control/tests/test_issue_create_prepared.py
+++ b/plugins/mission-control/tests/test_issue_create_prepared.py
@@ -125,6 +125,70 @@ def test_blocked_draft_refuses_to_mutate(tmp_path) -> None:
     mock_create.assert_not_called()
 
 
+def test_create_prepared_refuses_unapproved_then_succeeds_after_approval(tmp_path) -> None:
+    """The U11 gate is enforced (FIX 1): a ready-but-unapproved draft is refused
+    with no GitHub mutation, and the same draft creates once approved."""
+    draft = _ready_draft(tmp_path)
+    assert (
+        json.loads(draft.with_suffix(".json").read_text())["approval_state"]
+        == "needs_operator_approval"
+    )
+
+    # Refusal path: load_config / _create_github_issue must never be reached.
+    with (
+        patch.object(sdlc_manager, "load_config") as mock_config,
+        patch.object(sdlc_manager, "_create_github_issue") as mock_create,
+        pytest.raises(RuntimeError, match="awaits operator approval"),
+    ):
+        sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+    mock_config.assert_not_called()
+    mock_create.assert_not_called()
+
+    # Approve, then the same draft creates with no skip_approval override.
+    sdlc_manager.prepared_approve_batch([draft], fmt="text")
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(
+            sdlc_manager,
+            "_create_github_issue",
+            return_value=("https://github.com/infiquetra/hermes-claude-code-router/issues/7", 7),
+        ),
+        patch.object(sdlc_manager, "board_add"),
+        patch.object(sdlc_manager, "flow_set_field"),
+    ):
+        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+
+    assert result["created"] is True
+    assert result["number"] == 7
+
+
+def test_create_prepared_skip_approval_bypasses_gate(tmp_path) -> None:
+    """--skip-approval lets the operator's direct prepare->create path through
+    the gate without an explicit approve step (FIX 1)."""
+    draft = _ready_draft(tmp_path)
+
+    with (
+        patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
+        patch.object(sdlc_manager, "_repo_missing_labels", return_value=[]),
+        patch.object(sdlc_manager, "_repo_missing_templates", return_value=[]),
+        patch.object(
+            sdlc_manager,
+            "_create_github_issue",
+            return_value=("https://github.com/infiquetra/hermes-claude-code-router/issues/9", 9),
+        ),
+        patch.object(sdlc_manager, "board_add"),
+        patch.object(sdlc_manager, "flow_set_field"),
+    ):
+        result = sdlc_manager.issue_create_prepared(
+            draft, fmt="text", auto_confirm=True, skip_approval=True
+        )
+
+    assert result["created"] is True
+    assert result["number"] == 9
+
+
 def test_declined_confirmation_applies_no_mutation(tmp_path) -> None:
     draft = _ready_draft(tmp_path)
 
@@ -135,14 +199,22 @@ def test_declined_confirmation_applies_no_mutation(tmp_path) -> None:
         patch.object(sdlc_manager, "_safe_input", return_value="n"),
         patch.object(sdlc_manager, "_create_github_issue") as mock_create,
     ):
-        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=False)
+        # skip_approval: this test exercises create *mechanics* (declined
+        # confirmation), not the U11 approval gate (covered separately below).
+        result = sdlc_manager.issue_create_prepared(
+            draft, fmt="text", auto_confirm=False, skip_approval=True
+        )
 
     assert result == {"created": False, "reason": "declined"}
     mock_create.assert_not_called()
 
 
 def test_create_prepared_creates_issue_and_marks_draft(tmp_path) -> None:
+    # Models the REAL operator flow end to end: prepare -> approve -> create.
+    # No skip_approval — creation proceeds because the draft was approved first.
     draft = _ready_draft(tmp_path)
+    sdlc_manager.prepared_approve_batch([draft], fmt="text")
+    assert json.loads(draft.with_suffix(".json").read_text())["approval_state"] == "approved"
 
     with (
         patch.object(sdlc_manager, "load_config", return_value=_mapped_config()),
@@ -191,7 +263,10 @@ def test_missing_mapping_opens_pr_and_stops_without_override(tmp_path) -> None:
         patch.object(sdlc_manager, "_open_mapping_pr", return_value="https://github.com/pr/1"),
         patch.object(sdlc_manager, "_create_github_issue") as mock_create,
     ):
-        result = sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+        # skip_approval: exercises the missing-mapping stop, not the approval gate.
+        result = sdlc_manager.issue_create_prepared(
+            draft, fmt="text", auto_confirm=True, skip_approval=True
+        )
 
     assert result == {"created": False, "mapping_pr_url": "https://github.com/pr/1"}
     mock_create.assert_not_called()
@@ -219,11 +294,13 @@ def test_override_mapping_creates_issue_and_records_pending_mapping(tmp_path) ->
         patch.object(sdlc_manager, "board_add"),
         patch.object(sdlc_manager, "flow_set_field"),
     ):
+        # skip_approval: exercises the override-mapping create path, not the gate.
         result = sdlc_manager.issue_create_prepared(
             draft,
             fmt="text",
             auto_confirm=True,
             override_mapping=True,
+            skip_approval=True,
         )
 
     assert result["created"] is True
@@ -250,7 +327,8 @@ def test_missing_labels_and_templates_are_deployed_after_confirmation(tmp_path) 
         patch.object(sdlc_manager, "board_add"),
         patch.object(sdlc_manager, "flow_set_field"),
     ):
-        sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True)
+        # skip_approval: exercises label/template deploy mechanics, not the gate.
+        sdlc_manager.issue_create_prepared(draft, fmt="text", auto_confirm=True, skip_approval=True)
 
     mock_labels.assert_called_once_with("hermes-claude-code-router", fmt="text")
     mock_templates.assert_called_once_with("hermes-claude-code-router", fmt="text")

--- a/plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+++ b/plugins/mission-control/tests/test_issue_prepare_compile_approve.py
@@ -54,6 +54,40 @@ _none_
 """
 
 
+# A body with ALL required H3 sections present and a checklist item, but whose
+# acceptance criterion names NO runnable check (no `code span`, no fenced block
+# in the acceptance section). This trips ONLY the executable-acceptance check
+# (U8/KTD8), proving the gate covers more than absent-headers. Verification still
+# has its own fenced block so the failure is isolated to acceptance executability.
+NON_EXECUTABLE_ACCEPTANCE_BODY = """### Objective
+Add a prepared issue workflow.
+
+### Intent
+Authoring agents need a draft-then-approve path; without it cards skip review.
+End-state: every prepared card is drafted, gated, and only then created.
+
+### Acceptance criteria
+- [ ] The prepared draft is reviewed and looks correct to the operator
+
+### Out-of-scope / non-goals
+- Do not auto-move issues to Ready
+
+### Files expected to change
+plugins/mission-control/scripts/sdlc_manager.py
+
+### Tests to add or update
+plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+
+### Verification
+```bash
+uv run pytest plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+```
+
+### Context library links
+_none_
+"""
+
+
 def _prepare_olympus(tmp_path: Path, *, title: str, source: str = OLYMPUS_BODY) -> Path:
     """Prepare an olympus capability draft offline and return its path."""
     return sdlc_manager.issue_prepare(
@@ -126,6 +160,47 @@ def test_batch_approval(tmp_path) -> None:
         assert "approval_state: approved" in draft.read_text()
 
 
+def test_batch_approval_is_idempotent_and_preserves_timestamp(tmp_path) -> None:
+    """FIX 4: re-approving an already-approved draft is a no-op — it is SKIPPED
+    ("already approved") and approved_at/updated_at are NOT rewritten."""
+    draft = _prepare_olympus(tmp_path, title="Idempotent card")
+
+    first = sdlc_manager.prepared_approve_batch([draft], fmt="text")
+    assert first["approved"] == [str(draft)]
+    after_first = _sidecar(draft)
+    approved_at = after_first["approved_at"]
+    updated_at = after_first["updated_at"]
+
+    # Second approve: skipped, timestamps frozen (true no-op, not a re-stamp).
+    second = sdlc_manager.prepared_approve_batch([draft], fmt="text")
+    assert second["approved"] == []
+    assert second["skipped"] == [{"draft": str(draft), "reason": "already approved"}]
+    after_second = _sidecar(draft)
+    assert after_second["approved_at"] == approved_at
+    assert after_second["updated_at"] == updated_at
+
+
+def test_batch_approval_rejects_tampered_sidecar(tmp_path) -> None:
+    """FIX 3: approval re-derives readiness from the on-disk body, so a sidecar
+    hand-edited to `needs_operator_approval` over a body that FAILS the validator
+    is skipped ("fails validation"), never approved."""
+    # Start from a blocked draft (body fails the validator), then forge its
+    # sidecar approval_state to look like it cleared the compile gate.
+    draft = _prepare_olympus(tmp_path, title="Forged card", source="Just ship it.")
+    sidecar_path = draft.with_suffix(".json")
+    tampered = _sidecar(draft)
+    assert tampered["readiness"]["passed"] is False  # body really is invalid
+    tampered["approval_state"] = "needs_operator_approval"
+    sidecar_path.write_text(json.dumps(tampered))
+
+    result = sdlc_manager.prepared_approve_batch([draft], fmt="text")
+
+    assert result["approved"] == []
+    assert result["skipped"] == [{"draft": str(draft), "reason": "fails validation"}]
+    # The forged draft was NOT pushed to approved.
+    assert _sidecar(draft)["approval_state"] == "needs_operator_approval"
+
+
 def test_batch_approval_skips_blocked_draft(tmp_path) -> None:
     """A blocked draft has no approval gate; batch approval skips it, fault
     isolated, without aborting the rest of the batch."""
@@ -163,6 +238,21 @@ def test_validator_gates_agent_output(tmp_path) -> None:
     assert blocked_sidecar["state"] == "blocked"
     assert blocked_sidecar["approval_state"] is None
     assert "approval_state" not in blocked.read_text()
+
+    # Second malformed case (FIX 6): ALL required H3 sections present, but the
+    # acceptance criterion names no runnable check. This proves the gate covers
+    # the executable-acceptance contract (U8/KTD8), not just absent headers.
+    non_exec_ok, non_exec_errors = sdlc_manager.validate_card_body(NON_EXECUTABLE_ACCEPTANCE_BODY)
+    assert non_exec_ok is False
+    assert any("not executable" in err for err in non_exec_errors)
+
+    non_exec = _prepare_olympus(
+        tmp_path, title="Non-executable acceptance", source=NON_EXECUTABLE_ACCEPTANCE_BODY
+    )
+    non_exec_sidecar = _sidecar(non_exec)
+    assert non_exec_sidecar["readiness"]["passed"] is False
+    assert non_exec_sidecar["state"] == "blocked"
+    assert non_exec_sidecar["approval_state"] is None
 
     # The same gate lets a valid body through to the approval gate.
     valid_ok, _ = sdlc_manager.validate_card_body(OLYMPUS_BODY)

--- a/plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+++ b/plugins/mission-control/tests/test_issue_prepare_compile_approve.py
@@ -1,0 +1,174 @@
+"""Tests for the U11 prepared-issue compile + approve flow.
+
+Covers the four U11 pieces layered on the existing prepare/sidecar machinery:
+  1. project-field population in the sidecar (offline, derived from metadata),
+  2. the durable `needs_operator_approval` human gate,
+  3. batch approval out of that gate, and
+  4. the Phase C validator (`validate_card_body`) as the compile-time acceptance
+     gate on agent output (KTD9).
+
+Mirrors the fixtures/conventions in test_issue_prepare.py: tmp_path-scoped,
+fully offline (no live GitHub call), sidecar read back as JSON.
+"""
+
+# ruff: noqa: E402,I001
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import sdlc_manager  # noqa: E402
+
+
+# A cleanly-compiling olympus card body: carries the always-required Intent (R1)
+# + Context library links (R4), and the acceptance criteria name a runnable
+# check (R2/KTD8). Same shape as the OLYMPUS_BODY fixture in test_issue_prepare.
+OLYMPUS_BODY = """### Objective
+Add a prepared issue workflow.
+
+### Intent
+Authoring agents need a draft-then-approve path; without it cards skip review.
+End-state: every prepared card is drafted, gated, and only then created.
+
+### Acceptance criteria
+- [ ] Drafts are written before GitHub mutation; `uv run pytest plugins/mission-control/tests/test_issue_prepare_compile_approve.py` exits 0
+
+### Out-of-scope / non-goals
+- Do not auto-move issues to Ready
+
+### Files expected to change
+plugins/mission-control/scripts/sdlc_manager.py
+
+### Tests to add or update
+plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+
+### Verification
+```bash
+uv run pytest plugins/mission-control/tests/test_issue_prepare_compile_approve.py
+```
+
+### Context library links
+_none_
+"""
+
+
+def _prepare_olympus(tmp_path: Path, *, title: str, source: str = OLYMPUS_BODY) -> Path:
+    """Prepare an olympus capability draft offline and return its path."""
+    return sdlc_manager.issue_prepare(
+        repo="hermes-claude-code-router",
+        issue_type="capability",
+        team="olympus",
+        project="mount-olympus",
+        source=source,
+        title=title,
+        status=None,
+        risk="medium",
+        mode=None,
+        draft_dir=tmp_path,
+    )
+
+
+def _sidecar(draft: Path) -> dict:
+    return json.loads(draft.with_suffix(".json").read_text())
+
+
+def test_issue_prepare_populates_project_fields(tmp_path) -> None:
+    """Preparing a draft records the project-field values in the sidecar."""
+    draft = _prepare_olympus(tmp_path, title="Project fields populated")
+
+    fields = _sidecar(draft)["project_fields"]
+
+    # Issue type + Risk come straight from metadata; Lifecycle Origin is the
+    # auto-populated field (R10) carrying the handoff maturity that drove this
+    # draft. No source artifact was supplied, so no Objective is invented.
+    assert fields["Issue Type"] == "capability"
+    assert fields["Technical Risk"] == "medium"
+    assert fields["Lifecycle Origin"] == "requirements-ready"
+    assert "Objective" not in fields
+
+
+def test_needs_operator_approval_state(tmp_path) -> None:
+    """A cleanly-compiled prepared issue lands in Needs Operator Approval."""
+    draft = _prepare_olympus(tmp_path, title="Needs approval")
+
+    sidecar = _sidecar(draft)
+
+    # Durable in the sidecar...
+    assert sidecar["readiness"]["passed"] is True
+    assert sidecar["approval_state"] == "needs_operator_approval"
+    # ...and durable in the draft front-matter (what an operator reading the
+    # markdown directly sees). NOT auto-created: the creation-pipeline state is
+    # still the pre-create ready_to_create, never `created`.
+    assert "approval_state: needs_operator_approval" in draft.read_text()
+    assert sidecar["state"] == "ready_to_create"
+
+
+def test_batch_approval(tmp_path) -> None:
+    """Batch approval transitions multiple prepared drafts out of the gate."""
+    first = _prepare_olympus(tmp_path, title="Batch card one")
+    second = _prepare_olympus(tmp_path, title="Batch card two")
+
+    # Pre-condition: both sit in the approval gate.
+    assert _sidecar(first)["approval_state"] == "needs_operator_approval"
+    assert _sidecar(second)["approval_state"] == "needs_operator_approval"
+
+    result = sdlc_manager.prepared_approve_batch([first, second], fmt="text")
+
+    assert result["approved"] == [str(first), str(second)]
+    assert result["skipped"] == []
+    for draft in (first, second):
+        sidecar = _sidecar(draft)
+        assert sidecar["approval_state"] == "approved"
+        assert "approved_at" in sidecar
+        # Front-matter is kept in lockstep with the sidecar.
+        assert "approval_state: approved" in draft.read_text()
+
+
+def test_batch_approval_skips_blocked_draft(tmp_path) -> None:
+    """A blocked draft has no approval gate; batch approval skips it, fault
+    isolated, without aborting the rest of the batch."""
+    good = _prepare_olympus(tmp_path, title="Approvable card")
+    blocked = _prepare_olympus(tmp_path, title="Blocked card", source="Just ship it.")
+
+    # The blocked draft never entered the gate.
+    assert _sidecar(blocked)["approval_state"] is None
+
+    result = sdlc_manager.prepared_approve_batch([good, blocked], fmt="text")
+
+    assert result["approved"] == [str(good)]
+    assert len(result["skipped"]) == 1
+    assert result["skipped"][0]["draft"] == str(blocked)
+    # The blocked draft is untouched by approval.
+    assert _sidecar(blocked)["approval_state"] is None
+
+
+def test_validator_gates_agent_output(tmp_path) -> None:
+    """KTD9: a body that fails validate_card_body is rejected by prepare (does
+    NOT reach approval); a valid body passes through to the gate."""
+    # A malformed agent body: missing required H3 sections, no executable
+    # acceptance, no fenced verification. validate_card_body must reject it.
+    malformed = "Implement the prepared issue workflow somehow."
+    invalid_ok, invalid_errors = sdlc_manager.validate_card_body(malformed)
+    assert invalid_ok is False
+    assert invalid_errors  # the gate produced concrete findings
+
+    blocked = _prepare_olympus(tmp_path, title="Malformed agent output", source=malformed)
+    blocked_sidecar = _sidecar(blocked)
+
+    # Rejected at prepare time: blocked, never reaches the approval gate, and the
+    # validator findings are surfaced as blocking readiness gaps.
+    assert blocked_sidecar["readiness"]["passed"] is False
+    assert blocked_sidecar["state"] == "blocked"
+    assert blocked_sidecar["approval_state"] is None
+    assert "approval_state" not in blocked.read_text()
+
+    # The same gate lets a valid body through to the approval gate.
+    valid_ok, _ = sdlc_manager.validate_card_body(OLYMPUS_BODY)
+    assert valid_ok is True
+
+    passing = _prepare_olympus(tmp_path, title="Valid agent output")
+    passing_sidecar = _sidecar(passing)
+    assert passing_sidecar["readiness"]["passed"] is True
+    assert passing_sidecar["approval_state"] == "needs_operator_approval"


### PR DESCRIPTION
## U11 — prepare → compile → approve (Phase D, authoring inversion)

Finishes the intent→compile→approve flow on mission-control's existing prepared-issue machinery. Single file + tests; builds on the Phase C contract.

> **Stacked PR.** Base is `feat/context-package` (the plugins Phase C branch, PR #218) because U11 builds on the Phase C validator/vendored-data. **Merge #218 first**, then this. The diff shown here is the U11 delta only.

### What changed
- **Project-field population (offline).** `prepare` records the card's project-field values in the sidecar (`Issue Type`, `Technical Risk`, the auto-populated `Lifecycle Origin` per R10, and `Objective` only when the handoff source names one). Values are *recorded* for a later create-time consumer — consumption is a follow-up unit, not wired here (the docstring says so explicitly).
- **Durable `Needs Operator Approval` gate.** Modeled as a separate `approval_state` axis, orthogonal to the creation-pipeline `state` (so the existing readiness/create-prepared contract is untouched). A cleanly-compiled draft lands in `needs_operator_approval`, recorded in both the sidecar and the draft front-matter; a blocked draft never enters the gate.
- **Enforced at create.** `create-prepared` refuses a draft in `needs_operator_approval` (before any GitHub call) unless `--skip-approval` is passed. Agent-prepared cards must be approved (`issue approve <drafts...>`, batch) first; the operator's direct path uses `--skip-approval`. The gate defaults ON; the override is explicit, named, and auditable.
- **Self-defending approval.** `prepared_approve_batch` re-derives readiness from the on-disk body before approving, so a hand-edited/forged sidecar can't push an unvalidated body to `approved`. Idempotent (already-approved drafts skipped, `approved_at` preserved) and per-draft fault-isolated.
- **KTD9.** The Phase C validator (`validate_card_body`, run inside the olympus readiness profile) is the compile-time acceptance gate: a malformed agent body — including one with all headers but non-executable acceptance — fails readiness, is forced to `blocked`, and provably never reaches approval.

### Gates
- **Review consensus 5/5 ACCEPT** — devils-advocate 9.4, security 9.5, architecture 9.3, code-quality 9.4, testing 9.2 (cycle 2, after enforcing the gate + 5 robustness/test fixes from cycle 1).
- **Security:** manual review verified the gate is fail-closed AND enforcing, the forge path closed at both gates (defense in depth), no new subprocess/eval/secrets; Bandit shows only Low-severity pre-existing (`gh` shim) + intentional fault-isolation (B112) patterns.
- **Tests:** 24 (up from 13). Full plugins suite green except the known cross-repo `test_required_headers_match_actual_issue_templates` (skips in CI; fails locally only until sdlc Intent templates merge). `ruff check` + `ruff format --check` clean.

Merge held for operator.
