### PR TITLE
docs(review): readiness fixes for the tiering & execution campaign requirements

### DIFF
--- a/docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md
+++ b/docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md
@@ -17,13 +17,13 @@ into one campaign, planned and built **epic-by-epic**, with tiering as the share
 ## Problem Frame
 
 Two independent ideation efforts converged on the same root waste. The first found that the
-highest-value offloads are deterministic and cheap — yet the repo runs every subagent on the Opus main
-model (35 agent files were `model: inherit`; ~10 still are), has **zero hooks**, and re-pays expensive
-tokens for binary answers a hook could settle for free. The second found that saga *undersells and
-structurally avoids* its cheapest powerful backend: the `/plan` offer pitches dynamic (ultracode)
-workflows as fan-out only, and the recommender hard-forces team-execution on any consensus signal — so
-a workflow judge-panel is never recommended even though the Workflow tool documents judge panels as
-first-class.
+highest-value offloads are deterministic and cheap — yet the repo still leaves un-tiered subagents on
+the Opus main model (after the 17→7 cut, 5 of 30 agent files remain unpinned), has **zero hooks**, and
+re-pays expensive tokens for binary answers a hook could settle for free. The second found that saga
+*undersells and structurally avoids* its cheapest powerful backend: the `/plan` offer pitches dynamic
+(ultracode) workflows as fan-out only, and the recommender hard-forces team-execution on any consensus
+signal — so a workflow judge-panel is never recommended even though the Workflow tool documents judge
+panels as first-class.
 
 The seam between them is **tiering**: doc1's "pin the model where agents are dispatched" and doc2's
 "assign a per-unit `{model, effort}` where plan work is defined" are the same decision on two dispatch
@@ -82,7 +82,8 @@ R4. The tier rule is recorded once as prose where it is auto-loaded every sessio
 
 R5. The `/plan` execution-backend offer names dynamic workflows' **both** purposes — breadth/scale
 fan-out AND adversarial confidence (judge-panel / refute-N / perspective-diverse verification) — not
-fan-out alone.
+fan-out alone; and a drift-guard test asserts every offer surface stays a superset of the
+`operator-choice.md` §3.2 purpose list, so the under-sell cannot silently return on a future rebuild.
 
 R6. The offer frames the team-execution↔workflow choice on the **governance** axis ("does the verdict
 need to stick — block a merge/deploy and persist as evidence — or is it throwaway?"), not on "review
@@ -112,7 +113,8 @@ preserved).
 
 R12. Backend choice-vs-recommendation is recorded, and a `/retro` or `/optimize` pass surfaces the
 override-rate (plus over/under-tier and budget-exhaustion signals) so any future default re-weighting is
-evidence-driven, not asserted.
+evidence-driven, not asserted. This measurement is independent of Epics 0-1 and can begin early —
+ideally capturing a baseline before the Epic 1 representation changes land, for a clean before/after.
 
 **Epic 3 — Hook harness** *(independent; the repo's first hooks; can run in parallel)*
 
@@ -155,6 +157,10 @@ F2. **Off-host resume degradation (R11).**
 2. A one-line downgrade is surfaced; the orchestration tier recompiles down to team-execution or inline.
 3. Unit specs and per-unit tiers are preserved; the downgrade is recorded.
 
+Epics 3-4 (hooks, the cheap executor, release guards) are event-triggered guards rather than multi-step
+flows, so they carry no flow here — their behavior is fully captured by their requirements and acceptance
+examples.
+
 ## Acceptance Examples
 
 AE1. **Covers R7.** When work wants consensus but does NOT need to block a merge/deploy or persist a
@@ -172,6 +178,9 @@ surfaces it as an error, not a silent skip (the failure mode the context-fleet-a
 
 AE5. **Covers R13.** When an edit leaves `marketplace.json` unparseable or with unbalanced brackets → the
 hook blocks the edit and names the offending line.
+
+AE6. **Covers R14.** When a `feat`/`fix` commit stages code changes but no `docs/engineering-journal/`
+entry → the hook surfaces a nudge; it does not write the entry or block the commit.
 
 ## Scope Boundaries
 
@@ -194,13 +203,20 @@ Out of scope:
   routes to). Epic 3 (hooks) is independent and parallelizable.
 - **Capability gate:** dynamic workflows run on Claude Code only; this constrains R5 (omit the option
   off-host) and is the reason R11 (degradation) exists.
-- **Verified facts:** the repo has zero hooks today, so Epic 3 is greenfield; ~25 of 35 agent files are
-  already model-pinned, so Epic 0's enforcement is a small tail (the unpinned survivor agents + the
-  per-call arg + the rule), not a from-scratch build; the `cc-workflows-ultracode` enum string is carried
-  in persisted sagas, which is why R8 freezes it; `langfuse` ships user-enabled hooks cross-repo, the
-  existence proof for R14's distribution.
+- **Verified facts (2026-06-20, current 7-plugin tree):** the repo has zero hooks today, so Epic 3 is
+  greenfield; 25 of 30 agent files are already model-pinned, so Epic 0's enforcement is a small tail —
+  the 5 unpinned survivor agents (`deploy/release-orchestrator`, `home-lab-ops/homelab-sre`,
+  `mission-control/sdlc-operator`, `redis-channel/redis-channel-coach`, `unifi/unifi-network-ops`) plus
+  the per-call arg and the rule, not a from-scratch build; the `cc-workflows-ultracode` enum string is
+  carried in persisted sagas, which is why R8 freezes it; `langfuse` ships user-enabled hooks cross-repo,
+  the existence proof for R14's distribution.
 - **Assumption:** the Workflow tool's per-agent `model`/`effort` overrides and `budget` API are stable —
   R3, R9, and R12 depend on them.
