### PR TITLE
docs(saga): plan the tiering + execution-mechanism campaign

### DIFF
--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -22,6 +22,20 @@
 
 ---
 
+## 2026-06-21
+
+### Plan the saga tiering + execution-mechanism campaign as one workflow-built, per-unit-tiered build (plan PR pending — SHA-fill on merge)  {#saga-tiering-execution-campaign-plan}
+
+**Decision.** Plan the **whole** campaign (5 epics, 17 units U1-U17, requirements R1-R18) in one Deep plan and execute it through **one hand-authored ultracode workflow** (`docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js`) with a per-unit `{model, effort}` tier on every step (**5 Opus / 11 Sonnet / 1 Haiku**, operator-approved). Topology: `Preflight → parallel(Epic0, Epic1, Epic3) → barrier(E0+E1 merged) → parallel(Epic2, Epic4) → Final`, each epic an isolated worktree+branch landing as one PR, **full hands-off auto-merge** when the 5 required CI checks are green. Four operator/derived locks: **R7** gated-vs-advisory consensus via an explicit `/plan` interrogation question with a work-shape default (advisory → the existing `adversarial_confidence` ultracode branch); **R8** decouple-not-rename (display-label map → "dynamic workflows", enum `cc-workflows-ultracode` frozen); **R9** one spec, two emitters, saga points; **Epic 0** pins **4** callable agents (`redis-channel-coach` exempt — an MCP-instructions pointer, not Agent-dispatched).
+
+**Rejected alternatives.** (a) Plan epic-by-epic as separate docs (the brainstorm's KD6) — the operator chose to plan the whole thing; each epic still lands as its own PR, so independent execution is preserved. (b) Per-unit PRs — rejected for CI volume (~16 CI runs); epic-grouped PRs (~5 runs) with serial intra-epic units keep isolation without the churn. (c) Rename the enum to `dynamic-workflows` — rejected: the enum is a stored contract carried in persisted sagas; a display-label map is cheaper and reversible. (d) Infer R7 purely from work-shape, or always-ask with no default — rejected for explicit-question-**with**-default: the governance call ("does the verdict need to stick?") is the operator's, but the default removes friction. (e) Edit `~/.claude/CLAUDE.md` (R4) from inside the autonomous workflow — rejected: a global file outside the repo must not be in an unattended fan-out; applied inline with confirmation (KTD8).
+
+**Rationale.** Tiering is the genuine cross-doc seam, so it is the spine and lands first. Building the campaign **via** the workflow dogfoods R9 and validates the execution-spec by walking it manually before Epic 2 automates it. The autonomous oracle is sound — the test suite + the two plugin validators + the drift-guards gate every PR, and a red gate blocks the auto-merge — so full hands-off is safe behind green CI. R7 is a *surgical* split, not new plumbing: `adversarial_confidence` already exists as an ultracode trigger one branch from the `or needs_consensus` hard-force (`lifecycle_state.py:163` vs `:158`).
+
+**Revisit when.** Real override-rate data (R12) justifies re-weighting a recommender default; a second workflow-built campaign shows epic-PR auto-merge is too coarse (drop to per-unit checkpoints); the Workflow tool's `model`/`effort`/`budget` API changes; or a future rebuild needs the enum renamed after all (then do the migration the display-label map deferred).
+
+**Refs.** Plan `docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md` + sibling `.workflow.js`; requirements `docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md`; reference harness `infiquetra-context-library/scripts/context-fleet-audit.workflow.js`; [#operator-choice-docs-and-confidence](#operator-choice-docs-and-confidence); Track-1 builds queued under [#plugin-portfolio-groom-17-to-7](#plugin-portfolio-groom-17-to-7). Campaign-level LEARNINGS land at build time (U17).
+
 ## 2026-06-20
 
 ### Plugin portfolio groomed 17 → 7; marketplace version majors on plugin removal (04fa93e)  {#plugin-portfolio-groom-17-to-7}

--- a/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
+++ b/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
@@ -1,0 +1,616 @@
+---
+title: Saga Tiering & Execution-Mechanism Campaign — Implementation Plan
+type: feat
+status: active
+date: 2026-06-21
+origin: docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md
+---
+
+# Saga Tiering & Execution-Mechanism Campaign — Implementation Plan
+
+## Summary
+
+Build the whole campaign — five dependency-sequenced epics (tiering spine, execution-backend
+representation, dynamic-workflow authoring, hook harness, cheap executor + release guards) — and execute
+it through **one hand-authored ultracode workflow** with a per-unit `{model, effort}` tier on every step.
+The plan is the authoritative spec; the sibling
+[`2026-06-21-saga-tiering-and-execution-campaign.workflow.js`](./2026-06-21-saga-tiering-and-execution-campaign.workflow.js)
+is the execution harness `/work` runs. Authoring that script by hand is deliberate: it dogfoods the very
+capability Epic 2 will automate (R9), validating the spec by walking it.
+
+## Problem Frame
+
+Saga keeps defaulting expensive by omission: 4 callable ecosystem agents still run on Opus, the repo has
+zero hooks, the `/plan` offer undersells dynamic workflows as fan-out only, and the recommender
+hard-forces team-execution on any consensus signal (`lifecycle_state.py:158`, `team = … or
+needs_consensus`) so a workflow judge-panel is never recommended — even though `adversarial_confidence`
+already exists as an ultracode trigger one branch away (`lifecycle_state.py:163`). The cross-doc seam is
+tiering: "pin the model where agents are dispatched" and "assign a per-unit `{model, effort}` where plan
+work is defined" are the same decision on two dispatch surfaces. This plan resolves the HOW for all of it.
+
+## Requirements
+
+Carried forward from the brainstorm (R-IDs stable), grouped by epic in build order. These are the
+reviewer's and `/work`'s checklist; each maps to one or more Implementation Units below.
+
+**Epic 0 — Tiering spine**
+
+R1. A single tier rule governs every model/effort choice: judgment → Opus; mechanical/deterministic
+(census, link checks, file-existence, enumeration) → Sonnet/Haiku; read-only sampling/survey → Sonnet.
+
+R2. Enforced at both dispatch surfaces: (a) the **callable** ecosystem agents pin `model:` in frontmatter
+(the per-call-model half has no saga dispatch site — see KTD7); (b) a `/plan`-authored workflow spec
+carries an explicit per-unit `{model, effort}` annotation.
+
+R3. A workflow spec asserts the pilot↔fan-out same-tier invariant at authoring time — a mis-tiered pilot
+is an invalid oracle.
+
+R4. The tier rule is recorded once as prose where it auto-loads every session (global `~/.claude/CLAUDE.md`),
+not in `DECISIONS.md`.
+
+**Epic 1 — Execution-backend representation**
+
+R5. The `/plan` offer names dynamic workflows' **both** purposes — breadth/scale fan-out AND adversarial
+confidence (judge-panel / refute-N / perspective-diverse) — and a drift-guard test asserts every offer
+surface stays a superset of the `operator-choice.md` §3.2 purpose list.
+
+R6. The offer frames the team↔workflow choice on the **governance** axis (does the verdict need to stick —
+block a merge/deploy and persist — or is it throwaway?), not on "review depth," which both have.
+
+R7. The recommender distinguishes **gated** consensus (must block/persist → team-execution) from
+**advisory** consensus (N in-session votes → eligible for a workflow judge-panel) and stops hard-forcing
+team-execution on every consensus signal.
+
+R8. The operator-facing label is "dynamic workflows" via a display-label map; the stored enum value
+`cc-workflows-ultracode` is unchanged (frozen wire contract).
+
+**Epic 2 — Dynamic-workflow authoring**
+
+R9. `/plan` can author one structured execution-spec and emit from it **either** a runnable Claude Code
+workflow script **or** the team-execution markdown protocol; saga records a pointer, never vendors backend
+machinery.
+
+R10. Every fan-out unit declares an **enumerated** target list with post-run reconciliation — never a
+silent filter.
+
+R11. An authored workflow is capability-portable: every plan carries a runnable inline/serial baseline; the
+dynamic layer applies on a capable host; on off-host resume the choice is re-checked, a one-line downgrade
+is surfaced, and only the orchestration tier recompiles down (unit specs and tiers preserved).
+
+R12. Backend choice-vs-recommendation is recorded; a `/retro`/`/optimize` pass surfaces the override-rate
+(plus over/under-tier and budget-exhaustion signals) so any default re-weighting is evidence-driven.
+
+**Epic 3 — Hook harness**
+
+R13. A deterministic hook validates `marketplace.json` / `plugin.json` on edit (JSON parse + bracket-count)
+and blocks on failure with the offending line.
+
+R14. A hook nudges (does not write/block) when a `feat`/`fix` commit touches code but stages no
+`docs/engineering-journal/` entry, and ships so it can fire cross-repo.
+
+R15. A hook runs the repo's pre-push gate from a single-source gate manifest and reports by exception.
+
+**Epic 4 — Cheap executor + release guards**
+
+R16. Exactly one cheap-tier executor agent (haiku, Bash-only), dispatched by saga commands and inert until
+called, handles mechanical op-discriminated work.
+
+R17. A guard keeps the plugin release triad in sync (`plugin.json` ↔ `marketplace.json` ↔ `CHANGELOG.md`).
+
+R18. A SHA-stamp stager and a stale-main-after-squash guard, scoped to this repo, close the remaining
+release rituals.
+
+## Key Technical Decisions
+
+**KTD1 — One hand-authored ultracode workflow builds the campaign.** The plan stays decisions; the sibling
+`.workflow.js` is the execution harness (the `context-fleet-audit.workflow.js` precedent — control-flow
+only, agents do the work). Hand-authoring it now validates the R9 spec before Epic 2 automates it.
+
+**KTD2 — Per-unit `{model, effort}` tiering (operator-approved): 5 Opus / 11 Sonnet / 1 Haiku.** Rule:
+judgment → Opus, read-only survey → Sonnet, mechanical → Sonnet/Haiku. The full table is the Execution
+Spec below.
+
+**KTD3 — Full hands-off auto-merge (operator-chosen).** Each epic lands as its own PR, auto-merged when the
+5 required CI checks are green (`--admin` if branch protection needs it). The oracle is the test suite +
+the two plugin validators + the drift-guard tests; per-unit worktree isolation + rebase-before-merge
+prevents races. No mid-run operator checkpoint.
+
+**KTD4 — R7 gated-vs-advisory via an explicit interrogation question, work-shape pre-filled
+(operator-chosen).** `/plan` asks "does this verdict need to block a merge/deploy or persist as evidence?",
+defaulting to *gated* when deploy/security/persist signals are present, *advisory* otherwise. Advisory
+routes to the existing `adversarial_confidence` ultracode branch; gated keeps team-execution. The operator
+confirms.
+
+**KTD5 — Decouple, do not rename (R8).** A display-label map renders "dynamic workflows"; the enum string
+`cc-workflows-ultracode` is frozen (carried in persisted sagas). The label does **not** encode "(Claude
+Code only)" — the existing omit-off-host rule (`operator-choice.md` §4) already hides the option where it
+cannot run, so the suffix is on-host noise.
+
+**KTD6 — One spec, two emitters, saga points (R9).** The structured execution-spec lives as a delimited
+section authored into the plan; the two emitters produce sibling artifacts (a `.workflow.js` and the
+`## Team Structure` markdown); saga stores only `orchestration_ref`. The governance difference is *which
+emitter runs*, not the authoring.
+
+**KTD7 — Epic 0 scope correction: pin 4 agents, not 5.** `redis-channel/redis-channel-coach` is a
+reference pointer (the load-bearing guidance lives in the MCP server's `instructions=` field; "subagent
+invocations not expected") — pinning `model:` on it is inert, so it is documented exempt. saga has no
+`agents/` dir and no dispatch sites: the 4 callable agents live in 4 other plugins, dispatched by their own
+plugins, so R2's frontmatter pin carries the whole enforcement.
+
+**KTD8 — R4 is applied inline, not inside the workflow.** `~/.claude/CLAUDE.md` is a global file outside the
+repo; editing it must not happen in an unattended fan-out. The operator confirms the ~3-line rule addition
+out of band.
+
+**KTD9 — Rebase-before-merge discipline (from the reference pattern).** Every workflow agent runs
+`git fetch origin` and rebases the latest default branch before opening or merging its PR. The two
+saga.py-touching units (U3 instrument, U4 label map) live in different epics; their merge order resolves by
+rebase, not by a hard serialization.
+
+**KTD10 — R15 gate manifest is a small declarative file** co-located with the validators
+(`tools/gate-manifest.*`); the exact format is settled inside U9 (Epic 3 is independent and lowest-stakes,
+so the decision can land with its implementation).
+
+## Implementation Units
+
+Seventeen units, U-IDs stable, grouped by epic and dependency-ordered. Each unit is independently landable
+on its epic branch. The **Tier** field is the workflow step's `{model, effort}`; the **Test** field gives
+the repo-relative test path.
+
+### U1. Preflight — re-verify grounding facts on origin/main
+
+**Requirement:** gates the whole run (no R-ID).
+
+**Tier:** haiku / low.
+
+**Work:** confirm on `origin/main` that the 4 agents are unpinned, `ORCHESTRATION_MODES` matches
+`saga.py:71`, the `or needs_consensus` line is at `lifecycle_state.py:158`, and the repo has zero hooks.
+Reply `READY` or a short list of drift. HALT the workflow on drift.
+
+**Files:** read-only.
+
+**Test expectation:** none — a verification barrier, no code.
+
+**Dependencies:** none (first step).
+
+### U2. Pin the 4 callable ecosystem agents
+
+**Requirement:** R1, R2(a).
+
+**Tier:** sonnet / high.
+
+**Work:** add `model:` to frontmatter — `home-lab-ops/homelab-sre` → `opus`;
+`mission-control/sdlc-operator` → `sonnet`; `unifi/unifi-network-ops` → `sonnet`;
+`deploy/release-orchestrator` → `sonnet`. Document `redis-channel/redis-channel-coach` exempt (KTD7). Bump
+each touched plugin's release triad in the same change (`plugin.json` version, `.claude-plugin/marketplace.json`,
+`CHANGELOG.md`) per CLAUDE.md §6.
+
+**Files:** `plugins/{home-lab-ops,mission-control,unifi,deploy}/agents/*.md`, each plugin's `plugin.json`
++ `CHANGELOG.md`, `.claude-plugin/marketplace.json`.
+
+**Failure modes:** double-`]` corruption of `marketplace.json` (mitigated structurally by U7's hook once it
+lands, and by `python3 -m json.tool` validation here); version drift between the triad surfaces (U15 guards
+it later).
+
+**Test:** `tests/test_agent_tiering.py` (new) asserts the 4 agents carry their expected `model:` value and
+the coach is recorded exempt; existing plugin validators stay green.
+
+**Dependencies:** U1.
+
+### U3. Instrument choice-vs-recommendation recording
+
+**Requirement:** R12 (recording half; lands first so the field exists before any choice is recorded).
+
+**Tier:** sonnet / medium.
+
+**Work:** extend the saga envelope to record both the recommended backend and the operator's pick on each
+orchestration decision, so override-rate is computable later. No analysis yet (that is U13).
+
+**Files:** `plugins/saga/scripts/saga.py`, `plugins/saga/references/saga-spec.md` (field doc).
+
+**Failure modes:** an older saga lacking the field must load (backward-compatible default); never crash on
+absence.
+
+**Test:** `tests/test_saga_saga.py` asserts the recommendation+choice fields round-trip and absent-field
+sagas still load.
+
+**Dependencies:** U1. Shares `saga.py` with U4 → KTD9 rebase discipline.
+
+### U4. Display-label map (decouple, freeze the wire)
+
+**Requirement:** R8.
+
+**Tier:** sonnet / high.
+
+**Work:** add a display-label map (`cc-workflows-ultracode` → "dynamic workflows",
+`team-execution` → "team execution", `inline` → "inline"); route every offer surface's rendering through
+it; assert the enum value is unchanged. Label carries no "(Claude Code only)" suffix (KTD5).
+
+**Files:** `plugins/saga/scripts/saga.py` (or a small `lifecycle_state.py` helper), the offer surfaces in
+`plugins/saga/skills/{plan,work,loop,code-review}/SKILL.md`.
+
+**Failure modes:** a surface that renders the raw enum instead of the label (the drift-guard in U5 also
+covers naming); a map miss must fall back to the enum string, never error.
+
+**Test:** `tests/test_saga_saga.py` (or `tests/test_saga_plugin.py`) asserts the map renders "dynamic
+workflows" while `ORCHESTRATION_MODES` is byte-for-byte unchanged.
+
+**Dependencies:** U1. Shares `saga.py` with U3 → KTD9.
+
+### U5. Offer rewrite + drift-guard test
+
+**Requirement:** R5, R6.
+
+**Tier:** opus / high.
+
+**Work:** rewrite the `/plan` execution-backend offer (and the sibling offer in `code-review`) to name both
+workflow purposes and frame the team↔workflow fork on the governance axis. Add a drift-guard test asserting
+every offer surface's stated purpose list is a **superset** of `operator-choice.md` §3.2, so a future
+rebuild cannot silently drop a purpose.
+
+**Files:** `plugins/saga/skills/plan/SKILL.md` (the `:253` offer), `plugins/saga/skills/code-review/SKILL.md`,
+new `tests/test_operator_choice_drift.py`.
+
+**Failure modes:** the drift-guard must parse the §3.2 purpose list robustly (anchor on stable markers, not
+line numbers); a brittle assertion that breaks on benign reformatting is itself a regression.
+
+**Test:** `tests/test_operator_choice_drift.py` (new) — passes today, fails if any offer surface drops a
+§3.2 purpose.
+
+**Dependencies:** U1.
+
+### U6. Recommender split — gated vs advisory consensus (R7 keystone)
+
+**Requirement:** R7, KD5.
+
+**Tier:** opus / high.
+
+**Work:** in `recommend_execution_backend`, replace the single `needs_consensus` with a gated/advisory
+distinction. Gated → team-execution (unchanged path); advisory → feed the existing `adversarial_confidence`
+ultracode trigger; stop the unconditional `or needs_consensus` hard-force. Add the KTD4 interrogation
+question + the work-shape default to the `/plan` flow. Cover AE1 (advisory → ultracode) and AE2 (gated →
+team).
+
+**Files:** `plugins/saga/scripts/lifecycle_state.py`, `plugins/saga/references/operator-choice.md` (§3.1
+update), `plugins/saga/skills/plan/SKILL.md` (the new question), `tests/test_saga_plugin.py`.
+
+**Failure modes:** a contested-but-not-gated job must NOT regress to inline (it should reach the advisory
+ultracode branch); overlap (gated AND broad fan-out) still lists both alternatives; `has_code_surface`
+docs-gating preserved.
+
+**Test:** `tests/test_saga_plugin.py` — AE1, AE2, the overlap case, and the docs-gating case.
+
+**Dependencies:** U1. Touches `lifecycle_state.py` + `operator-choice.md` (U5 also edits offer prose, not
+this file).
+
+### U7. Marketplace/plugin.json validation hook (R13)
+
+**Requirement:** R13.
+
+**Tier:** sonnet / high.
+
+**Work:** the repo's first hook. A `PreToolUse`/edit-time hook that JSON-parses `marketplace.json` /
+`plugin.json` and asserts balanced brackets, blocking on failure (exit 2) with the offending line. Ship as a
+plugin's `hooks/hooks.json` (the langfuse-style cross-repo pattern) wired into the plugin that owns
+marketplace integrity.
+
+**Files:** new `plugins/<owner>/hooks/hooks.json` + the validator script, plugin release triad bump.
+
+**Failure modes:** the hook must not block unrelated edits; must handle a transiently half-written file
+without false-blocking a legitimate multi-edit; exit-code contract correct (2 blocks).
+
+**Test:** `tests/test_marketplace_hook.py` (new) — AE5 (unbalanced brackets → block + named line; valid JSON
+→ pass).
+
+**Dependencies:** U1.
+
+### U8. Journal-omission nudge hook (R14)
+
+**Requirement:** R14.
+
+**Tier:** sonnet / high.
+
+**Work:** a non-blocking hook that, on a `feat`/`fix` commit touching code with no staged
+`docs/engineering-journal/` entry, surfaces a nudge. Does not write the entry and does not block. Ships so
+it can fire cross-repo (user-enabled).
+
+**Files:** the hook entry in `hooks/hooks.json` + script.
+
+**Failure modes:** must not nudge on docs-only or chore commits; must not block; cross-repo path assumptions
+must degrade quietly where the journal dir is absent.
+
+**Test:** `tests/test_journal_nudge_hook.py` (new) — AE6 (code `feat`/`fix`, no journal → nudge, no write,
+no block; docs-only → silent).
+
+**Dependencies:** U1. Co-located with U7's `hooks.json` → authored after U7 on the E3 branch.
+
+### U9. Pre-push gate hook + manifest (R15)
+
+**Requirement:** R15, KTD10.
+
+**Tier:** sonnet / medium.
+
+**Work:** a small declarative gate manifest (`tools/gate-manifest.*`) listing the pre-push gate
+(`ruff format --check`, `ruff check`, the two validators, `pytest`) and a hook that runs it and reports by
+exception. Settle the manifest format here.
+
+**Files:** new `tools/gate-manifest.*`, the hook entry + runner.
+
+**Failure modes:** report-by-exception (silence on pass); must not duplicate the CI definition divergently —
+single source.
+
+**Test:** `tests/test_pre_push_gate.py` (new) — manifest drives the gate; a seeded failure reports, a clean
+tree is silent.
+
+**Dependencies:** U1. Co-located with U7/U8 on the E3 branch.
+
+### U10. Execution-spec schema + workflow-script emitter (R9 keystone)
+
+**Requirement:** R9, R3, R10.
+
+**Tier:** opus / high.
+
+**Work:** define the structured execution-spec (units, per-unit `{model, effort}`, return contracts,
+dependency barriers, escalations, enumerated fan-out targets) and the emitter that produces a runnable
+Claude Code workflow script from it. Assert the pilot↔fan-out same-tier invariant (R3) and enumerated-target
+reconciliation (R10) at emit time. This plan's own sibling `.workflow.js` is the worked reference.
+
+**Files:** new `plugins/saga/scripts/<execution_spec>.py` + emitter, `plugins/saga/references/` doc.
+
+**Failure modes:** a fan-out unit without an enumerated target list must fail emit (R10); a pilot at a
+different tier than its fan-out must fail emit (R3); budget-exhaustion guidance baked into generated
+cheap-tier agents (cap output, mandatory emit, skim, batch).
+
+**Test:** `tests/test_workflow_emitter.py` (new) — a spec emits a valid script with per-unit tiers; missing
+enumerated targets and mis-tiered pilots are rejected.
+
+**Dependencies:** U2, U6 merged (Epic 0 + Epic 1 barrier).
+
+### U11. team-execution markdown emitter + saga pointer (R9 second emitter)
+
+**Requirement:** R9, KD4.
+
+**Tier:** sonnet / high.
+
+**Work:** a second emitter from the same spec producing the `## Team Structure` markdown (mirroring
+`team-execution/SKILL.md:234`); saga records the `orchestration_ref` pointer. The governance choice selects
+the emitter.
+
+**Files:** the emitter beside U10's, `plugins/saga/scripts/saga.py` (pointer recording reuse).
+
+**Failure modes:** the markdown must match the existing template's parsed structure (workers/reviewers/
+validators/gates); never vendor team-execution machinery.
+
+**Test:** `tests/test_team_emitter.py` (new) — the same spec yields valid Team Structure markdown.
+
+**Dependencies:** U10 (shares the spec schema).
+
+### U12. Capability-portable degradation (R11)
+
+**Requirement:** R11.
+
+**Tier:** opus / high.
+
+**Work:** every authored plan carries a runnable inline/serial baseline; on off-host resume re-check the
+Workflow tool, surface a one-line downgrade, and recompile only the orchestration tier down to
+team-execution/inline with unit specs + per-unit tiers preserved. Record the downgrade.
+
+**Files:** `plugins/saga/scripts/lifecycle_state.py` (capability re-check), the emitter (baseline embed),
+saga record.
+
+**Failure modes:** AE3 — off-host resume must downgrade with a note, never error or silently run nothing;
+unit tiers must survive the recompile.
+
+**Test:** `tests/test_capability_degrade.py` (new) — AE3.
+
+**Dependencies:** U10.
+
+### U13. Override-rate surface (R12 analysis half)
+
+**Requirement:** R12.
+
+**Tier:** sonnet / high.
+
+**Work:** a `/retro`/`/optimize` pass that reads U3's recorded data and surfaces override-rate, over/under-
+tier, and budget-exhaustion signals. Operational measurement accrues post-merge; this builds the surface.
+
+**Files:** `plugins/saga/skills/retro/SKILL.md` (or `optimize`), a small reader helper.
+
+**Failure modes:** zero-data must report "no data yet," not divide-by-zero; the surface is read-only.
+
+**Test:** `tests/test_override_rate.py` (new) — recorded fixtures → correct rate; empty → graceful.
+
+**Dependencies:** U3 (the recorded field).
+
+### U14. Cheap-tier mechanical executor agent (R16)
+
+**Requirement:** R16.
+
+**Tier:** sonnet / high (authoring; the agent itself runs **haiku**).
+
+**Work:** one `model: haiku`, Bash-only, op-discriminated executor agent, dispatched by saga commands and
+inert until called. Designing the op-discrimination + dispatch contract is the judgment; the runtime is
+haiku.
+
+**Files:** new `plugins/saga/agents/mechanical-executor.md` (or the owning plugin), dispatch wiring in the
+saga skills that use it, release triad bump.
+
+**Failure modes:** must be inert until dispatched (no auto-trigger); Bash-only tool scope; op-discriminated
+so an unknown op is rejected, not guessed.
+
+**Test:** `tests/test_mechanical_executor.py` (new) — frontmatter pins haiku + Bash-only; op-discrimination
+rejects unknown ops.
+
+**Dependencies:** U2 merged (Epic 0 barrier — needs the tier rule).
+
+### U15. Release-triad sync guard (R17)
+
+**Requirement:** R17.
+
+**Tier:** sonnet / medium.
+
+**Work:** a guard (test or hook) that fails when `plugin.json` version, `.claude-plugin/marketplace.json`,
+and `CHANGELOG.md` disagree on a version-bearing change.
+
+**Files:** new `tests/test_release_triad.py` and/or a hook entry.
+
+**Failure modes:** must fire only on version-bearing changes; clear message naming the drifting surface.
+
+**Test:** `tests/test_release_triad.py` (new) — a seeded mismatch fails; a synced triad passes.
+
+**Dependencies:** U2 (Epic 0 barrier).
+
+### U16. SHA-stamp stager + stale-main guard (R18)
+
+**Requirement:** R18.
+
+**Tier:** sonnet / medium.
+
+**Work:** a SHA-stamp stager and a stale-main-after-squash guard, scoped to this repo, closing the remaining
+release rituals.
+
+**Files:** new `tests/test_release_rituals.py` and/or `tools/` helpers.
+
+**Failure modes:** this-repo-local only (do not assume the idiom cross-repo); the stale-main guard must not
+false-fire on a legitimately current main.
+
+**Test:** `tests/test_release_rituals.py` (new).
+
+**Dependencies:** U2 (Epic 0 barrier).
+
+### U17. Final verification + journal
+
+**Requirement:** all (closure).
+
+**Tier:** opus / high.
+
+**Work:** run the full gate fleet-wide (`ruff format --check`, `ruff check`, the two validators, `pytest`,
+`mypy`), confirm green, write the `DECISIONS.md` + `LEARNINGS.md` entries the campaign earned, and a
+reconciliation report mapping every R-ID to its landed unit (no silent skips).
+
+**Files:** `docs/engineering-journal/{DECISIONS,LEARNINGS}.md`, a final report under `docs/analysis/`.
+
+**Test expectation:** none — it *runs* the suite rather than being tested by it.
+
+**Dependencies:** all prior units merged.
+
+## Execution Spec (the workflow shape)
+
+This is the R9 spec demonstrated by hand — the sibling
+[`2026-06-21-saga-tiering-and-execution-campaign.workflow.js`](./2026-06-21-saga-tiering-and-execution-campaign.workflow.js)
+encodes it. Each unit is one `agent()` call at its tier; epics are PR-isolated phases.
+
+**Phases and barriers.** `Preflight` (U1) → `parallel(Epic 0 {U2,U3}, Epic 1 {U4,U5,U6}, Epic 3
+{U7,U8,U9})` → barrier (E0+E1+E3 merged) → `parallel(Epic 2 {U10,U11,U12,U13}, Epic 4 {U14,U15,U16})` →
+`Final` (U17). Epic 2 needs E0+E1; Epic 4 needs E0; Epic 3 is fully independent. Within an epic, units run
+serially on one worktree+branch (no intra-epic race) and land as one PR; epics run in parallel.
+
+**Per-unit tier table (KTD2).**
+
+| Unit | Epic | `model` | `effort` | Shape |
+|---|---|---|---|---|
+| U1 | pre | haiku | low | verification barrier |
+| U2 | 0 | sonnet | high | mechanical edits across 5 release triads |
+| U3 | 0 | sonnet | medium | bounded field plumbing |
+| U4 | 1 | sonnet | high | additive, wire-frozen, test-gated |
+| U5 | 1 | opus | high | prose judgment + drift-guard design |
+| U6 | 1 | opus | high | the load-bearing routing change |
+| U7 | 3 | sonnet | high | greenfield hook harness |
+| U8 | 3 | sonnet | high | heuristic, bounded |
+| U9 | 3 | sonnet | medium | mechanical once manifest decided |
+| U10 | 2 | opus | high | keystone spec + emitter |
+| U11 | 2 | sonnet | high | mirrors existing template |
+| U12 | 2 | opus | high | degradation semantics |
+| U13 | 2 | sonnet | high | analysis pass, bounded |
+| U14 | 4 | sonnet | high | authoring the dispatch contract |
+| U15 | 4 | sonnet | medium | bounded guard |
+| U16 | 4 | sonnet | medium | bounded, this-repo-local |
+| U17 | fin | opus | high | final verify + journal |
+
+**Safety model.** The oracle is the test suite + the two validators + the drift-guards (no human review
+mid-run, per KTD3). Each epic agent runs the full local gate before opening its PR, fetches+rebases latest
+main (KTD9), then auto-merges when the 5 required CI checks are green. A budget floor checkpoints the run;
+a circuit breaker halts on repeated gate failure. The run HALTS on a preflight drift (U1) or a failed
+barrier (a required epic PR not merged).
+
+**Out of the workflow.** R4's global `~/.claude/CLAUDE.md` tier rule is applied inline with operator
+confirmation (KTD8), not by an autonomous agent.
+
+## Scope Boundaries
+
+In scope: all 17 units above (the 15 ideation survivors organized as 5 epics, plus the tiering-seam
+resolution), built via the one workflow.
+
+Out of scope:
+- The revivable cuts (doc2 R1-R7; doc1 R-items) unless explicitly revived.
+- Cross-host **routing** (shipping a workflow to a capable host); only the degradation path (R11) is in.
+- Redesigning the enum into a continuous spectrum or two-axis vocabulary.
+- Editing the global `~/.claude/CLAUDE.md` from inside the workflow (KTD8 — inline only).
+
+Deferred to Follow-Up Work:
+- Re-weighting any recommender default — blocked on real override-rate data (R12 measures; it does not
+  re-weight).
+
+## Risk Analysis & Mitigation
+
+**Autonomous edits to load-bearing logic (U6 recommender, U10 spec).** A subtle recommender regression
+mis-routes every future job. *Mitigation:* AE1/AE2/overlap/docs-gating tests gate U6; the drift-guard (U5)
+catches purpose-list erosion; full hands-off still gates each PR on the complete CI suite — a red gate
+blocks the auto-merge.
+
+**`marketplace.json` double-`]` corruption during the U2 triad bumps.** *Mitigation:* `python3 -m json.tool`
+validation in U2; U7 makes it structurally unrepresentable thereafter (and U7 is in the parallel first
+wave).
+
+**Cross-epic `saga.py` conflict (U3 vs U4).** *Mitigation:* KTD9 rebase-before-merge; both are small,
+additive edits.
+
+**Cheap-tier budget exhaustion in generated agents (R9).** *Mitigation:* U10 bakes the
+`workflow_structuredoutput_budget` lesson (cap output, mandatory emit, skim, batch) into emitted cheap-tier
+agents; re-run only failed indices.
+
+**PR/CI volume (5 epic PRs + CI each).** *Mitigation:* epic-grouped PRs (not per-unit) keep it to ~5 CI
+runs; epics parallelize; a budget floor checkpoints for resume.
+
+## Dependencies / Assumptions
+
+- **Sequencing:** Epic 0 precedes Epic 2 (U10) and Epic 4 (U14-U16); Epic 1 precedes Epic 2; Epic 3 is
+  independent. Encoded as workflow barriers.
+- **Capability gate:** dynamic workflows run on Claude Code only — this is why the offer omits the option
+  off-host and why R11 (degradation) exists. The workflow itself requires the Workflow tool to run.
+- **Verified facts (2026-06-21, 7-plugin tree):** 4 callable agents unpinned (coach exempt); zero hooks;
+  `adversarial_confidence` already a recommender trigger (`lifecycle_state.py:163`); `cc-workflows-ultracode`
+  carried in persisted sagas (why R8 freezes it); recommender tested in `tests/test_saga_plugin.py`; the two
+  validators are `marketplace/validator/validate.py` + `scripts/validate_plugins.py`.
+- **Assumption:** the Workflow tool's per-agent `model`/`effort` overrides and `budget` API are stable —
+  R3, R9, R12 and this campaign's own harness depend on them.
+- **Release-surface obligation (cross-cutting):** every epic that changes plugin behavior bumps the release
+  triad in the same PR (CLAUDE.md §6). Epics 0-2 modify saga; Epic 3 adds hooks to a plugin; Epic 4 adds an
+  agent — each carries it.
+
+## Success Metrics
+
+- **Epic 0:** no saga-dispatched subagent runs richer than its work warrants; the tier rule is loaded every
+  session.
+- **Epic 1:** the offer makes consensus-via-workflows legible without opening the contract; the drift-guard
+  fails if a future rebuild drops a purpose; AE1/AE2 pass.
+- **Epic 2:** a dynamic pick yields a runnable, correctly-tiered artifact with no silent-skip path; off-host
+  resume degrades with a recorded note (AE3).
+- **Epic 3:** the double-`]` corruption cannot reach a commit (AE5); a code-only `feat`/`fix` with no journal
+  entry is nudged (AE6).
+- **Epic 4:** mechanical handoff runs on haiku; the release triad cannot drift silently.
+- **Campaign:** the full gate is green on main; the U17 reconciliation maps every R-ID to a landed unit.
+
+## Sources / Research
+
+- Requirements: `docs/brainstorms/2026-06-20-saga-tiering-and-execution-campaign-requirements.md`.
+- Grounding (`file:line`): `plugins/saga/scripts/lifecycle_state.py:148-163` (the `or needs_consensus`
+  hard-force + the existing `adversarial_confidence` branch); `plugins/saga/scripts/saga.py:71`
+  (`ORCHESTRATION_MODES`), `:1077` (`--orchestration-mode` choices); `plugins/saga/skills/plan/SKILL.md:253`
+  (the offer under-sell); `plugins/saga/references/operator-choice.md` §3.2 / §4 / §6; `team-execution/SKILL.md:234`
+  (the markdown template); recommender tests in `tests/test_saga_plugin.py`; validators at
+  `marketplace/validator/validate.py` + `scripts/validate_plugins.py`.
+- The plan→script reference: `infiquetra-context-library/scripts/context-fleet-audit.workflow.js` (per-agent
+  `{model, effort}`, pilot↔fan-out same-tier invariant, enumerated-target reconciliation / the silent-skip
+  lesson behind R10, budget floor + circuit breaker, rebase-before-merge).
+- Journal: `DECISIONS.md` `#operator-choice-framework`; `LEARNINGS.md` 2026-06-13 (the team↔workflow line is
+  governance, not review depth); the `workflow_structuredoutput_budget` lesson (binds R9's cheap-tier agents).

--- a/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
+++ b/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
@@ -1,0 +1,350 @@
+export const meta = {
+  name: 'saga-tiering-execution-campaign',
+  description:
+    'Build the saga tiering + execution-mechanism campaign (5 epics, 17 units) with a per-unit {model,effort} tier on every step. ' +
+    'Epic-isolated PRs, full hands-off auto-merge when CI is green. Opus for judgment (offer rewrite, recommender split, the spec ' +
+    'emitter, degradation, final verify); Sonnet for bounded builds; Haiku for the preflight existence check. Control-flow only — ' +
+    'every agent reads the plan as its authoritative spec.',
+  phases: [
+    { title: 'Preflight' },
+    { title: 'Epic 0 - Tiering', model: 'sonnet' },
+    { title: 'Epic 1 - Representation', model: 'opus' },
+    { title: 'Epic 3 - Hooks', model: 'sonnet' },
+    { title: 'Epic 2 - Authoring', model: 'opus' },
+    { title: 'Epic 4 - Executor + guards', model: 'sonnet' },
+    { title: 'Final', model: 'opus' },
+  ],
+}
+
+// =============================================================================
+// Saga Tiering & Execution-Mechanism Campaign -- execution harness.
+//
+// Authoritative spec (READ IT, do not re-derive):
+//   infiquetra-claude-plugins/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
+//   (R1-R18, U1-U17, KTD1-KTD10, the per-unit tier table, AE1-AE6).
+//
+// CONTROL FLOW only. The agents do the real work (edit code, add tests, run the
+// gate, open + auto-merge PRs). Each agent is told to read the plan first and
+// implement its unit verbatim.
+//
+// Per-unit model tiering (KTD2, operator-approved): 5 Opus / 11 Sonnet / 1 Haiku.
+// INVARIANT mirrored from the reference (context-fleet-audit.workflow.js): a unit's
+// tier matches its work shape -- judgment->Opus, bounded build->Sonnet, existence
+// check->Haiku. The gate+merge step runs Sonnet/high (mechanical gate-fixing).
+//
+// Topology (KTD3 full hands-off; dependency barriers from the plan):
+//   Preflight (U1, halt-on-drift)
+//     -> parallel( Epic0 {U2,U3}, Epic1 {U4,U5,U6}, Epic3 {U7,U8,U9} )   [first wave]
+//     -> BARRIER: Epic0 + Epic1 merged (Epic2 needs both; Epic4 needs Epic0)
+//     -> parallel( Epic2 {U10,U11,U12,U13}, Epic4 {U14,U15,U16} )         [second wave]
+//     -> Final (U17): full gate fleet-wide + journal + R-ID reconciliation.
+//
+// Each epic runs its units SERIALLY on ONE worktree+branch (no intra-epic race)
+// and lands as ONE PR. Epics run in parallel; cross-epic saga.py overlap (U3 vs U4)
+// resolves by rebase-before-merge (KTD9). The oracle is the test suite + the two
+// validators + the drift-guards -- a red gate blocks the auto-merge.
+//
+// Resume: re-run with {scriptPath, resumeFromRunId}. Merge agents probe for an
+// already-open/merged PR and a pre-existing worktree, so a re-run skips landed epics.
+// =============================================================================
+
+const REPO = '/Users/jefcox/workspace/infiquetra/infiquetra-claude-plugins'
+const PLAN_PATH = REPO + '/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md'
+const WT = REPO + '/.claude/worktrees/campaign'
+const BUDGET_FLOOR = 60000 // checkpoint before a new wave when remaining output budget drops below this
+
+// Every agent prompt starts with this so the plan is authoritative and the rules are uniform.
+const SPEC =
+  'AUTHORITATIVE SPEC: read ' + PLAN_PATH + ' in full FIRST -- it is the spec (R-IDs, U-IDs, KTDs, AEs). ' +
+  'Implement your assigned unit EXACTLY as its `### U<N>.` section says. ' +
+  'RULES: (1) On any plugin behavior/metadata change, bump the release triad in the SAME change -- the plugin ' +
+  "`.claude-plugin/plugin.json` version, `.claude-plugin/marketplace.json`, and the plugin `CHANGELOG.md` (CLAUDE.md section 6); " +
+  'validate marketplace.json with `python3 -m json.tool` after editing it. ' +
+  '(2) Do NOT edit docs/engineering-journal/ -- U17 writes the campaign DECISIONS/LEARNINGS to avoid cross-epic journal conflicts. ' +
+  '(3) Follow repo commit/PR conventions (`type(scope): description`, atomic); NEVER add attribution lines ' +
+  '("Generated with", "Co-authored-by") to commits, PRs, or any content. ' +
+  '(4) Feature-bearing units add real tests at the repo-relative path the plan names; run them before reporting done. ' +
+  'Your final message IS the structured return value -- no human-facing prose.'
+
+// ---- structured-return schemas ----
+const PREFLIGHT_SCHEMA = {
+  type: 'object',
+  required: ['ready', 'drift'],
+  properties: {
+    ready: { type: 'boolean', description: 'true iff every grounding fact still holds on origin/main' },
+    drift: { type: 'array', items: { type: 'string' }, description: 'each fact that no longer holds (empty iff ready)' },
+  },
+}
+
+const UNIT_SCHEMA = {
+  type: 'object',
+  required: ['unit', 'done', 'files'],
+  properties: {
+    unit: { type: 'string' },
+    done: { type: 'boolean', description: 'edits committed to the epic worktree + unit tests pass locally' },
+    files: { type: 'array', items: { type: 'string' } },
+    testAdded: { type: 'string', description: 'repo-relative test path, or "none -- <reason>"' },
+    note: { type: 'string' },
+  },
+}
+
+const EPIC_SCHEMA = {
+  type: 'object',
+  required: ['epic', 'gatePassed', 'ciGreen', 'merged'],
+  properties: {
+    epic: { type: 'string' },
+    pr: { type: 'string' },
+    gatePassed: { type: 'boolean', description: 'full local gate (ruff format+check, both validators, pytest, mypy) green' },
+    ciGreen: { type: 'boolean', description: 'all 5 required CI checks SUCCESS' },
+    merged: { type: 'boolean', description: 'true ONLY if the squash-merge landed' },
+    units: { type: 'array', items: { type: 'string' } },
+    reason: { type: 'string' },
+  },
+}
+
+const FINAL_SCHEMA = {
+  type: 'object',
+  required: ['gateGreen', 'rIdsCovered', 'rIdsTotal', 'merged'],
+  properties: {
+    gateGreen: { type: 'boolean' },
+    rIdsCovered: { type: 'number' },
+    rIdsTotal: { type: 'number' },
+    merged: { type: 'boolean' },
+    reportPath: { type: 'string' },
+    note: { type: 'string' },
+  },
+}
+
+function budgetExhausted() {
+  return budget.total && budget.remaining() < BUDGET_FLOOR
+}
+
+// ---- the epic runner: serial tiered units on one worktree, then gate + auto-merge ----
+async function runEpic(epicId, phaseTitle, branch, units) {
+  const dir = WT + '/' + epicId
+  for (let i = 0; i < units.length; i++) {
+    const u = units[i]
+    const setup =
+      i === 0
+        ? 'Create the epic worktree FIRST (reuse it if a prior run left it): ' +
+          '`git -C ' + REPO + ' fetch origin && git -C ' + REPO + ' worktree add ' + dir + ' -b ' + branch + ' origin/main` ' +
+          '(if the branch already exists, `git -C ' + REPO + ' worktree add ' + dir + ' ' + branch + '`). '
+        : 'The epic worktree already exists at ' + dir + ' on branch ' + branch + '. '
+    const res = await agent(
+      SPEC +
+        '\n\nWORKTREE: ' + setup +
+        'Make ALL edits inside ' + dir + ' and commit there (`git -C ' + dir + ' add -A && git -C ' + dir + ' commit -m "<type(scope): msg>"`). ' +
+        'Do NOT push or open a PR -- the epic merge step does that.\n\n' + u.prompt,
+      { schema: UNIT_SCHEMA, label: u.label, phase: phaseTitle, model: u.model, effort: u.effort }
+    )
+    if (!res || !res.done) {
+      throw new Error('HALT: ' + epicId + ' unit ' + u.label + ' failed: ' + (res ? res.note || 'not done' : 'dead agent'))
+    }
+    log(epicId + ': ' + u.label + ' done (' + (res.files || []).length + ' files; test=' + (res.testAdded || '?') + ')')
+  }
+
+  // Gate + PR + auto-merge -- FULL HANDS-OFF (KTD3): merge when CI is green, no human checkpoint.
+  const merge = await agent(
+    SPEC +
+      '\n\nEPIC MERGE STEP for ' + epicId + ' (worktree ' + dir + ', branch ' + branch + '). FULL HANDS-OFF -- merge when green.\n' +
+      '1) From WITHIN ' + dir + ' run the full local gate: `ruff format --check .`; `ruff check .`; ' +
+      '`python3 scripts/validate_plugins.py`; `python3 marketplace/validator/validate.py`; `uv run pytest`; `uv run mypy plugins/`. ' +
+      'If any FAILS, fix it in the worktree (small, in-scope fixes only) and re-run until all pass. Set gatePassed accordingly.\n' +
+      '2) `git -C ' + dir + ' fetch origin && git -C ' + dir + ' rebase origin/main` -- resolve conflicts by integrating BOTH sides ' +
+      '(watch plugins/saga/scripts/saga.py and .claude-plugin/marketplace.json). Re-run the gate if the rebase changed anything.\n' +
+      '3) Push and open a PR (`gh pr create`; title "' + epicId + ': <summary>"). Probe first: if a PR for this branch already exists, reuse it; if already MERGED, set merged=true and skip to step 5.\n' +
+      '4) Poll the 5 REQUIRED checks (Tests (Python 3.12) / Validate Plugins / Lint / Type Check / Security Scan). "Publish Plugin" SKIPPED is expected and NOT a failure. ' +
+      'When all 5 are SUCCESS, squash-merge: `gh pr merge --squash --admin --delete-branch`. If any required check FAILS, do NOT merge -- set ciGreen=false, merged=false, and report the failing check.\n' +
+      '5) `git -C ' + REPO + ' worktree remove ' + dir + ' --force` (ignore if already gone).\n' +
+      'Return EPIC_SCHEMA. merged=true ONLY if the squash-merge actually landed on origin/main.',
+    { schema: EPIC_SCHEMA, label: epicId + ' gate+merge', phase: phaseTitle, model: 'sonnet', effort: 'high' }
+  )
+  if (!merge) return { epic: epicId, gatePassed: false, ciGreen: false, merged: false, reason: 'merge agent died' }
+  log(epicId + ' merge: gate=' + merge.gatePassed + ' ci=' + merge.ciGreen + ' merged=' + merge.merged + (merge.pr ? ' (' + merge.pr + ')' : ''))
+  return merge
+}
+
+// ---- unit definitions (terse recaps; the plan section is authoritative) ----
+const EPIC0 = [
+  {
+    label: 'U2 agent pins', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U2 -- pin model: on the 4 CALLABLE ecosystem agents: home-lab-ops/homelab-sre->opus, ' +
+      'mission-control/sdlc-operator->sonnet, unifi/unifi-network-ops->sonnet, deploy/release-orchestrator->sonnet. ' +
+      'Document redis-channel/redis-channel-coach EXEMPT (KTD7: an MCP-instructions pointer, not Agent-dispatched). ' +
+      'Bump each touched plugin release triad. Add tests/test_agent_tiering.py asserting the 4 pins + the coach exemption.',
+  },
+  {
+    label: 'U3 choice instrument', model: 'sonnet', effort: 'medium',
+    prompt: 'UNIT U3 -- record recommended-vs-chosen backend on each orchestration decision in the saga envelope ' +
+      '(backward-compatible: older sagas without the field must still load). Extend tests/test_saga_saga.py + saga-spec.md. ' +
+      'No analysis yet (that is U13).',
+  },
+]
+const EPIC1 = [
+  {
+    label: 'U4 label map', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U4 -- add a display-label map (cc-workflows-ultracode->"dynamic workflows", team-execution->"team execution", ' +
+      'inline->"inline"); route every offer surface through it; ASSERT the enum value ORCHESTRATION_MODES is byte-for-byte unchanged ' +
+      '(frozen wire contract, KTD5; no "(Claude Code only)" suffix). A map miss falls back to the enum string, never errors. ' +
+      'Test in tests/test_saga_saga.py.',
+  },
+  {
+    label: 'U5 offer + drift-guard', model: 'opus', effort: 'high',
+    prompt: 'UNIT U5 -- rewrite the /plan (skills/plan/SKILL.md ~:253) AND /code-review offer to name BOTH dynamic-workflow purposes ' +
+      '(breadth fan-out AND adversarial confidence) and frame the team<->workflow fork on the GOVERNANCE axis (does the verdict need ' +
+      'to stick?), not "review depth". Add tests/test_operator_choice_drift.py asserting every offer surface is a SUPERSET of ' +
+      'operator-choice.md section 3.2 purposes (anchor on stable markers, not line numbers).',
+  },
+  {
+    label: 'U6 recommender split', model: 'opus', effort: 'high',
+    prompt: 'UNIT U6 (R7 KEYSTONE) -- in recommend_execution_backend (lifecycle_state.py), replace the single needs_consensus with ' +
+      'a GATED vs ADVISORY distinction: gated (block/persist)->team-execution; advisory->feed the EXISTING adversarial_confidence ' +
+      'ultracode trigger (already at :163); stop the unconditional `or needs_consensus` hard-force (:158). Add the KTD4 interrogation ' +
+      'question + work-shape default to skills/plan/SKILL.md. Update operator-choice.md section 3.1. Cover AE1 (advisory->ultracode), ' +
+      'AE2 (gated->team), the overlap case (both alternatives listed), and the docs-gating case in tests/test_saga_plugin.py.',
+  },
+]
+const EPIC3 = [
+  {
+    label: 'U7 marketplace hook', model: 'sonnet', effort: 'high',
+    prompt: "UNIT U7 (R13) -- the repo's FIRST hook: a plugin hooks/hooks.json that on edit JSON-parses marketplace.json/plugin.json " +
+      'and asserts balanced brackets, BLOCKING on failure (exit 2) with the offending line. Wire it into the plugin that owns ' +
+      'marketplace integrity; bump that plugin triad. Add tests/test_marketplace_hook.py (AE5).',
+  },
+  {
+    label: 'U8 journal nudge hook', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U8 (R14) -- a NON-blocking, NON-writing nudge hook: on a feat/fix commit that touches code but stages no ' +
+      'docs/engineering-journal/ entry, surface a nudge. Docs-only/chore commits stay silent. Cross-repo-safe (degrade quietly where ' +
+      'the journal dir is absent). Co-locate in the U7 hooks.json. Add tests/test_journal_nudge_hook.py (AE6).',
+  },
+  {
+    label: 'U9 pre-push gate hook', model: 'sonnet', effort: 'medium',
+    prompt: 'UNIT U9 (R15, KTD10) -- a single-source declarative tools/gate-manifest.* listing the pre-push gate (ruff format --check, ' +
+      'ruff check, both validators, pytest) + a hook that runs it and REPORTS BY EXCEPTION (silent on pass). Settle the manifest format ' +
+      'here. Add tests/test_pre_push_gate.py.',
+  },
+]
+const EPIC2 = [
+  {
+    label: 'U10 spec + workflow emitter', model: 'opus', effort: 'high',
+    prompt: 'UNIT U10 (R9 KEYSTONE) -- define the structured execution-spec (units, per-unit {model,effort}, return contracts, dependency ' +
+      'barriers, escalations, ENUMERATED fan-out targets) and the emitter producing a runnable Claude Code workflow script from it. ' +
+      'FAIL EMIT on a fan-out unit without enumerated targets (R10) or a pilot at a different tier than its fan-out (R3). Bake the ' +
+      'workflow_structuredoutput_budget lesson (cap output, mandatory emit, skim, batch) into generated cheap-tier agents. This plan' +
+      "'s own sibling .workflow.js is the worked reference. Add tests/test_workflow_emitter.py.",
+  },
+  {
+    label: 'U11 team-exec emitter', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U11 (R9 2nd emitter) -- a second emitter from the SAME U10 spec producing the ## Team Structure markdown ' +
+      '(mirror team-execution/skills/team-execution/SKILL.md ~:234) + record the saga orchestration_ref pointer (never vendor ' +
+      'team-execution machinery). Add tests/test_team_emitter.py.',
+  },
+  {
+    label: 'U12 capability degrade', model: 'opus', effort: 'high',
+    prompt: 'UNIT U12 (R11) -- every authored plan carries a runnable inline/serial baseline; on off-host resume re-check the Workflow ' +
+      'tool, surface a one-line downgrade, recompile ONLY the orchestration tier down to team-execution/inline with unit specs + ' +
+      'per-unit tiers PRESERVED, and record the downgrade. Add tests/test_capability_degrade.py (AE3: never error/silently-run-nothing).',
+  },
+  {
+    label: 'U13 override-rate surface', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U13 (R12 analysis) -- a /retro (or /optimize) pass that reads U3 recorded data and surfaces override-rate + over/under-' +
+      'tier + budget-exhaustion signals. Zero-data reports "no data yet" (no divide-by-zero); read-only. Add tests/test_override_rate.py.',
+  },
+]
+const EPIC4 = [
+  {
+    label: 'U14 cheap executor', model: 'sonnet', effort: 'high',
+    prompt: 'UNIT U14 (R16) -- author ONE model:haiku, Bash-only, op-discriminated mechanical executor agent, dispatched by saga commands ' +
+      'and INERT until called (no auto-trigger; unknown op rejected, not guessed). Wire the dispatch; bump the owning plugin triad. ' +
+      'Add tests/test_mechanical_executor.py (haiku + Bash-only frontmatter; op-discrimination rejects unknown ops).',
+  },
+  {
+    label: 'U15 release-triad guard', model: 'sonnet', effort: 'medium',
+    prompt: 'UNIT U15 (R17) -- a guard that FAILS when plugin.json version, .claude-plugin/marketplace.json, and CHANGELOG.md disagree on a ' +
+      'version-bearing change (fires only on version-bearing changes; message names the drifting surface). Add tests/test_release_triad.py.',
+  },
+  {
+    label: 'U16 release rituals', model: 'sonnet', effort: 'medium',
+    prompt: 'UNIT U16 (R18) -- a SHA-stamp stager + a stale-main-after-squash guard, THIS-REPO-LOCAL only (do not assume cross-repo; do not ' +
+      'false-fire on a current main). Add tests/test_release_rituals.py.',
+  },
+]
+
+// =============================================================================
+// PREFLIGHT -- re-verify the grounding facts before fanning out (U1)
+// =============================================================================
+phase('Preflight')
+const pf = await agent(
+  SPEC +
+    '\n\nUNIT U1 -- PREFLIGHT (read-only). Verify on origin/main of ' + REPO + ' (git fetch first): ' +
+    '(a) the 4 agents home-lab-ops/homelab-sre, mission-control/sdlc-operator, unifi/unifi-network-ops, deploy/release-orchestrator ' +
+    'have NO model: frontmatter line; (b) plugins/saga/scripts/saga.py:71 still defines ' +
+    'ORCHESTRATION_MODES = ("inline", "team-execution", "cc-workflows-ultracode"); (c) plugins/saga/scripts/lifecycle_state.py still ' +
+    'has the `or needs_consensus` hard-force (~:158) and the adversarial_confidence ultracode trigger (~:163); (d) the repo has ZERO ' +
+    'hooks (no hooks/hooks.json, no "hooks" key in any plugin.json). Return PREFLIGHT_SCHEMA: ready=true iff ALL hold, else list drift.',
+  { schema: PREFLIGHT_SCHEMA, label: 'U1 preflight', phase: 'Preflight', model: 'haiku', effort: 'low' }
+)
+if (!pf || !pf.ready) {
+  throw new Error('HALT: preflight drift -- the plan was grounded against a different tree: ' + (pf ? pf.drift.join('; ') : 'no response'))
+}
+log('Preflight READY -- grounding facts confirmed on origin/main.')
+
+// =============================================================================
+// FIRST WAVE -- Epic 0, Epic 1, Epic 3 in parallel (all independent)
+// =============================================================================
+const wave1 = await parallel([
+  () => runEpic('epic0', 'Epic 0 - Tiering', 'feat/campaign-epic0-tiering', EPIC0),
+  () => runEpic('epic1', 'Epic 1 - Representation', 'feat/campaign-epic1-representation', EPIC1),
+  () => runEpic('epic3', 'Epic 3 - Hooks', 'feat/campaign-epic3-hooks', EPIC3),
+])
+const [e0, e1, e3] = wave1
+
+// BARRIER: Epic 2 needs Epic 0 + Epic 1 merged; Epic 4 needs Epic 0. Epic 3 is independent (warn, don't halt).
+if (!e0 || !e0.merged) throw new Error('HALT: Epic 0 (tiering) did not merge -- Epic 2 and Epic 4 depend on it. ' + (e0 ? e0.reason : 'dead'))
+if (!e1 || !e1.merged) throw new Error('HALT: Epic 1 (representation) did not merge -- Epic 2 depends on it. ' + (e1 ? e1.reason : 'dead'))
+if (!e3 || !e3.merged) log('WARNING: Epic 3 (hooks) did not merge -- it is independent, so the run continues; review/land its PR: ' + ((e3 && e3.pr) || 'none'))
+log('Barrier passed: Epic 0 + Epic 1 merged. Proceeding to authoring (Epic 2) + executor/guards (Epic 4).')
+
+// =============================================================================
+// SECOND WAVE -- Epic 2 (authoring) + Epic 4 (executor + guards) in parallel
+// =============================================================================
+if (budgetExhausted()) {
+  log('Budget floor reached after wave 1 -- checkpointing. Resume with resumeFromRunId to run Epic 2 + Epic 4 + Final.')
+  return { status: 'checkpointed-budget', wave1: wave1.map((w) => w && { epic: w.epic, merged: w.merged }) }
+}
+const wave2 = await parallel([
+  () => runEpic('epic2', 'Epic 2 - Authoring', 'feat/campaign-epic2-authoring', EPIC2),
+  () => runEpic('epic4', 'Epic 4 - Executor + guards', 'feat/campaign-epic4-guards', EPIC4),
+])
+const [e2, e4] = wave2
+if (!e2 || !e2.merged) log('WARNING: Epic 2 (authoring) did not merge -- review its PR before Final: ' + ((e2 && e2.pr) || 'none'))
+if (!e4 || !e4.merged) log('WARNING: Epic 4 (executor + guards) did not merge -- review its PR before Final: ' + ((e4 && e4.pr) || 'none'))
+
+// =============================================================================
+// FINAL -- full gate fleet-wide + journal + R-ID reconciliation (U17)
+// =============================================================================
+phase('Final')
+const epicsLanded = [e0, e1, e3, e2, e4].filter((x) => x && x.merged).map((x) => x.epic)
+const final = await agent(
+  SPEC +
+    '\n\nUNIT U17 -- FINAL verification + journal. Work in a fresh worktree ' + WT + '/final on branch feat/campaign-final off origin/main.\n' +
+    '1) Run the FULL gate fleet-wide from that worktree (ruff format --check, ruff check, both validators, uv run pytest, uv run mypy plugins/) and confirm GREEN.\n' +
+    '2) Write the campaign DECISIONS.md + LEARNINGS.md entries this campaign earned (KTD1-KTD10; the dead-wiring/source-fidelity lessons if any surfaced).\n' +
+    '3) Write a reconciliation report under docs/analysis/2026-06-21-saga-tiering-execution-campaign-report.md mapping EVERY R-ID (R1-R18) to its landed unit ' +
+    'and listing any unit whose epic did not merge (epics merged: ' + JSON.stringify(epicsLanded) + '). NO silent skips.\n' +
+    '4) Gate, open a PR, poll the 5 required checks, and squash-merge when green (full hands-off). Remove the worktree.\n' +
+    'Return FINAL_SCHEMA (rIdsTotal=18).',
+  { schema: FINAL_SCHEMA, label: 'U17 final + journal', phase: 'Final', model: 'opus', effort: 'high' }
+)
+
+// ---- summary to the parent session (which notifies the operator) ----
+return {
+  status: final && final.merged ? 'complete' : 'incomplete-review-final',
+  epicsMerged: epicsLanded,
+  wave1: wave1.map((w) => w && { epic: w.epic, pr: w.pr, merged: w.merged }),
+  wave2: wave2.map((w) => w && { epic: w.epic, pr: w.pr, merged: w.merged }),
+  final: final || null,
+  rIdCoverage: final ? final.rIdsCovered + '/' + final.rIdsTotal : 'unknown',
+  note: 'Full hands-off run. Any epic with merged=false is left as an open PR for review (see wave summaries). ' +
+    'Epic 3 is independent of the saga-execution epics. Resume incomplete runs with resumeFromRunId.',
+}


### PR DESCRIPTION
## What

Plan the whole **saga tiering + execution-mechanism campaign** (the 2026-06-20 requirements doc) as one Deep plan plus a runnable ultracode workflow that builds it.

- **Plan** `docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md` — 5 epics, requirements R1–R18, 17 units (U1–U17) each with a per-unit `{model, effort}` tier, KTD1–KTD10, acceptance examples AE1–AE6, risk analysis.
- **Harness** `docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js` — control-flow only; `Preflight → parallel(E0, E1, E3) → barrier(E0+E1 merged) → parallel(E2, E4) → Final`; per-unit tiers (**5 Opus / 11 Sonnet / 1 Haiku**); epic-isolated worktrees+PRs; full hands-off auto-merge behind the 5 required CI checks; budget floor + resume.
- **Decision** recorded at `DECISIONS.md#saga-tiering-execution-campaign-plan`.

## Operator-locked

Tiering approved as-is · full hands-off auto-merge · R7 via an explicit `/plan` interrogation question with a work-shape default.

## Corrections to the requirements (caught at planning)

- Epic 0 pins **4** callable agents, not 5 — `redis-channel/redis-channel-coach` is an MCP-`instructions=` pointer, not an Agent-dispatched subagent, so it is documented exempt.
- `adversarial_confidence` already exists in the recommender (`lifecycle_state.py:163`), so R7 is a **surgical split** of `needs_consensus`, not new plumbing.

## Not in this PR

Code. This is the plan; `/work` runs the harness. Recommended route: `/doc-review` first.

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe
