### PR TITLE
chore(mission-control): publish contract sync metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -345,8 +345,8 @@
     {
       "name": "mission-control",
       "source": "./plugins/mission-control",
-      "version": "2.0.0",
-      "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and Mount Olympus boards. Adds prepared issue drafts, board management, project fields, labels, flow metrics, milestones, and rollout helpers via Python CLI.",
+      "version": "2.1.0",
+      "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and CAMPPS boards. Adds prepared issue drafts, live schema sync, project fields, labels, metrics, milestones, and rollout helpers via Python CLI.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"
@@ -358,7 +358,7 @@
         "kanban",
         "project-management",
         "github-projects",
-        "mount-olympus",
+        "campps",
         "asgard",
         "jeff-intent",
         "project-fields",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,12 @@ plugin-name/
 3. Write tests in `tests/` for CLI plugins
 4. Document in README.md
 5. Add entry to `.claude-plugin/marketplace.json`
-6. Submit PR for review
+6. For every plugin behavior, schema, command, prompt, or user-facing guidance change, update the
+   plugin release surfaces in the same PR: `plugins/<plugin>/.claude-plugin/plugin.json`,
+   `.claude-plugin/marketplace.json`, `plugins/<plugin>/CHANGELOG.md`, and any version/metadata
+   drift guard tests. Do not treat code/tests as PR-ready until installed-plugin metadata tells the
+   same story as the diff.
+7. Submit PR for review
 
 ## Running Quality Checks
 

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,36 @@
 
 ## 2026-06-17
 
+### Plugin behavior can ship while installed metadata still advertises the old contract  {#plugin-release-metadata-is-a-release-surface}
+
+**Context.** PR #224 shipped the mission-control issue-contract sync and SDLC schema refresh, but the
+plugin manifest, marketplace entry, and changelog did not move with it. The installed plugin still
+advertised `mission-control` `2.0.0` and described Mount Olympus as an active board after the code and
+vendored schema had moved to the Jeff Intent / Asgard / CAMPPS active-board model.
+
+**Evidence.** After PR #224 merged as `898cc8e`, `plugins/mission-control/.claude-plugin/plugin.json` and
+`.claude-plugin/marketplace.json` still listed `version: 2.0.0`, and `plugins/mission-control/CHANGELOG.md`
+had no `2.1.0` release notes for the contract/schema change. Follow-up PR #225 fixes the metadata and
+adds this release-closeout rule to `AGENTS.md`.
+
+**Mechanism.** The implementation diff made code, schema, tests, and receipts correct, but the release
+surfaces are independent files outside the runtime path. CI validated the plugin shape and tests, yet it
+could not infer that a behavior/schema change should bump metadata and update upgrade notes unless the
+version guard and process checklist demand it.
+
+**Fix.** Bump `mission-control` plugin and marketplace metadata to `2.1.0`, add changelog migration notes,
+and extend the prompt-alignment test to assert the new version and active-board metadata.
+
+**Validation.** `python3 -m json.tool` on both JSON files, `uv run pytest
+plugins/mission-control/tests/test_prompt_alignment.py -q`, `uv run python marketplace/validator/validate.py`,
+and CI on PR #225.
+
+**Generalizable rule.** A plugin release is not complete when code is correct. For any plugin behavior,
+schema, command, prompt, or guidance change, update `plugin.json`, the marketplace entry, changelog, and
+version/metadata drift tests in the same PR before calling the branch PR-ready.
+
+**Refs.** LEARNINGS [#marketplace-drift](#marketplace-drift); AGENTS.md Development Workflow.
+
 ### Issue-contract consumers need both generated data and source-schema drift guards  {#issue-contract-consumer-schema-and-data-guards}
 
 **Context.** Issue #222 reported mission-control drift from the current Hermes issue contract. The generated

--- a/plugins/mission-control/.claude-plugin/plugin.json
+++ b/plugins/mission-control/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "mission-control",
-  "version": "2.0.0",
-  "description": "SDLC management for Jeff Intent, Asgard, and Mount Olympus: prepared issue drafts, board schemas, labels, project fields, sub-issues, metrics, and card validation.",
+  "version": "2.1.0",
+  "description": "SDLC management for Jeff Intent, Asgard, and CAMPPS: prepared issue drafts, live schema sync, board schemas, labels, project fields, metrics, and card validation.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "sub-issues", "mount-olympus", "asgard", "jeff-intent"]
+  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "sub-issues", "campps", "asgard", "jeff-intent"]
 }

--- a/plugins/mission-control/CHANGELOG.md
+++ b/plugins/mission-control/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — mission-control
 
+## [2.1.0] — 2026-06-17
+
+### Migration notes
+- Mission Control now treats Jeff Intent, Asgard, and CAMPPS as the active board surfaces.
+  Mount Olympus remains historical context in the vendored SDLC schema and should not be used as
+  an active routing target for new work.
+- `sdlc-schema.json` resolves from `infiquetra-sdlc` on GitHub `main` before falling back to the
+  vendored snapshot, so operators are less likely to read stale local checkout state.
+
+### Changed
+- Re-vendored the current `infiquetra-sdlc` schema snapshot at `schema_version: 2026-06-17`.
+- Prepared actionable issue drafts now compile fallback bodies from generated SDLC issue-contract
+  data instead of hand-written prompt template sections.
+- Readiness validation now applies issue-type and risk-aware required fields, including high-risk
+  sections and empty-section rejection.
+- Updated issue command and skill guidance to route through `issue prepare` for generated contract
+  bodies.
+- Bumped plugin and marketplace metadata to `2.1.0`.
+
 ## 1.6.1 - 2026-05-31
 
 ### Changed

--- a/plugins/mission-control/tests/test_prompt_alignment.py
+++ b/plugins/mission-control/tests/test_prompt_alignment.py
@@ -19,9 +19,13 @@ def test_sdlc_manager_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "mission-control")
 
     assert plugin_json["name"] == "mission-control"
-    assert plugin_json["version"] == "2.0.0"
+    assert plugin_json["version"] == "2.1.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/mission-control"
+    assert "CAMPPS" in plugin_json["description"]
+    assert "Mount Olympus" not in plugin_json["description"]
+    assert "campps" in plugin_json["keywords"]
+    assert "mount-olympus" not in plugin_json["keywords"]
     assert "Jeff Intent" in entry["description"]
     assert "Beads" not in entry["description"]
     assert "beads" not in entry["keywords"]


### PR DESCRIPTION
## Summary

Mission Control's release metadata now reflects the contract/schema sync that just shipped. The plugin manifest and marketplace entry are bumped to `2.1.0`, advertise Jeff Intent, Asgard, and CAMPPS as the active surfaces, and no longer describe Mount Olympus as an active board.

The changelog now includes upgrade notes for the `2026-06-17` SDLC schema refresh, live schema resolution, generated contract bodies, and risk-aware readiness validation.

## Tests

- `python3 -m json.tool plugins/mission-control/.claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `uv run pytest plugins/mission-control/tests/test_prompt_alignment.py -q`
- `uv run python marketplace/validator/validate.py`
- `uv run ruff check plugins/mission-control/tests/test_prompt_alignment.py`
- `uv run python -m ruff format --check plugins/mission-control/tests/test_prompt_alignment.py`