+- **Release-surface obligation (cross-cutting):** every epic that changes plugin behavior updates the
+  release surfaces in the same PR — the plugin's `.claude-plugin/plugin.json` version,
+  `.claude-plugin/marketplace.json`, the plugin `CHANGELOG.md`, and any version/metadata drift-guard
+  tests (CLAUDE.md §6; the ideation's Thread C). Epics 0-2 modify saga, Epic 3 adds hooks to a plugin,
+  Epic 4 adds an agent — each carries this obligation.
 
 ## Success Criteria
 

--- a/docs/reviews/2026-06-20-saga-tiering-and-execution-campaign-review.md
+++ b/docs/reviews/2026-06-20-saga-tiering-and-execution-campaign-review.md
@@ -1,0 +1,50 @@
+# Doc Review — Saga Tiering & Execution-Mechanism Campaign (requirements)
+
+**Verdict: READY to drive planning.** No P0/P1. Seven P2/P3 findings, all fixed in place against
+verified evidence. The campaign frame maps all 15 ideation survivors to R-IDs with clean sequencing;
+HOW-level decisions are correctly deferred to `/plan`.
+
+## Review-result contract
+
+| field | value |
+|-------|-------|
+| target | `docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md` |
+| reviewed revision | working tree atop `main` `56bfec7` (the as-merged doc) |
+| classification | requirements (path `docs/brainstorms/` + content signals) |
+| rubric engine | not run — requirements docs use the readiness-skeptic pass, not idea/issue/spec rubrics |
+| blocked status | **not blocked** (no P0/P1) |
+| safe fixes applied | 7 (in place) |
+| review artifact | `docs/reviews/2026-06-20-saga-tiering-and-execution-campaign-review.md` |
+| upstream | ideation `docs/ideation/2026-06-20-net-new-skills-agents-ideation.md` + `…-execution-backend-representation-ideation.md` |
+
+## Verification performed (verify-before-trusting)
+
+| claim | result |
+|-------|--------|
+| `saga.py:71` ORCHESTRATION_MODES | ✓ exact |
+| `lifecycle_state.py:158` is the `or needs_consensus` hard-force | ✓ line 158 is literally `or needs_consensus` |
+| `plan/SKILL.md:253` offer under-sell | ✓ "broad independent fan-out without elevated risk" at :253 |
+| `team-execution/SKILL.md:234` `## Team Structure` template | ✓ (3rd match) |
+| "zero hooks" in the repo | ✓ no `hooks.json`, no `hooks/` dirs, no hook configs |
+| context-fleet-audit workflow + plan paths | ✓ both exist |
+| agent tiering count | ✗ **stale** — doc said "35 / ~10 inherit"; actual current tree is **30 agents, 25 pinned, 5 unpinned** |
+
+## Findings (all fixed in place)
+
+| id | pri | finding | fix | status |
+|----|-----|---------|-----|--------|
+| F1 | P2 | Stale agent count ("35 agent files", "~10 still inherit") — pre-cut figures | Corrected to "30 agents, 5 unpinned" in Problem Frame + Dependencies | fixed |
+| F2 | P2 | The S1 drift-guard test lived only in Success Criteria, not as a requirement | Folded into R5 as an explicit, testable clause | fixed |
+| F3 | P2 | Cross-cutting release-surface obligation (CLAUDE.md §6 + ideation Thread C) unstated — planning could omit version/CHANGELOG/marketplace/drift-guard updates | Added as a Dependencies/Assumptions bullet binding every epic | fixed |
+| F4 | P2 | R2's target agent set was a filter ("still-unpinned survivor agents") — the doc itself preaches enumerate-not-filter (R10) | Enumerated the 5 agents in Dependencies | fixed |
+| F5 | P3 | R14 (conditional nudge) had no acceptance example | Added AE6, faithful to R14 | fixed |
+| F6 | P3 | Epics 3-4 carry no Key Flows and the omission was unnoted (contract asks for a note) | Added a one-line note (event-triggered guards, non-flow-shaped) | fixed |
+| F7 | P3 | R12's sequencing (independent; baseline ideally precedes Epic 1) was unstated | Added a note to R12 | fixed |
+
+## Residual risk
+
+Low. The doc defers R7 (gated/advisory signal-acquisition), R8 (label encoding), R9 (spec location), and
+R15 (manifest format) to `/plan` — these are genuine HOW decisions, correctly deferred, not gaps. The one
+unverifiable claim is the assumption that the Workflow tool's per-agent `model`/`effort` and `budget` API
+are stable; it is a platform assumption outside this repo and is flagged as an assumption, not asserted as
+fact.


### PR DESCRIPTION
Readiness review (`/doc-review`) of the unified campaign requirements doc. **Verdict: ready to drive planning** — no P0/P1; 7 P2/P3 findings fixed in place against verified evidence.

**Key fix:** the agent-tiering count was stale (pre-cut) — doc said "35 / ~10 inherit," actual current tree is **30 agents, 25 pinned, 5 unpinned**. Corrected + the 5 enumerated.

**Other fixes:** S1 drift-guard test promoted into requirement R5; cross-cutting release-surface obligation added; AE6 for R14; non-flow note for Epics 3-4; R12 sequencing note.

Verified against the current tree: `saga.py:71`, `lifecycle_state.py:158`, `plan:253`, `team-exec:234`, zero-hooks, context-fleet-audit paths — all confirmed. Review artifact: `docs/reviews/2026-06-20-saga-tiering-and-execution-campaign-review.md`. Docs only.

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe