### PR TITLE
docs(saga): global transcendent-learnings design package

### DIFF
--- a/docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md
+++ b/docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md
@@ -1,0 +1,149 @@
+---
+date: 2026-06-20
+topic: global-transcendent-learnings
+maturity: requirements-ready
+source: docs/ideation/2026-06-19-global-engineering-journal-ideation.md (survivors #1 derived-rollup + #2 retro-promote, reshaped)
+---
+
+# Global Transcendent-Learnings Layer
+
+## Summary
+
+A global layer that promotes the *select few* learnings which genuinely cross repositories into the `infiquetra-context-library` engineering journal as distilled org standards. The per-repo journals stay the system of record; the global layer is a small, derived, pull-only set — not an aggregate of every journal.
+
+## Problem Frame
+
+The per-repo engineering journal works. Roughly 785 `**Generalizable rule.**` lines now exist across 30 repos — but each is a silo with zero rollup, so a lesson learned in one repo is invisible when the same mistake reappears in another. The instinct was to harvest all 785 into one generated `GLOBAL_LEARNINGS.md`.
+
+That instinct is wrong, and naming why is the whole frame. The `Generalizable rule` marker means "generalized *from* the incident" — within-repo, usually domain-bound (an Ansible `selectattr`/`loop_control.label` lesson is useless outside the home-lab). It does **not** mean "transcends repositories." Bulk-harvesting conflates the two senses of "general" and produces a duplicated, context-bloating file nobody wants.
+
+The real gap is a handful of learnings that *do* transcend any single repo, with no home and no path to get there. The cost today is silent re-learning: the same cross-cutting lesson rediscovered repo by repo because the transcendent few are buried in an undifferentiated long tail.
+
+## Key Decisions
+
+The framing choices that constrain everything below.
+
+- **Global means the transcendent subset, never the aggregate.** The deliverable is the select learnings that cross repos, not a roll-up of all 785. This kills the harvest-everything model outright; the 785 stay where they are.
+- **Two feeders: declare + recurrence net.** Transcendence is caught at write time (a marker applied when the lesson is known to cross repos) *and* by a periodic safety-net sweep that catches what declaration missed. Neither alone is trusted to be complete.
+- **Home is the context-library journal, pull-only.** Promoted learnings land in `infiquetra-context-library/docs/engineering-journal/LEARNINGS.md` and are read on demand. No new aggregate file, no always-loaded hot tier in this build — so the layer costs zero context budget at rest.
+- **Promotion is copy + backlink, not move.** The distilled lesson is copied up with a backlink to its origin; the source entry stays put as the incident record. Idempotency keys on the lesson's drift-stable identity (a content hash or assigned ID), not on line position — so the backlinks stay a pure provenance trail while re-runs reliably skip what is already promoted.
+- **What lands is Rule + Mechanism, readable cold.** A promoted entry is self-contained — the generalizable rule plus the why — stripped of incident-specific cruft, understandable without opening the source repo.
+- **`/retro`'s single-repo boundary stays intact.** Per-repo `/retro` only *marks* transcendence locally; it never writes across repos. The cross-repo write lives in a new workspace-level pass, `/retro`'s sibling.
+- **Agent judgment, not vectors.** The recurrence sweep reads the `Generalizable rule` lines (which fit one context window today) and clusters by judgment. No embeddings, no RAG, no re-index tax.
+- **Every context-library write is gated.** Promotions are proposed as a diff and wait for human approval before anything is written — these become org standards, so a human signs off.
+
+## Requirements
+
+What must be true of the layer. IDs are stable and referenced by the flows and acceptance examples below.
+
+**Selection & marking (the declare feeder)**
+
+- R1. A transcendence marker exists that is greppable and visually distinct from `**Generalizable rule.**`, applied inline alongside the source learning in its own repo's `LEARNINGS.md`.
+- R2. `/retro` gains a step that applies the marker when a learning passes the transcendence test — *would this rule hold and help in a repo of a different stack or domain?* — operating only within the repo it is run in.
+- R3. A human can apply the marker to any learning at any time, independent of `/retro`, using the same transcendence test.
+- R4. Marking introduces no cross-repo write; `/retro`'s single-repo safety boundary is preserved exactly as it is today.
+
+**Recurrence detection (the recurrence-net feeder)**
+
+- R5. A workspace-level pass reads `Generalizable rule` lines from the `docs/engineering-journal/` directories of all repos under the Infiquetra workspace root (the directory that parents the repos) as its candidate pool; whether a line counts as not-yet-promoted is determined by the dedup ledger (R12), not by mutating the source — source markers persist in place.
+- R6. The pass clusters "same lesson appearing in multiple repos" by agent judgment over that text — no vector store, no embeddings.
+- R7. The pass nominates a cluster for promotion when the lesson recurs across at least two distinct repos by default — the literal meaning of recurrence — with the threshold configurable and raisable if nominations prove noisy.
+
+**Promotion (the global pass → context-library)**
+
+- R8. Promotion writes a self-contained entry — the generalizable rule plus its mechanism — into the context-library journal, readable without opening the source repo.
+- R9. Each promoted entry carries one or more backlinks to its origin(s) as `repo/path:line` references for human navigation; these are provenance pointers that may drift as source files grow, not the idempotency key (R12).
+- R10. The source entry is left in place as the incident record; promotion copies, never moves or deletes.
+- R11. Every write into the context-library journal is gated: the pass proposes a diff and waits for explicit human approval before writing.
+- R12. The pass is idempotent — dedup keys on each lesson's drift-stable identity (a content hash of its rule and mechanism, or an assigned lesson ID), so a lesson already promoted is never promoted again even as source line numbers shift.
+- R13. A recurrence cluster upserts a single context-library entry — matched by the lesson's stable identity (R12) — carrying one backlink per source repo rather than one entry per repo; backlink count is the transcendence signal.
+- R14. The pass excludes the context-library's own journal from its candidate pool, so promoted entries never feed themselves.
+
+**Recall & cost**
+
+- R15. Promoted learnings are consumed pull-only — grepped or read from the context-library journal on demand — with no automatic injection into sessions.
+- R16. The ~785 existing learnings remain in their repos, untouched and individually searchable; they are the long tail, not migrated.
+
+**Invocation**
+
+- R17. The global pass runs manually on demand as an invocable skill; scheduled or automatic invocation is deferred.
+
+## Key Flows
+
+The two paths a learning can travel from a repo to the global layer.
+
+**F1. Declaration-driven promotion**
+
+- **Trigger:** `/retro` (R2) or a human (R3) marks a learning transcendent in its repo's `LEARNINGS.md`.
+- The marker sits locally until the next global-pass run — no cross-repo write happens at mark time (R4).
+- On the next run, the pass collects marked learnings, distills each to Rule + Mechanism, and proposes a copy-up with a backlink to the source (R8, R9, R10).
+- The human approves or rejects each proposed entry; only approved entries are written to the context-library journal (R11).
+
+**F2. Recurrence-net promotion**
+
+- **Trigger:** the global pass runs and reads all not-yet-promoted `Generalizable rule` lines as its pool (R5), excluding the context-library's own journal (R14).
+- It clusters same-lesson-across-repos by judgment (R6) and keeps clusters that clear the recurrence threshold (R7).
+- For each surviving cluster it proposes a single upserted entry carrying one backlink per source repo (R13); already-backlinked sources are skipped as duplicates (R12).
+- The human approves or rejects each proposal before any write (R11).
+
+## Acceptance Examples
+
+The conditional requirements, pinned so planning cannot reinvent the edge behavior.
+
+- AE1. **Covers R12.** When the pass runs and a lesson's stable identity already exists in the context-library journal, that lesson produces no new or duplicate entry — even if its source line number has since shifted.
+- AE2. **Covers R7.** When a lesson is judged to recur across at least the threshold number of distinct repos, it is nominated; when it appears in fewer, it is not.
+- AE3. **Covers R13.** When a recurrence cluster spans three repos, the pass proposes one context-library entry with three backlinks — not three separate entries.
+- AE4. **Covers R14.** When the pass builds its candidate pool, `Generalizable rule` lines already living in the context-library's own journal are excluded from clustering and nomination.
+- AE5. **Covers R2, R11, R15.** When a learning is marked transcendent, it does not appear in the context-library journal at mark time; it appears only after a subsequent pass run and only after the human approves the proposed entry.
+
+## Scope Boundaries
+
+What this build deliberately does not do.
+
+- **No aggregate `GLOBAL_LEARNINGS.md` and no bulk-copy of the 785.** This is the rejected harvest model; the long tail stays distributed.
+- **No vectors, RAG, or embeddings.** Agent judgment over greppable text is the chosen mechanism (revivable cut R2 stays rejected).
+- **No always-loaded hot tier and no auto-memory-dir population.** That is survivor #4 — deferred, and addable later with no rework here, since it would simply read the most-backlinked context-library entries.
+- **No `/recall` skill, no Todoist integration, no dedicated journal git repo.** Survivors #3, #6, and #5 are out of this build's scope.
+- **No cross-machine sync engineering.** The context-library is already a git repo, so durability and sync ride along for free; building a sync mechanism is not in scope.
+- **No scheduling or automation of the pass.** Manual invocation only for now (R17).
+- **No write-back to source repos from the global pass.** The pass writes only to the context-library journal; source-repo markers are written locally by `/retro` or a human, never by the global pass.
+
+## Success Criteria
+
+Signals that the layer is doing its job, beyond the requirements being met.
+
+- Zero context-budget cost at rest — nothing about the layer auto-loads into a session.
+- A reader can grep the context-library journal for an org standard and trace it back to the originating incident through its backlink.
+- Re-running the pass is safe and boring — no duplicate proliferation, ever (the drift-stable dedup ledger holds).
+- A promoted entry reads correctly cold, with no need to open the source repo to understand it.
+- The 785 per-repo learnings are demonstrably untouched, and `/retro` still performs no cross-repo writes.
+
+## Dependencies / Assumptions
+
+Upstream facts the design leans on, including the ones worth revisiting as scale grows.
+
+- Depends on `infiquetra-context-library` existing with an active `docs/engineering-journal/` (verified present this session: `LEARNINGS.md` ~17KB, 50+ dated entries).
+- Depends on the `**Generalizable rule.**` marker being a stable, greppable anchor (verified: 785 marker lines across 30 repos; 602 in canonical form; 778 carry the lesson text inline on the same line).
+- **Scaling assumption:** the candidate pool fits one context window, which is what makes "judgment, not vectors" viable. True at ~785 lines today; revisit when the corpus outgrows a single window.
+- **Format-tolerance assumption:** the recurrence pass must normalize across the 13+ observed marker variants (canonical, leading-space, colon-terminated, heading-form, bare), not just the canonical 571 — a planning-level detail, but a real one.
+- Assumes `/retro` can host a marking step inside its existing per-repo, gated, propose-diff structure (verified: `/retro` is prompt-driven and single-repo; the marking step fits its local-curation phase).
+
+## Outstanding Questions
+
+All deferred to planning — none is an open product decision that blocks `/plan`.
+
+- The exact marker string and syntax for declaration (distinct from `Generalizable rule`, cleanly greppable).
+- Whether the default recurrence threshold of two repos should be raised, once real nomination noise is observed.
+- Whether the global pass is a brand-new skill or an extension of an existing one, and its name.
+- The context-library entry template — how rule, mechanism, and multiple backlinks render in one entry.
+- The exact drift-stable dedup key — a content hash of the rule and mechanism versus an assigned lesson ID — and how the `repo/path:line` backlink pointer is refreshed when source lines move.
+- Whether declared-but-not-yet-promoted learnings should also flow through recurrence clustering (likely yes, so a declared lesson can still merge with undeclared siblings).
+
+## Sources / Research
+
+Breadcrumbs a planner reading cold would want.
+
+- `docs/ideation/2026-06-19-global-engineering-journal-ideation.md` — the ideation this deep-dives; survivors #1 and #2, reshaped after the aggregate-harvest model was rejected.
+- `plugins/saga/skills/retro/SKILL.md` and `plugins/saga/skills/retro/references/self-edit-safety.md` — `/retro`'s gated, single-repo safety model; the boundary R4 preserves and the propose-diff pattern R11 reuses.
+- `infiquetra-context-library/docs/engineering-journal/LEARNINGS.md` — the promotion destination.
+- Marker scan (this session): 785 lines / 30 repos / 33 journal dirs; 602 canonical, 778 inline — the basis for the single-window recurrence pass and the format-tolerance assumption.

--- a/docs/ideation/2026-06-19-global-engineering-journal-ideation.md
+++ b/docs/ideation/2026-06-19-global-engineering-journal-ideation.md
@@ -1,0 +1,245 @@
+---
+date: 2026-06-19
+topic: global-engineering-journal
+focus: Elevate the per-repo engineering journal to a global (workspace/machine/cross-machine) level
+scope: broad
+repo: infiquetra-claude-plugins
+maturity: idea-ready
+---
+
+# Ideation: Global Engineering Journal
+
+Run-id `3d0b82f0`. Cross-cutting / workspace-global run (cwd was the non-git workspace root
+`~/workspace/infiquetra`, not a single repo); saved here because most actionable survivors are saga
+changes. 6-frame fan-out + 2 grounding agents (local reality + external prior art).
+
+## Core realization
+
+You already own nearly every primitive a global journal needs — they're just unused. The gap is three
+missing **verbs**, not a missing tool or a RAG system:
+
+- **promote** — lift cross-repo learnings out of their silos,
+- **recall** — find them from anywhere,
+- **carry** — survive across machines.
+
+And a "global journal" is really **three shelf-lives**: durable LEARNINGS/DECISIONS (globalize freely),
+volatile QUEUED (push to Todoist, don't pay sync tax), and a tiny always-loaded hot set. Build the
+right home for each, and make the global layer **derived, never hand-maintained** (a hand-kept global
+file rots — see `tasks/todo.md`, prescribed in CLAUDE.md and used by 0/31 repos).
+
+**Terminology.** The journal's `Generalizable rule` subheader captures a distilled **learning** —
+information to guide a future decision, not a law to enforce. The global layer is a body of *learnings*;
+only the rare entry (e.g. Validation-Discipline) hardens into a directive. This reframe reinforces the
+no-RAG call: you're surfacing guidance to inform a decision, not enforcing an authoritative index, so
+grep is enough.
+
+## Grounding Context
+
+**Repo / reality:** 31 repos carry `docs/engineering-journal/` (LEARNINGS/DECISIONS/QUEUED/ARCHIVE +
+narratives/), each a silo with zero rollup; **785 `**Generalizable rule.**` lines already exist** across
+them (≈700 real entries after filtering template/meta lines — these are your distilled **learnings**, one
+per LEARNINGS entry; stable, greppable marker). The saga `/retro` skill already pure-appends learnings/decisions/queued/
+archive into a repo's journal unattended — but is single-repo scoped. Machine-level hooks already exist
+and are unused: global `~/.claude/CLAUDE.md` (defines the journal rules, loads every session) and the
+Claude Code auto-memory dir `~/.claude/projects/-Users-jefcox/memory/` (EXISTS but EMPTY, MEMORY.md
+index, one-fact-per-file). `tasks/todo.md` used by 0/31 repos; home-lab QUEUED.md is 452KB. No
+cross-machine sync; the workspace root is not a git repo; dotfiles tracks `.claude/` config as a template
+baseline only.
+
+**Context-libraries:** `infiquetra-context-library` — canonical org-wide standards/decisions location
+with its own journal; the natural promotion target for learnings that recur across repos.
+
+**External prior art:** Basic Memory (basicmachines-co) and simonw/til are the closest design analogs —
+file-first markdown, no vector DB. RAG-over-notes fails on retrieval (staleness/drift/re-index tax),
+and Anthropic's own stance is that agentic grep beats a vector index for journal-sized markdown
+(Claude Code ships on grep, no vectors). Todoist exposes an official hosted MCP (`ai.todoist.net/mcp`)
+that drops into Claude Code. Flags: "openbrain" is most likely the AI-2027 fictional lab (or tiny
+GitHub projects), not a tool to bet on; Cursor "Memories" was removed (don't model on it); Claude Code
+native auto-memory overlaps the "agent-maintained global journal" goal — reconcile, don't duplicate.
+
+## Topic Axes
+
+- A — Placement & structure (where the global layer lives + how organized)
+- B — Capture & cross-repo promotion (how findings bubble up from 31 silos)
+- C — Retrieval & recall (how knowledge surfaces when relevant)
+- D — Cross-machine sync & durability
+- E — Backlog/queue integration + Todoist
+
+## Ranked Survivors
+
+### 1. Derived global learnings rollup — harvest the ~700 you already wrote
+
+One generated `GLOBAL_LEARNINGS.md`, built by harvesting the distilled learnings (the `Generalizable
+rule` lines) already in your journals — never hand-edited, rebuildable on command.
+
+A script greps the stable `**Generalizable rule.**` marker across all 33 journals (785 hits today, ≈700
+real entries), emits one workspace-level file with each learning prefixed by its source `repo/file:line`,
+and you re-run it to refresh. Source of truth stays in the repos; the global file is a disposable
+projection, so it can't drift the way a hand-kept file does — think `make journal`, not a document.
+
+These are the highest-value learnings you have (per CLAUDE.md, the `Generalizable rule` line is the
+single highest-value field), they already exist, and they're already tagged — so this is direct evidence
+at near-zero build cost with same-day payoff; it also defuses seed S1 (a workspace file one level up is
+right, but only if generated). Downsides: the marker has format variants (602 canonical, plus
+heading/punctuation variants and some template-header leakage), so the harvest needs light normalization,
+not a dumb `cat`; and it's a snapshot — without #2 feeding it, it goes stale.
+
+| field | value |
+|-------|-------|
+| basis | `direct:` 785 `**Generalizable rule.**` lines confirmed via grep across the journals (≈700 real learnings); tasks/todo.md at 0/31 adoption |
+| confidence | 88 |
+| complexity | Low |
+| axis | A — placement & structure |
+| status | Unexplored |
+
+### 2. Teach `/retro` to promote upward
+
+Add one "promote cross-repo" step to the `/retro` skill that already auto-files learnings, so future
+generalizable findings flow up to the rollup — and to `infiquetra-context-library` when they recur.
+
+`/retro` already pure-appends learnings/decisions with no confirmation; it's just single-repo blind.
+Give it a final classifier: when an entry carries a `Generalizable rule` line, also append it to the
+global rollup with provenance; when the same learning independently appears in ≥2–3 repos, flag it for
+promotion to an org standard. A dedup/threshold guard keeps the global layer from becoming a junk drawer.
+
+This reuses the one piece of machinery that already runs unattended at the richest possible moment (when
+the learning is born), so capture costs nothing new — it's the compounding engine that keeps #1 fresh
+forever. Downsides: cross-repo classification needs judgment (false promotes add noise; misses stay
+siloed) and it edits a shared lifecycle skill, so it wants care.
+
+| field | value |
+|-------|-------|
+| basis | `direct:` /retro confirmed to auto-append, single-repo scoped; context-library is the canonical org-standard target |
+| confidence | 84 |
+| complexity | Med |
+| axis | B — capture & cross-repo promotion |
+| status | Unexplored |
+
+### 3. `/recall` — agentic grep across all journals, not RAG
+
+A thin `/recall <topic>` skill that globs and greps every repo's journal and returns ranked hits with
+provenance — cross-repo recall today, no index to build or keep fresh.
+
+It fans `grep` across `*/docs/engineering-journal/*.md`, pulls matching entries plus their nearby
+`Mechanism` / `Generalizable rule` lines, and returns them with `repo/file:line`. A saved "last 7 days
+across all repos" variant gives a standup-style digest on demand. This is the direct rebuttal to seed S3.
+
+The grounding is decisive — RAG-over-notes fails on retrieval, while agentic grep beats a vector index
+for journal-sized markdown (Anthropic's own design choice for Claude Code; simonw/til proves structured
+markdown + full-text search beats vectors at this scale). Downsides: grep is literal — it misses synonyms
+a vector search might catch, so it leans on consistent vocabulary; a much larger corpus would want a
+til-style SQLite FTS index (still no vectors).
+
+| field | value |
+|-------|-------|
+| basis | `external:` Anthropic "just-in-time" agentic retrieval (Claude Code ships on grep); simonw/til |
+| confidence | 85 |
+| complexity | Low |
+| axis | C — retrieval & recall |
+| status | Unexplored |
+
+### 4. Fill the empty auto-memory dir — the always-surfaced learnings
+
+Promote only your top cross-repo learnings into Claude Code's native auto-memory dir (one-fact-per-file),
+which the harness injects into every session — recall with zero retrieval step.
+
+`~/.claude/projects/-Users-jefcox/memory/` already exists, is indexed by MEMORY.md, and is completely
+empty — an unused machine-wide primitive that loads into every session's context for free. Feed it the
+handful of learnings worth seeing in every session — mostly guidance, with the rare genuine directive
+(e.g. the Validation-Discipline rule) as the special case — curated ruthlessly to a small token budget
+and earned by recurrence. The full rollup (#1) stays the searchable cold tier; this is the hot tier.
+
+This is seed S2 answered honestly — the "memory tool to adopt" is the one already wired in and at zero
+utilization, not a new dependency; because it's push (injected) not pull (queried), it sidesteps the
+retrieval problem RAG fails at. Downsides: context budget is scarce, so it only works kept tiny; it
+overlaps Claude Code's own evolving memory feature, so reconcile rather than fight it.
+
+| field | value |
+|-------|-------|
+| basis | `direct:` auto-memory dir confirmed empty; one-fact-per-file taxonomy; CLAUDE.md's Validation-Discipline is exactly such a learning that hardened into a directive |
+| confidence | 80 |
+| complexity | Med |
+| axis | A — placement & structure (hot/cold tiering) |
+| status | Unexplored |
+
+### 5. A git-backed global journal repo for cross-machine durability
+
+Put the global layer in one small git repo (or `infiquetra-context-library`), so cross-machine sync,
+durability, and provenance come from git for free.
+
+The workspace root isn't a git repo and nothing syncs `.claude` across machines today, so a
+workspace-level file alone dies on your other boxes. A dedicated `infiquetra-journal` repo holds the
+generated rollup + the seeded memory + any index; symlink the memory dir into it, and `git pull` on a
+new machine is the entire sync story. Append-only markdown is the ideal git payload.
+
+Cross-machine is the one part of the ask with genuinely no current answer, and git already solves
+replication, durability, offline, and history — a hosted memory DB would be strictly worse; promotion
+becomes an auditable commit. Downsides: concurrent edits on two machines mean occasional merge conflicts
+(mitigated by append-only + per-repo sections), and it's one more repo to remember to push.
+
+| field | value |
+|-------|-------|
+| basis | `direct:` workspace root not a git repo, no cross-machine sync, dotfiles only tracks config; `external:` Basic Memory / til prove markdown-in-git needs no server |
+| confidence | 78 |
+| complexity | Med |
+| axis | D — cross-machine sync & durability |
+| status | Unexplored |
+
+### 6. Close the Todoist loop and retire the dead `todo.md`
+
+Make Todoist bidirectional via its official MCP — push P0/P1 QUEUED items with a backlink, read the
+queue back at session start, auto-complete on ship — and formally kill `tasks/todo.md`.
+
+The official Doist MCP (hosted at `ai.todoist.net/mcp`) drops into Claude Code, so `/retro` can push
+selected queued items out, sessions can pull "open P1s across all repos" at the start of work, and moving
+a QUEUED item to ARCHIVE as SHIPPED auto-closes its task. Separately, retire `tasks/todo.md` from
+CLAUDE.md — prescribed, used by 0/31 repos, a zero-adoption directive that erodes trust in the rest of
+the file.
+
+A backlog only has value if it's read, so meeting your attention where it already is (Todoist, on your
+phone) plus a return path converts the graveyard into a system; pick one source of truth (QUEUED is the
+record, Todoist the live surface) so the two can't drift. Downsides: bidirectional sync has real edge
+cases (dup detection, conflicting completes) and is the most moving-parts idea here; it only pays off if
+you actually keep Todoist as your daily surface.
+
+| field | value |
+|-------|-------|
+| basis | `direct:` seed S4; Todoist hosted MCP works in Claude Code; tasks/todo.md at 0/31; CLAUDE.md "QUEUED ships → ARCHIVE SHIPPED" |
+| confidence | 74 |
+| complexity | High |
+| axis | E — backlog/queue integration |
+| status | Unexplored |
+
+## Did not survive (revivable)
+
+Explicit rejection is the quality mechanism. Cut ideas keep stable ids so they can be revived (which
+re-enters the Phase 3 filter with new evidence).
+
+| id | title | summary | reason | status |
+|----|-------|---------|--------|--------|
+| R1 | Adopt a dedicated memory tool | Bring in Basic Memory / mem0 / Letta / Zep | Heavier than needed — mem0/Letta/Zep want a vector or graph DB; native auto-memory + grep dominate at journal scale | rejected |
+| R2 | Build a vector RAG (seed S3, literal) | Embed the journals, retrieve by similarity | Fails on retrieval + carries an embed/re-index tax; dominated by agentic grep for journal-sized markdown | rejected |
+| R3 | Case-law citation graph | `Cites:` / `Overruled-by:` links + a "good law" staleness check | Novel staleness fix but higher complexity; better as a later layer on #1 once the rollup exists | rejected |
+| R4 | Git-hook promotion trigger | A post-commit hook scrapes new learning lines instead of `/retro` | Deterministic but fragile to install across 31 repos and judgment-free; duplicates #2's path | rejected |
+| R5 | Global-first (repos are views) | One global store; per-repo journals become projections of it | Elegant but a massive migration against the grain of 33 silos and `/retro`; #1 gets most of it cheaply | rejected |
+| R6 | Dedicated scheduled distiller | A CALL-style consolidation cron as its own job | Valuable at volume but premature; folded into #2's promotion cadence for now | rejected |
+
+Axis coverage: A×2, B, C, D, E — no zero-survivor axis. ~49 raw candidates across 6 frames collapsed
+hard; most cuts were duplicates folded into the survivor that stated the move best (memory-consolidation
+/ LSM-compaction / CALL → #2; generated-index / event-sourcing / newsroom-morgue → #1; zero-tooling /
+read-10x digest → #3; dotfiles-carrier / git-submodule → #5; andon-cord / SRE-runbook-split → #6).
+
+## Co-ideation log
+
+| source | entered | idea / seed | outcome |
+|--------|---------|-------------|---------|
+| user-seed | Phase 0 | S1 — workspace journal + CLAUDE.md one level up | reshaped; survived as #1 (generated form) + #5 (git home). Challenged: hand-kept global files rot (tasks/todo.md 0/31) |
+| user-seed | Phase 0 | S2 — adopt an existing memory tool (openbrain / memory apps) | redirected to #4 (native auto-memory); tool-adoption form cut → R1 |
+| user-seed | Phase 0 | S3 — a RAG system | challenged by grounding; answered by #3 (agentic grep); literal RAG cut → R2 |
+| user-seed | Phase 0 | S4 — Todoist, write-only queue, ignored | built on; survived as #6 (bidirectional + read-back) |
+| frame-agent | Phase 2 (leverage) | learnings harvest (785 lines) | survived as #1 |
+| frame-agent | Phase 2 (inversion / assumption / leverage) | extend /retro append to global | survived as #2 |
+| frame-agent | Phase 2 (pain / inversion / assumption) | grep-not-RAG /recall | survived as #3 |
+| frame-agent | Phase 2 (pain / leverage / assumption) | fill empty auto-memory dir | survived as #4 |
+| frame-agent | Phase 2 (analogy / constraint / inversion) | git-backed cross-machine journal | survived as #5 |
+| frame-agent | Phase 2 (analogy / constraint) | citation-graph, global-first, distiller pass | cut → R3, R5, R6 |

--- a/docs/plans/2026-06-20-global-transcendent-learnings-plan.md
+++ b/docs/plans/2026-06-20-global-transcendent-learnings-plan.md
@@ -78,6 +78,8 @@ Dependency-ordered. Each is independently landable. Paths are repo-qualified whe
 
 **Landing surfaces (multi-repo).** This plan touches three repos: `infiquetra-claude-plugins` (the `promote` skill, scripts, tests, and release surfaces — U1-U5), `infiquetra-context-library` (the promotion destination journal plus a README template note — U1, U4), and `infiquetra-sdlc` (the practice-doc and DECISIONS reconciliation — U6). It does not land as one PR; each repo carries its own branch/PR, sequenced by the unit dependency order.
 
+**Coordination (decided — Option A).** A single workspace-level `/work` session drives all three repos and opens one branch/PR per repo in dependency order. U1's data contract lands first because everything depends on it; then the `infiquetra-claude-plugins` PR carries U1's contract reference plus U2-U5, the `infiquetra-context-library` PR carries U1's README template note, and the `infiquetra-sdlc` PR carries U6. The driving session holds the cross-repo dependency chain so U2-U6 never start against an unfrozen contract.
+
 ### U1. Promotion data contract (marker, key, entry template)
 
 **Goal:** Pin the formats everything else depends on — the `**Transcendent.**` marker, the source-key derivation, and the context-library promoted-entry template with `**Sources.**`.

--- a/docs/plans/2026-06-20-global-transcendent-learnings-plan.md
+++ b/docs/plans/2026-06-20-global-transcendent-learnings-plan.md
@@ -1,0 +1,212 @@
+---
+title: Global Transcendent-Learnings Layer — Implementation Plan
+type: feat
+status: active
+date: 2026-06-20
+origin: docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md
+---
+
+# Global Transcendent-Learnings Layer — Implementation Plan
+
+## Summary
+
+Build a workspace-level layer that promotes the select few cross-repo learnings into `infiquetra-context-library`'s engineering journal as distilled org standards. Two feeders — a `/retro` marking step (declare) and a new gated workspace pass (recurrence net) — funnel transcendent learnings through a propose-diff-and-wait gate into one upsert-by-lesson destination. The ~785 per-repo learnings stay where they are; recall is pull-only.
+
+## Problem Frame
+
+The per-repo engineering journal works, but each is a silo: a lesson learned in one repo is invisible when the same mistake recurs in another. The naive fix — harvesting all `Generalizable rule` lines into one aggregate file — was rejected during brainstorming as context-bloating duplication, because the marker means "generalized *from* the incident," not "transcends repos."
+
+The grounded gap is narrower and already half-modeled in the codebase. `infiquetra-sdlc/docs/process/engineering-journal.md:195-217` already prescribes "promote when the same rule appears 2+ times" and frames the journal as a feeder to durable surfaces — but that promotion path is per-repo and stops at the repo boundary. There is no cross-repo tier and no mechanism to lift a genuinely transcendent learning into the org-wide library. This plan builds that tier as a gated, derived, pull-only layer.
+
+## Requirements
+
+What the built layer must satisfy. R-IDs trace to the origin brainstorm's requirements (shown in parentheses) and are the reviewer's and `/work`'s checklist.
+
+**Selection & marking**
+
+- R1. A greppable transcendence marker, visually distinct from `**Generalizable rule.**`, is applied inline in a source repo's `LEARNINGS.md` entry. (brainstorm R1)
+- R2. `/retro` proposes the marker as a gated edit when a learning passes the transcendence test, operating only within the repo it runs in. (R2, R4)
+- R3. A human can apply the marker to any learning at any time, using the same test. (R3)
+
+**Recurrence detection**
+
+- R4. A workspace-level pass reads the marked learnings plus all not-yet-promoted `Generalizable rule` lines across repo journals as its candidate pool, excluding context-library's own journal. (R5, R14)
+- R5. Clustering of "same lesson across repos" is by agent judgment with no vector store; a cluster is nominated at a default threshold of two distinct repos, configurable. (R6, R7)
+
+**Promotion**
+
+- R6. Promotion writes a self-contained Rule + Mechanism entry into `infiquetra-context-library`'s `LEARNINGS.md`, readable without opening the source repo. (R8)
+- R7. Each promoted entry carries source backlinks (a navigational pointer plus a drift-stable key) to every origin; the source entry stays in place — copy, never move. (R9, R10)
+- R8. Every write into the context-library journal is gated: propose a diff, wait for explicit approval. (R11)
+- R9. The pass is idempotent via a drift-stable source-key ledger; a recurrence cluster upserts one entry carrying one backlink per source repo. (R12, R13)
+- R10. The pass writes only to context-library — never back to source repos — and is READ-ONLY on the SDLC (no issue/board/saga mutation). (brainstorm scope boundary)
+
+**Recall, cost, and integration**
+
+- R11. Promoted learnings are consumed pull-only (grep/read on demand); nothing auto-loads into sessions. (R15)
+- R12. The ~785 existing learnings remain in their repos, untouched and searchable. (R16)
+- R13. The pass runs manually on demand as an invocable saga skill; scheduling is deferred. (R17)
+- R14. The workspace tier reconciles with the existing journal-to-surface promotion model in `infiquetra-sdlc/docs/process/engineering-journal.md`, positioned as a cross-repo journal *feeder*, not a sixth durable surface. (grounding-driven)
+
+## Key Technical Decisions
+
+The load-bearing choices that constrain implementation.
+
+- KTD1. **Marker form — a `**Transcendent.**` subheader line** on the source `LEARNINGS.md` entry, greppable as `^\*\*Transcendent`, distinct from `**Generalizable rule.**`. Rationale: format-consistent with the existing `**Subheader.**` entry grammar (`docs/engineering-journal/LEARNINGS.md:8-22`); trivially greppable; both `/retro` and a human apply it the same way.
+- KTD2. **Dedup identity — a per-source stable key `<repo>:<short-hash of the normalized Generalizable-rule text>`**, never a line number. Context-library entries carry the covered key-set, which *is* the dedup ledger. Rationale: resolves the brainstorm's drift P2 — line numbers shift as `LEARNINGS.md` grows; hashing the rule text is drift-proof and needs no ID registry. Trade-off: editing a rule's text re-keys it; the human gate (KTD6) catches the rare re-nomination.
+- KTD3. **Backlink convention — a new `**Sources.**` field** in the promoted entry, one line per origin: `<repo> · <YYYY-MM-DD> · <short-hash> — <repo>/docs/engineering-journal/LEARNINGS.md`. Rationale: context-library's journal has no existing backlink/source convention (Agent 3); this introduces the minimal one, doubling as provenance (navigation) and dedup ledger (the keys).
+- KTD4. **Recurrence mechanism — agent-judgment clustering over the in-window candidate pool, threshold ≥2 repos, no vectors.** Rationale: matches the brainstorm and Anthropic's agentic-grep stance, and aligns with the practice doc's existing "same rule appears 2+ times → promote" heuristic (`infiquetra-sdlc/docs/process/engineering-journal.md:195-217`).
+- KTD5. **Home & mirror — a new saga skill in `infiquetra-claude-plugins`, mirroring `/ideate`'s cross-repo grounding** (workspace + `gh` repo discovery, per-repo reader agents, context-library short-circuit). Rationale: `/ideate` (`.../skills/ideate/SKILL.md:40-100, 247-300`) is the only proven workspace-spanning pattern in saga; reuse it rather than invent. Working command name **`promote`** (disambiguated below; open to override at routing).
+- KTD6. **Gating — every context-library write and the `/retro` marking edit are Tier-2 propose-diff-and-wait.** Rationale: marking modifies an existing entry, which `/retro`'s self-edit-safety contract already classifies as gated (`.../skills/retro/SKILL.md:81-99`); cross-repo writes into the canonical library warrant the same gate, consistent with sdlc's high-blast-radius cadence decision (`infiquetra-sdlc/docs/engineering-journal/DECISIONS.md:81-90`).
+- KTD7. **Boundary split — `/retro` keeps its single-repo boundary; the cross-repo write lives ONLY in the new skill,** which is saga READ-ONLY on the SDLC and writes only to context-library. Rationale: preserves brainstorm R4 and confines all cross-repo mutation to one auditable place.
+
+The `promote` name reuses the practice doc's existing "promotion" vocabulary (journal → standard) and is distinct from mission-control's *issue* promotion; alternatives `globalize` / `transcend` are noted for the routing confirmation.
+
+## High-Level Technical Design
+
+The shape of the layer, end to end.
+
+Two feeders converge on one gated pass that writes one destination. **Declare:** `/retro` (or a human) marks a transcendent learning in its own repo with `**Transcendent.**` (KTD1) — a local, gated edit, no cross-repo write. **Recurrence net:** the new `promote` skill enumerates every repo journal under the workspace (mirroring `/ideate`'s discovery, KTD5), reads the marked entries plus all `Generalizable rule` lines, excludes context-library (recursion guard), and clusters same-lesson-across-repos by judgment (KTD4).
+
+The pass splits into a deterministic backbone and a judgment layer. A new `promote_scan.py` script does the mechanical work — enumerate journals, parse the marker and rule lines across their known format variants, compute the drift-stable source-key (KTD2), and filter out keys already present in context-library's `**Sources.**` ledger. The SKILL.md does the judgment — cluster nomination, distillation to a self-contained Rule + Mechanism entry, and the propose-diff-and-wait gate (KTD6). Promotion is an upsert keyed on the source-key set: a three-repo cluster becomes one entry with three `**Sources.**` backlinks, not three entries.
+
+Architecturally this is a **cross-repo journal feeder**, not a new durable surface. It sits beside the per-repo journals one tier up; from context-library, the existing journal-to-surface promotion rules still apply. U6 reconciles this with `engineering-journal.md` so the workspace tier extends — rather than forks — the documented promotion model.
+
+## Implementation Units
+
+Dependency-ordered. Each is independently landable. Paths are repo-qualified when they leave this plan's repo (`infiquetra-claude-plugins`): context-library and sdlc targets carry their repo prefix; bare paths (e.g. `plugins/saga/...`, `tests/...`) are relative to `infiquetra-claude-plugins`.
+
+**Landing surfaces (multi-repo).** This plan touches three repos: `infiquetra-claude-plugins` (the `promote` skill, scripts, tests, and release surfaces — U1-U5), `infiquetra-context-library` (the promotion destination journal plus a README template note — U1, U4), and `infiquetra-sdlc` (the practice-doc and DECISIONS reconciliation — U6). It does not land as one PR; each repo carries its own branch/PR, sequenced by the unit dependency order.
+
+### U1. Promotion data contract (marker, key, entry template)
+
+**Goal:** Pin the formats everything else depends on — the `**Transcendent.**` marker, the source-key derivation, and the context-library promoted-entry template with `**Sources.**`.
+
+**Dependencies:** none (foundational).
+
+**Files:** `plugins/saga/skills/promote/references/promotion-contract.md` (new); a short entry-template note appended to `infiquetra-context-library/docs/engineering-journal/README.md`.
+
+**Approach:** Specify the marker line and its grep pattern; define the normalized-rule hashing (lowercase, collapse whitespace, strip the `**Generalizable rule.**` label and trailing punctuation, then short hash); define the `**Sources.**` line grammar and the promoted-entry skeleton (reusing context-library's `**Author.**` + subheader grammar, Agent 3). Enumerate the known marker format variants the parser must tolerate.
+
+**Test expectation:** none — convention/reference doc; its rules are enforced executably by the U3 `promote_scan.py` tests and the U5 drift guard.
+
+**Verification:** the contract's marker regex and key recipe are quoted verbatim by `promote_scan.py` (U3) and the `/retro` sweep (U2); no divergent second definition exists.
+
+### U2. `/retro` transcendence-marking sweep (declare feeder)
+
+**Goal:** Teach `/retro` to assess transcendence and propose the `**Transcendent.**` marker, within the current repo only.
+
+**Dependencies:** U1.
+
+**Files:** `plugins/saga/skills/retro/SKILL.md` (Phase-4 CURATE); optionally `.../retro/references/retro-passes.md`.
+
+**Approach:** Add a rule-enforcement-style sweep in Phase 4 CURATE (`.../retro/SKILL.md:215-239`) that applies the transcendence test — *would this rule hold and help in a repo of a different stack or domain?* — and, when met, proposes adding the marker as a Tier-2 propose-diff-and-wait edit (it modifies an existing entry, so it is gated by the existing contract at `:81-99`). No cross-repo write; the marker sits locally until the next `promote` run.
+
+**Test scenarios** (`tests/test_saga_plugin.py`): the retro contract test asserts the marking sweep tokens are present in Phase 4; asserts it is classified Tier-2 (propose-diff), not auto-append; boundary negative — the sweep adds no cross-repo or context-library write to `/retro`.
+
+**Verification:** `grep` for the sweep + a dry contract-test run; `/retro`'s "writes only to current repo" boundary statements remain intact.
+
+### U3. `promote` skill — discovery, scan, and recurrence clustering (recurrence-net feeder)
+
+**Goal:** Build the new workspace skill's read half — discover journals, build the candidate pool, exclude context-library, compute keys, and nominate recurrence clusters.
+
+**Dependencies:** U1.
+
+**Files:** `plugins/saga/skills/promote/SKILL.md` (new); `plugins/saga/scripts/promote_scan.py` (new).
+
+**Approach:** `promote_scan.py` enumerates `*/docs/engineering-journal/LEARNINGS.md` under the workspace root (and local clones, mirroring `/ideate` at `.../skills/ideate/SKILL.md:247-273`), parses `**Transcendent.**` markers and `Generalizable rule` lines across the U1 variants, computes per-source keys (KTD2), and drops keys already in context-library's ledger. SKILL.md mirrors `/ideate`'s grounding gate, then clusters same-lesson-across-repos by judgment (KTD4) at the ≥2 threshold, emitting a nomination list.
+
+**Test scenarios** (`tests/test_promote_scan.py`, new): fixture journals across 3 fake repos → enumeration finds all; **key is stable when a fixture entry's line number is shifted** (drift proof, KTD2); context-library fixture journal is excluded (recursion guard, AE4); all marker format variants parse; a lesson present in 1 repo is below threshold, in 2 is nominated (AE2). Plus a contract test that `promote/SKILL.md` carries the `/ideate`-mirrored discovery tokens.
+
+**Verification:** `pytest tests/test_promote_scan.py`; manual dry-run scan over the real workspace prints a sane nomination list with no context-library entries.
+
+### U4. `promote` skill — gated upsert and idempotency (promotion)
+
+**Goal:** Build the new skill's write half — distill, upsert by lesson, gate, and dedup.
+
+**Dependencies:** U3, U1.
+
+**Files:** `plugins/saga/skills/promote/SKILL.md`; `plugins/saga/scripts/promote_scan.py` (upsert/ledger helpers).
+
+**Approach:** For each approved cluster, distill Rule + Mechanism into the U1 entry template, compute the destination upsert (match an existing entry by overlapping source-key set, else create), append `**Sources.**` backlinks for new origins, and write only to context-library behind a Tier-2 propose-diff-and-wait gate (KTD6). Idempotency comes from the key ledger (KTD2): already-covered keys are skipped.
+
+**Test scenarios** (`tests/test_promote_scan.py`): re-running with an already-present key-set yields no new/duplicate entry (AE1); a 3-repo cluster yields one entry with three `**Sources.**` lines, not three entries (AE3); the writer refuses any path outside context-library's journal (R10 write-surface guard); a marked-but-unapproved cluster produces a proposed diff and no write until approval (AE5). Contract test: `promote/SKILL.md` states the Tier-2 gate and the context-library-only boundary.
+
+**Verification:** `pytest`; a manual end-to-end dry run shows a proposed diff, and approving it writes exactly one upserted entry.
+
+### U5. Skill registration and release surfaces
+
+**Goal:** Make `promote` an installed, packaged saga command without metadata drift.
+
+**Dependencies:** U2, U3, U4.
+
+**Files:** `plugins/saga/commands/promote.md` (new); `plugins/saga/.claude-plugin/plugin.json` (version 0.22.1 → 0.23.0); `.claude-plugin/marketplace.json` (matching version); `plugins/saga/CHANGELOG.md` (new entry); `tests/test_saga_plugin.py` (dispatch tuple).
+
+**Approach:** Add the command file (the `Load saga/skills/promote/SKILL.md …` shape of `.../commands/ideate.md:1-16`); bump both versions in lockstep; add the CHANGELOG entry; add `promote` to the packaged-commands tuple at `tests/test_saga_plugin.py:57-78`. Follow the repo's release-surface rule (`CLAUDE.md:96-107`).
+
+**Test scenarios** (`tests/test_saga_plugin.py`): the dispatch test now expects `promote`; the version-drift guard sees identical `plugin.json`/`marketplace.json` versions; the CHANGELOG has the new top entry.
+
+**Verification:** `uv run pytest tests/test_saga_plugin.py` green; `python3 -m json.tool` validates both JSON files.
+
+### U6. Practice-doc and decision-record integration (sdlc)
+
+**Goal:** Document the workspace tier where the practice lives and reconcile it with the existing promotion model.
+
+**Dependencies:** U1.
+
+**Files:** `infiquetra-sdlc/docs/process/engineering-journal.md`; `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md`.
+
+**Approach:** Extend `infiquetra-sdlc/docs/process/engineering-journal.md:195-217` to describe the cross-repo transcendent-learnings tier as a *feeder* (not a sixth surface, per `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md:254-283`), and reconcile it with the existing "promote when 2+ times" rule so the two paths compose rather than conflict. Record KTD1-KTD7 as a dated entry in `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md` at implementation time (not now — pre-review), with rationale and revisit conditions. These are build-time documentation edits to sdlc markdown, distinct from R10's *runtime* READ-ONLY-on-SDLC boundary (the `promote` pass never mutates SDLC issues, boards, or sagas).
+
+**Test expectation:** none — documentation; verified by cross-reference link-check.
+
+**Verification:** the practice doc names the `promote` skill and the marker; the DECISIONS entry exists with revisit conditions; no contradictory promotion rule remains.
+
+## Scope Boundaries
+
+What this plan does not do.
+
+**Deferred to follow-up work:**
+
+- An always-loaded hot tier / auto-memory population (brainstorm survivor #4) — addable later with no rework; it would read the most-backlinked context-library entries.
+- Scheduled/automatic invocation of the `promote` pass — manual only for now (R13).
+- A dedicated `/recall` agentic-grep skill (survivor #3) — separate work; recall stays plain grep for now.
+
+**True non-goals:**
+
+- No aggregate `GLOBAL_LEARNINGS.md` and no bulk-copy of the ~785 learnings — the rejected harvest model.
+- No vectors, RAG, or embeddings.
+- No write-back to source repos from the pass; no cross-machine sync engineering (context-library is already git).
+- No bulk migration of existing journals to the new `**Sources.**`/marker conventions — the convention is introduced going forward.
+
+## Risk Analysis & Mitigation
+
+The ways this most plausibly fails, and the guards.
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Candidate pool outgrows one context window (breaks the judgment-not-vectors basis) | Low now (~785 lines), rising | `promote_scan.py` chunks the scan and `log`s when the pool exceeds a configurable size; revisit-when condition recorded in DECISIONS (U6). |
+| Inconsistent transcendence marking by `/retro` and humans | Medium | Operational test in U2; the recurrence net (U3) backstops missed declarations; the gate filters false positives. |
+| Rule text edited after promotion re-keys the lesson → re-nomination | Low | Hash the *normalized* rule (KTD2); the human gate (KTD6) catches the rare duplicate; the source-key is surfaced in `**Sources.**` for manual reconciliation. |
+| Cross-repo write blast radius into the canonical library | Medium | Tier-2 gate on every write (KTD6); write-surface confined to context-library (R10); recursion guard (AE4). |
+| New tier conflicts with the existing "2+ times → CLAUDE.md" promotion rule | Medium | U6 reconciles explicitly and positions the tier as a feeder, not a surface. |
+
+## Alternatives Considered
+
+Why the rejected forks were rejected.
+
+- **Vector RAG over journals** — dominated by agentic grep at journal scale; re-index tax and retrieval-failure risk. Rejected (brainstorm revivable cut R2).
+- **Aggregate harvest into one generated file** — context-bloating duplication; conflates "general" with "transcendent." Rejected — this is the reframe the whole feature rests on.
+- **Write-back a "promoted" flag to source repos** — expands the write surface to every repo; unnecessary once the drift-stable key ledger (KTD2) tells the pass what is already promoted. Rejected.
+- **Git-hook / automatic promotion** — fragile across 30+ repos and judgment-free; the manual, gated, agent-judged pass is the safer shape (consistent with `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md:81-90`). Rejected.
+
+## Sources / Grounding
+
+Anchors a reviewer or implementer reading cold will want.
+
+- `docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md` — the settled WHAT; this plan is its HOW.
+- `plugins/saga/skills/ideate/SKILL.md:40-100, 247-300` — the cross-repo grounding pattern KTD5 mirrors.
+- `plugins/saga/skills/retro/SKILL.md:81-99, 215-239` — the self-edit-safety tiers and Phase-4 CURATE slot for U2.
+- `infiquetra-context-library/docs/engineering-journal/LEARNINGS.md` — the destination format; no existing backlink convention (KTD3 introduces it).
+- `infiquetra-sdlc/docs/process/engineering-journal.md:195-217` and `infiquetra-sdlc/docs/engineering-journal/DECISIONS.md:81-90, 254-283` — the existing promotion model and cadence the tier must reconcile with (U6).
+- `CLAUDE.md:96-107`, `tests/test_saga_plugin.py:57-78` — the release-surface and dispatch-test touchpoints for U5.

--- a/docs/reviews/2026-06-20-global-transcendent-learnings-doc-review.md
+++ b/docs/reviews/2026-06-20-global-transcendent-learnings-doc-review.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-20
+type: doc-review
+target: docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md
+reviewed_revision: working tree
+blocked: false
+---
+
+# Doc Review — Global Transcendent-Learnings Layer
+
+## Review-result contract
+
+- **Target:** `docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md`
+- **Reviewed revision:** working tree (uncommitted)
+- **Classification:** requirements (path + content shape; no formal SDLC rubric phase applies)
+- **Blocked:** No — no `P0` or `P1` findings.
+- **Applied fixes:** all five findings resolved as in-place edits to the target at the user's direction (2026-06-20).
+- **Linked source:** `docs/ideation/2026-06-19-global-engineering-journal-ideation.md` (survivors #1 + #2)
+- **Resolution:** dedup key repinned to a drift-stable identity (R9/R12/R13/AE1 + decision bullet); transcendence test made operational (R2/R3); recurrence threshold defaulted to ≥2, configurable (R7); enumeration root named (R5); source-marker lifecycle specified with no write-back (R5 + new scope boundary).
+
+## Readiness summary
+
+The doc can drive `/plan` — scope, decisions, and success criteria are pinned, and the open items are correctly tagged deferred-to-planning. The two `P2` findings are sharpenings that make the layer more precise and its idempotency guarantee real; neither blocks planning, but both are cheaper to settle now than after code exists.
+
+## Findings by priority
+
+| # | Priority | Finding | Status |
+|---|---|---|---|
+| 1 | P2 | Idempotency key is unstable under line drift: R9 pins backlinks to `repo/path:line`, R12 calls the backlink set the dedup ledger. As `LEARNINGS.md` files grow, line numbers shift, so a line-keyed ledger can fail to recognize an already-promoted lesson and re-propose it — undercutting the "no duplicate proliferation, ever" success criterion. The R11 human gate backstops actual duplication, so blast radius is repeated re-proposals to reject, not corrupted data. Resolution: key dedup on something drift-stable (lesson/content hash or a stable ID), keep `file:line` only as a human-navigable pointer. | Resolved |
+| 2 | P2 | Transcendence criterion is conceptual, not operational: R2/R3 rely on "judges whether a learning crosses repos." The Problem Frame illustrates the distinction (generalized-from-incident vs transcends-repos) but gives no concrete test, risking inconsistent marking across `/retro` runs and humans. Mitigated by the recurrence net (feeder 2) and the gate, so it is a precision/recall issue, not a correctness one. Resolution: add a one-line operational test, e.g. "would this rule be true and useful in a repo of a different stack/domain?" | Resolved |
+| 3 | P3 | Recurrence threshold has no default: R7's "at least a configurable threshold of distinct repos" is left fully open (also in Outstanding Questions). Suggest leaning to a default of ≥2 repos — the literal meaning of "recurs across repositories" — raisable if it proves noisy. | Resolved |
+| 4 | P3 | Repo-enumeration root undefined: R5 reads "across all repo journals," but the pass needs a defined discovery root, and the workspace root is not a git repo. An agent would otherwise invent where to look. Name the enumeration root during planning. | Resolved |
+| 5 | P3 | Local marker lifecycle after promotion is unspecified: once a declared learning is promoted, the doc does not say whether its source marker is annotated as promoted. Dedup (R12) keeps re-collection correct either way, so this is a minor re-scan-cost/clarity point, not a correctness gap. | Resolved |
+
+## Residual risk from limited evidence
+
+The "single context window holds the candidate pool" assumption (the basis for judgment-over-vectors) is verified at ~785 lines today but is the layer's main scaling fault line; the doc surfaces it, and it is the right thing to revisit as the corpus grows.
+
+Because the doc reshapes a workflow the user relies on and carries a real product-scope decision (transcendent-subset over aggregate), `/founder-review` is a reasonable optional lens before planning — not required, since the scope call is already made and recorded.

--- a/docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md
+++ b/docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md
@@ -1,0 +1,60 @@
+---
+title: Doc-Review — Global Transcendent-Learnings Implementation Plan
+date: 2026-06-20
+target: docs/plans/2026-06-20-global-transcendent-learnings-plan.md
+reviewed_revision: working tree (committed in the same change)
+blocked: false
+origin: docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md
+---
+
+# Doc-Review: Global Transcendent-Learnings Implementation Plan
+
+**Readiness verdict: ready to drive implementation — not blocked.** No P0/P1 findings. Seven evidence-backed citation/path fixes were applied in place after verifying every load-bearing reference against the three live repos; one P2 multi-repo coordination decision should be settled at `/work`, especially under a team-execution backend.
+
+## Applied fixes
+
+Verified against `infiquetra-claude-plugins`, `infiquetra-context-library`, and `infiquetra-sdlc` at review time.
+
+| # | Fix | Evidence |
+|---|-----|----------|
+| 1 | U6 **Files** repo-qualified to `infiquetra-sdlc/...` | claude-plugins has no `docs/process/`; that file exists only in sdlc |
+| 2 | U6 **Approach** paths + DECISIONS entry target qualified | claude-plugins has its OWN `docs/engineering-journal/DECISIONS.md`, so the bare ref was ambiguous and would mis-target |
+| 3 | Implementation-Units preamble reworded | It claimed "sdlc-local paths are repo-relative to this plan's repo," but this plan's repo is now claude-plugins — residual drift from the sdlc → claude-plugins move |
+| 4 | `DECISIONS.md` range `254-282` / `254-305` → `254-283` | The cited decision spans line 254 to just before the next `###` header at 284 |
+| 5 | KTD4, KTD6, Alternatives citations repo-qualified to sdlc | Cross-repo refs were inconsistently bare |
+| 6 | Sources index path qualified + range corrected | The reference index a cold reader chases should be precise |
+| 7 | Added **Landing surfaces (multi-repo)** note | Makes the three-repo footprint explicit at the Implementation-Units boundary |
+
+A clarifying clause was also added to U6 distinguishing its build-time sdlc markdown edits from R10's *runtime* READ-ONLY-on-SDLC boundary, removing the apparent tension.
+
+## Verified-correct citations (spot-checked, no change needed)
+
+- saga `plugin.json` and `marketplace.json` version both `0.22.1`; plan bumps to `0.23.0` — confirmed.
+- `retro/SKILL.md` tiered self-edit-safety contract at `:81`+, Phase-4 CURATE at `:215`/`:227` — confirmed.
+- `ideate/SKILL.md` cross-repo discovery: local-clone preference `:256-258`, `gh repo list infiquetra` `:291`, context-library reader `:275`+ — confirmed.
+- `tests/test_saga_plugin.py:57-78` packaged-commands dispatch tuple — confirmed exact.
+- context-library journal has NO existing backlink/source convention (KTD3 introduces it) — confirmed by grep returning nothing.
+- context-library `README.md` exists (U1 appends to it); `**Author.**` and `**Generalizable rule.**` grammar present — confirmed.
+- sdlc `engineering-journal.md` "promote when the same rule appears in 2+ entries" at `:201`/`:209`; DECISIONS cadence `:81`+, feeder/5-surface decision `:254-283` — confirmed.
+
+## Remaining findings
+
+| Priority | Finding | Status |
+|----------|---------|--------|
+| P2 | Multi-repo landing/sequencing is stated only at the level of the new note. The three repos land as separate branches/PRs, and U1's data contract (claude-plugins) feeds U2-U4 plus the context-library README across repo boundaries. Under team-execution this coordination — PR sequencing, cross-repo dependency handoff, which session drives — should be an explicit call. | Open — decide at `/work` |
+| P3 | Cosmetic: the narrative bare ref `engineering-journal.md` (~line 73) is illustrative; KTD5 still says the `promote` name is "open to override at routing" though routing confirmed `promote` this session; `commands/ideate.md:1-16` is cited but the file is 15 lines. | Acknowledged — no action |
+
+## Recommendation
+
+Proceed. Before invoking `/work` with team-execution, make one explicit multi-repo coordination call: either (a) drive all three repos from one workspace-level `/work` session that opens a branch/PR per repo in unit-dependency order, or (b) split into three scoped runs — claude-plugins skill first, then the context-library README note, then the sdlc U6 reconciliation last. Option (a) preserves the unit dependency chain end-to-end; (b) is simpler but requires U1's data contract frozen before the dependent units start.
+
+## Review-result contract
+
+- **Target:** `docs/plans/2026-06-20-global-transcendent-learnings-plan.md`
+- **Reviewed revision:** working tree (committed in the same change)
+- **Blocked:** false (no P0/P1)
+- **Applied fixes:** 7 (table above) plus 1 clarity clause
+- **Remaining:** 1 x P2 (open, decide at `/work`); P3 cosmetic
+- **Review artifact:** `docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md`
+- **Override rationale:** n/a (not blocked)
+- **Linked:** brainstorm `docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md`; plan saga `task-global-transcendent-learnings`

--- a/docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md
+++ b/docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md
@@ -9,7 +9,7 @@ origin: docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.m
 
 # Doc-Review: Global Transcendent-Learnings Implementation Plan
 
-**Readiness verdict: ready to drive implementation — not blocked.** No P0/P1 findings. Seven evidence-backed citation/path fixes were applied in place after verifying every load-bearing reference against the three live repos; one P2 multi-repo coordination decision should be settled at `/work`, especially under a team-execution backend.
+**Readiness verdict: ready to drive implementation — not blocked.** No P0/P1 findings. Seven evidence-backed citation/path fixes were applied in place after verifying every load-bearing reference against the three live repos; the one P2 multi-repo coordination decision is now resolved — Option A: a single `/work` session opening one PR per repo in dependency order, recorded in the plan.
 
 ## Applied fixes
 
@@ -41,7 +41,7 @@ A clarifying clause was also added to U6 distinguishing its build-time sdlc mark
 
 | Priority | Finding | Status |
 |----------|---------|--------|
-| P2 | Multi-repo landing/sequencing is stated only at the level of the new note. The three repos land as separate branches/PRs, and U1's data contract (claude-plugins) feeds U2-U4 plus the context-library README across repo boundaries. Under team-execution this coordination — PR sequencing, cross-repo dependency handoff, which session drives — should be an explicit call. | Open — decide at `/work` |
+| P2 | Multi-repo landing/sequencing is stated only at the level of the new note. The three repos land as separate branches/PRs, and U1's data contract (claude-plugins) feeds U2-U4 plus the context-library README across repo boundaries. Under team-execution this coordination — PR sequencing, cross-repo dependency handoff, which session drives — should be an explicit call. | Resolved — Option A: single `/work` session, one PR per repo in dependency order; recorded in the plan's landing-surfaces note |
 | P3 | Cosmetic: the narrative bare ref `engineering-journal.md` (~line 73) is illustrative; KTD5 still says the `promote` name is "open to override at routing" though routing confirmed `promote` this session; `commands/ideate.md:1-16` is cited but the file is 15 lines. | Acknowledged — no action |
 
 ## Recommendation
@@ -54,7 +54,7 @@ Proceed. Before invoking `/work` with team-execution, make one explicit multi-re
 - **Reviewed revision:** working tree (committed in the same change)
 - **Blocked:** false (no P0/P1)
 - **Applied fixes:** 7 (table above) plus 1 clarity clause
-- **Remaining:** 1 x P2 (open, decide at `/work`); P3 cosmetic
+- **Remaining:** P3 cosmetic only (the P2 multi-repo coordination is resolved — Option A, recorded in the plan)
 - **Review artifact:** `docs/reviews/2026-06-20-global-transcendent-learnings-plan-doc-review.md`
 - **Override rationale:** n/a (not blocked)
 - **Linked:** brainstorm `docs/brainstorms/2026-06-20-global-transcendent-learnings-requirements.md`; plan saga `task-global-transcendent-learnings`


### PR DESCRIPTION
Full saga design trail for the planned `promote` skill — a workspace-level pass that promotes the select few cross-repo "transcendent" learnings into `infiquetra-context-library`'s engineering journal as distilled standards, gated and pull-only (not a bulk harvest of the ~785 per-repo rules).

**Included:**
- `docs/ideation/` — survivors of the global-engineering-journal ideate
- `docs/brainstorms/` — requirements-ready brainstorm (the settled WHAT)
- `docs/reviews/` — brainstorm + plan doc-reviews
- `docs/plans/` — implementation plan (6 units, 7 KTDs, the HOW)

**Doc-review:** not blocked (no P0/P1); 7 evidence-backed citation/path fixes applied after verifying every reference against the three live repos. Multi-repo coordination resolved as **Option A** — a single `/work` session opens one PR per repo (claude-plugins / context-library / sdlc) in unit-dependency order.

Planned only — no plugin code, scripts, or release surfaces in this PR.
