### PR TITLE
feat(team-execution): per-teammate model tiers (Opus/Sonnet/Haiku)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -321,7 +321,7 @@
     {
       "name": "team-execution",
       "source": "./plugins/team-execution",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "description": "Two-phase plan execution with reviewer consensus, validator gates, and guarded nonprod automation for Infiquetra repositories.",
       "author": {
         "name": "Infiquetra",

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -327,3 +327,10 @@ scrolls the real tag off the page and reports "no deployment found".
 - Current behavior degrades gracefully (no crash, just a missing env line).
 - Fix options when triggered: paginate until a tag-ref is found or N pages exhausted, or use the
   `environment` filter combined with a larger page. See [LEARNINGS.md#gh-api-f-defaults-post](LEARNINGS.md#gh-api-f-defaults-post).
+
+### Plan-dictated per-teammate effort levels for `/work` + team-execution  {#team-execution-per-teammate-effort}
+
+**Priority.** P3 (→ P2 if Claude Code ships an `effort:` agent-frontmatter field).
+**Effort.** Multi-day — re-architect team-execution's spawn onto the Workflow engine (where `agent()` accepts `effort`), then teach `/work` to parse and pass per-teammate effort.
+**Worth it when.** Uniform session effort proves too coarse — you want deep reasoning concentrated on specific reviewers (e.g. security, architecture) without paying it across the mechanical scanners — or Claude Code adds an `effort:` agent-frontmatter field (at which point most of this collapses to a cheap frontmatter edit mirroring the model tiers).
+**Context.** Companion to the v2.1.0 per-teammate **model** tiers (reviewers Opus / testers Sonnet / scanners+monitors Haiku). Model is settable per agent because it is frontmatter; **effort is not** — per-agent effort only exists inside a Workflow script (`agent(..., {effort})`), and team-execution spawns subagents by type, so all teammates inherit one session-global effort. Target design (Jeff, 2026-06-20): the plan carries an effort level per teammate (e.g. a `validator → effort` table) and `/work` ingests it during the work phase to set each teammate's effort at spawn. Feasibility hinges on the spawn path exposing effort — today that means routing team-execution through the Workflow engine. Note Haiku may clamp the top effort tiers; verify per-model effort support when built.

--- a/plugins/team-execution/.claude-plugin/plugin.json
+++ b/plugins/team-execution/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team-execution",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Two-phase plan execution with reviewer consensus, validator gates, and guarded nonprod automation for Infiquetra repositories.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/team-execution/CHANGELOG.md
+++ b/plugins/team-execution/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this plugin are documented here.
 
 ---
 
+## [2.1.0] - 2026-06-20
+
+### Changed
+- Teammate agents now run on role-appropriate models instead of all inheriting the
+  session model: the 10 reviewers on **Opus** (deep judgment), the 8 testers on
+  **Sonnet**, and the 7 scanners/monitors on **Haiku** (mechanical tool-running).
+  Set per agent via the `model:` frontmatter; any agent can be returned to `inherit`
+  to track the session model. Reasoning effort is unchanged (session-level).
+
+---
+
 ## [2.0.0] - 2026-05-27
 
 ### Added

--- a/plugins/team-execution/agents/ai-usefulness-reviewer.md
+++ b/plugins/team-execution/agents/ai-usefulness-reviewer.md
@@ -11,7 +11,7 @@ description: |
 
   NOT for: dumbing down content; general documentation quality (clarity-reviewer).
   Focus: making specs structured and explicit for AI consumption.
-model: inherit
+model: opus
 color: yellow
 ---
 

--- a/plugins/team-execution/agents/api-compat-scanner.md
+++ b/plugins/team-execution/agents/api-compat-scanner.md
@@ -5,7 +5,7 @@ description: |
   changes.
 
   Candidate tools: oasdiff, Schemathesis.
-model: inherit
+model: haiku
 color: green
 ---
 

--- a/plugins/team-execution/agents/api-contract-tester.md
+++ b/plugins/team-execution/agents/api-contract-tester.md
@@ -5,7 +5,7 @@ description: |
   behavior, and generated client expectations.
 
   Candidate tools: Schemathesis, oasdiff.
-model: inherit
+model: sonnet
 color: green
 ---
 

--- a/plugins/team-execution/agents/api-reviewer.md
+++ b/plugins/team-execution/agents/api-reviewer.md
@@ -8,7 +8,7 @@ description: |
   SDK, contract, breaking change.
 
   NOT for: implementation security (security-reviewer's job); infrastructure concerns.
-model: inherit
+model: opus
 color: green
 ---
 

--- a/plugins/team-execution/agents/architecture-reviewer.md
+++ b/plugins/team-execution/agents/architecture-reviewer.md
@@ -13,7 +13,7 @@ description: |
 
   NOT for: code quality specifics (code-quality-reviewer); security-specific concerns
   (security-reviewer's job); test coverage (testing-reviewer).
-model: inherit
+model: opus
 color: purple
 ---
 

--- a/plugins/team-execution/agents/clarity-reviewer.md
+++ b/plugins/team-execution/agents/clarity-reviewer.md
@@ -11,7 +11,7 @@ description: |
   Primarily used for docs/specs plans and mixed plans with doc content.
 
   NOT for: copy editing or grammar (focuses on meaning and structure); code quality.
-model: inherit
+model: opus
 color: cyan
 ---
 

--- a/plugins/team-execution/agents/code-quality-reviewer.md
+++ b/plugins/team-execution/agents/code-quality-reviewer.md
@@ -9,7 +9,7 @@ description: |
 
   NOT for: security concerns (security-reviewer); test coverage (testing-reviewer);
   style/formatting (linter handles that).
-model: inherit
+model: opus
 color: cyan
 ---
 

--- a/plugins/team-execution/agents/concurrency-tester.md
+++ b/plugins/team-execution/agents/concurrency-tester.md
@@ -3,7 +3,7 @@ name: concurrency-tester
 description: |
   Tester validator for team-execution. Tests concurrent execution, locks, retries,
   idempotency, races, and worker coordination.
-model: inherit
+model: sonnet
 color: purple
 ---
 

--- a/plugins/team-execution/agents/dependency-scanner.md
+++ b/plugins/team-execution/agents/dependency-scanner.md
@@ -5,7 +5,7 @@ description: |
   inputs for vulnerable or risky supply-chain changes.
 
   Candidate tools: pip-audit, Trivy.
-model: inherit
+model: haiku
 color: orange
 ---
 

--- a/plugins/team-execution/agents/deploy-watcher.md
+++ b/plugins/team-execution/agents/deploy-watcher.md
@@ -5,7 +5,7 @@ description: |
   workflows after reviewer, scanner, CI, and required tester gates pass.
 
   NOT for: production, staging, force-push, branch deletion, or credential changes.
-model: inherit
+model: haiku
 color: blue
 ---
 

--- a/plugins/team-execution/agents/devils-advocate-reviewer.md
+++ b/plugins/team-execution/agents/devils-advocate-reviewer.md
@@ -9,7 +9,7 @@ description: |
 
   NOT for: blocking on theoretical concerns; redesigning the solution; doing the security
   reviewer's job (auth/secrets); doing the architecture reviewer's job (patterns/conventions).
-model: inherit
+model: opus
 color: red
 ---
 

--- a/plugins/team-execution/agents/event-flow-tester.md
+++ b/plugins/team-execution/agents/event-flow-tester.md
@@ -3,7 +3,7 @@ name: event-flow-tester
 description: |
   Tester validator for team-execution. Validates queues, streams, webhooks, pub/sub,
   retries, idempotency, and async event paths.
-model: inherit
+model: sonnet
 color: purple
 ---
 

--- a/plugins/team-execution/agents/github-actions-monitor.md
+++ b/plugins/team-execution/agents/github-actions-monitor.md
@@ -3,7 +3,7 @@ name: github-actions-monitor
 description: |
   Monitor validator for team-execution. Checks GitHub Actions status and relevant logs for
   PR, CI, merge, and nonprod workflow gates.
-model: inherit
+model: haiku
 color: blue
 ---
 

--- a/plugins/team-execution/agents/iac-cost-scanner.md
+++ b/plugins/team-execution/agents/iac-cost-scanner.md
@@ -5,7 +5,7 @@ description: |
   and cost-risk signals.
 
   Candidate tools: Checkov, Trivy.
-model: inherit
+model: haiku
 color: blue
 ---
 

--- a/plugins/team-execution/agents/infra-reviewer.md
+++ b/plugins/team-execution/agents/infra-reviewer.md
@@ -9,7 +9,7 @@ description: |
   multi-region, infrastructure, AWS.
 
   NOT for: application-level security (security-reviewer's job); API design concerns.
-model: inherit
+model: opus
 color: blue
 ---
 

--- a/plugins/team-execution/agents/performance-tester.md
+++ b/plugins/team-execution/agents/performance-tester.md
@@ -5,7 +5,7 @@ description: |
   claims when performance risk is in scope.
 
   Candidate tool: k6.
-model: inherit
+model: sonnet
 color: magenta
 ---
 

--- a/plugins/team-execution/agents/privacy-reviewer.md
+++ b/plugins/team-execution/agents/privacy-reviewer.md
@@ -9,7 +9,7 @@ description: |
   anonymize, personal data, privacy.
 
   NOT for: general security concerns (security-reviewer); legal determinations (flags for legal review).
-model: inherit
+model: opus
 color: magenta
 ---
 

--- a/plugins/team-execution/agents/runtime-monitor.md
+++ b/plugins/team-execution/agents/runtime-monitor.md
@@ -3,7 +3,7 @@ name: runtime-monitor
 description: |
   Monitor validator for team-execution. Checks runtime health using repository-appropriate
   observability after nonprod deploy or publish.
-model: inherit
+model: haiku
 color: blue
 ---
 

--- a/plugins/team-execution/agents/scenario-tester.md
+++ b/plugins/team-execution/agents/scenario-tester.md
@@ -3,7 +3,7 @@ name: scenario-tester
 description: |
   Tester validator for team-execution. Executes scenario flows from plan context or
   `.team-execution.json` scenario_hints.
-model: inherit
+model: sonnet
 color: yellow
 ---
 

--- a/plugins/team-execution/agents/sdk-regression-tester.md
+++ b/plugins/team-execution/agents/sdk-regression-tester.md
@@ -3,7 +3,7 @@ name: sdk-regression-tester
 description: |
   Tester validator for team-execution. Checks SDK compatibility, generated client behavior,
   packaging smoke tests, and regression fixtures.
-model: inherit
+model: sonnet
 color: green
 ---
 

--- a/plugins/team-execution/agents/security-reviewer.md
+++ b/plugins/team-execution/agents/security-reviewer.md
@@ -8,7 +8,7 @@ description: |
   Always spawned — present for every plan execution regardless of plan type.
 
   NOT for: code quality concerns; architecture patterns; test coverage.
-model: inherit
+model: opus
 color: orange
 ---
 

--- a/plugins/team-execution/agents/security-scanner.md
+++ b/plugins/team-execution/agents/security-scanner.md
@@ -5,7 +5,7 @@ description: |
   tools where available.
 
   Candidate tools: Semgrep, Bandit, Gitleaks, detect-secrets.
-model: inherit
+model: haiku
 color: orange
 ---
 

--- a/plugins/team-execution/agents/smoke-tester.md
+++ b/plugins/team-execution/agents/smoke-tester.md
@@ -3,7 +3,7 @@ name: smoke-tester
 description: |
   Tester validator for team-execution. Runs the narrowest meaningful smoke tests for services,
   CLIs, health endpoints, or configured smoke targets.
-model: inherit
+model: sonnet
 color: yellow
 ---
 

--- a/plugins/team-execution/agents/testing-reviewer.md
+++ b/plugins/team-execution/agents/testing-reviewer.md
@@ -8,7 +8,7 @@ description: |
   unit test, e2e, test suite.
 
   NOT for: code quality concerns (code-quality-reviewer); infrastructure testing.
-model: inherit
+model: opus
 color: yellow
 ---
 

--- a/plugins/team-execution/agents/ui-regression-tester.md
+++ b/plugins/team-execution/agents/ui-regression-tester.md
@@ -5,7 +5,7 @@ description: |
   workflows and visible behavior.
 
   Candidate tool: Playwright.
-model: inherit
+model: sonnet
 color: cyan
 ---
 

--- a/tests/test_team_execution_plugin.py
+++ b/tests/test_team_execution_plugin.py
@@ -58,7 +58,7 @@ def test_team_execution_metadata_is_v2_and_marketplace_matches() -> None:
     marketplace = json.loads(_read(ROOT / ".claude-plugin" / "marketplace.json"))
     entry = next(p for p in marketplace["plugins"] if p["name"] == "team-execution")
 
-    assert plugin_json["version"] == "2.0.0"
+    assert plugin_json["version"] == "2.1.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/team-execution"
     assert "validator" in plugin_json["description"].lower()


### PR DESCRIPTION
Stop every team-execution teammate inheriting the session model; pin role-appropriate models in agent frontmatter.

| Tier | Agents |
|---|---|
| **Opus** | 10 reviewers (deep judgment) |
| **Sonnet** | 8 testers |
| **Haiku** | 7 scanners + monitors (mechanical tool-running) |

Any agent can be returned to `model: inherit` to track the session. Reasoning effort is unchanged (session-level) — per-teammate effort is captured as a QUEUED follow-up (`{#team-execution-per-teammate-effort}`), since effort is not frontmatter and would need team-execution's spawn re-architected onto the Workflow engine.

Version `2.0.0 → 2.1.0` (plugin.json + marketplace.json + CHANGELOG + version-drift test). `test_team_execution_plugin.py` 6/6 green.
