### PR TITLE
docs(saga): harden the tiering+execution campaign plan for full hands-off (doc-review)

### DIFF
--- a/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
+++ b/docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
@@ -110,10 +110,16 @@ only, agents do the work). Hand-authoring it now validates the R9 spec before Ep
 judgment → Opus, read-only survey → Sonnet, mechanical → Sonnet/Haiku. The full table is the Execution
 Spec below.
 
-**KTD3 — Full hands-off auto-merge (operator-chosen).** Each epic lands as its own PR, auto-merged when the
-5 required CI checks are green (`--admin` if branch protection needs it). The oracle is the test suite +
-the two plugin validators + the drift-guard tests; per-unit worktree isolation + rebase-before-merge
-prevents races. No mid-run operator checkpoint.
+**KTD3 — Full hands-off auto-merge (operator-chosen).** Each epic lands as its own PR and merges with a
+plain `gh pr merge --squash` (**not** `--admin`) only after the agent confirms all 5 CI checks are
+conclusively SUCCESS. The oracle is the test suite + the two plugin validators + the drift-guard tests.
+**Verified caveat (doc-review):** `main` is currently **unprotected** — no GitHub-required checks — so the
+merge gate is the agent's poll discipline alone, not GitHub enforcement (`--admin` would bypass nothing and
+is dropped). The harness merge step therefore (a) merges only on all-SUCCESS, treating pending / null /
+FAILURE as do-not-merge, and (b) forbids its gate-fix loop from weakening tests, deleting assertions, or
+adding `# type: ignore` / `# noqa` to force a pass (cap 3 attempts, then leave the PR unmerged). The proper
+hardening — enabling branch protection with the 5 checks so GitHub enforces the gate — is recommended but is
+the operator's infra call (see Risk Analysis, R-RISK-1). No mid-run operator checkpoint.
 
 **KTD4 — R7 gated-vs-advisory via an explicit interrogation question, work-shape pre-filled
 (operator-chosen).** `/plan` asks "does this verdict need to block a merge/deploy or persist as evidence?",
@@ -144,7 +150,11 @@ out of band.
 **KTD9 — Rebase-before-merge discipline (from the reference pattern).** Every workflow agent runs
 `git fetch origin` and rebases the latest default branch before opening or merging its PR. The two
 saga.py-touching units (U3 instrument, U4 label map) live in different epics; their merge order resolves by
-rebase, not by a hard serialization.
+rebase, not by a hard serialization. **Hands-off guardrail:** if the rebase produces a CONFLICT in
+`plugins/saga/scripts/saga.py` (or any load-bearing logic file), the agent does **not** auto-resolve — it
+aborts the rebase, leaves the PR unmerged with a "needs review" reason, and the run continues (the conflict
+is surfaced to the operator at completion). Autonomous conflict resolution in load-bearing code is out of
+bounds.
 
 **KTD10 — R15 gate manifest is a small declarative file** co-located with the validators
 (`tools/gate-manifest.*`); the exact format is settled inside U9 (Epic 3 is independent and lowest-stakes,
@@ -485,7 +495,10 @@ false-fire on a legitimately current main.
 
 **Work:** run the full gate fleet-wide (`ruff format --check`, `ruff check`, the two validators, `pytest`,
 `mypy`), confirm green, write the `DECISIONS.md` + `LEARNINGS.md` entries the campaign earned, and a
-reconciliation report mapping every R-ID to its landed unit (no silent skips).
+reconciliation report mapping every R-ID (R1–R18) to its landed unit (no silent skips). The reconciliation
+**must** flag two things explicitly: **R4** as `applied-inline — operator confirm done` (it is not built by
+any unit), and any epic left as an **unmerged open PR** (a non-required epic that did not merge, or a
+saga.py-conflict HALT) so nothing is silently dropped.
 
 **Files:** `docs/engineering-journal/{DECISIONS,LEARNINGS}.md`, a final report under `docs/analysis/`.
 
@@ -528,12 +541,34 @@ serially on one worktree+branch (no intra-epic race) and land as one PR; epics r
 
 **Safety model.** The oracle is the test suite + the two validators + the drift-guards (no human review
 mid-run, per KTD3). Each epic agent runs the full local gate before opening its PR, fetches+rebases latest
-main (KTD9), then auto-merges when the 5 required CI checks are green. A budget floor checkpoints the run;
-a circuit breaker halts on repeated gate failure. The run HALTS on a preflight drift (U1) or a failed
-barrier (a required epic PR not merged).
+main (KTD9), then merges only when all 5 CI checks are conclusively SUCCESS. A budget floor checkpoints the
+run; a circuit breaker halts on repeated gate failure. The run HALTS on a preflight drift (U1) or a failed
+barrier (a required epic PR not merged). A non-required epic that does not merge (E3 alone, or a wave-2
+epic) is left as an open PR and surfaced at completion — never force-merged.
 
-**Out of the workflow.** R4's global `~/.claude/CLAUDE.md` tier rule is applied inline with operator
-confirmation (KTD8), not by an autonomous agent.
+**Full-hands-off readiness (the explicit review lens).** Three properties make the unattended run safe to
+leave: **(1) the merge gate** is the agent confirming all-SUCCESS with a plain `--squash` (no `--admin`
+bypass) — and because `main` is unprotected, the gate-fix loop is constrained so it cannot game its own
+oracle (KTD3); **(2) recoverability** — every HALT (preflight drift, dead agent, exhausted budget, a
+saga.py conflict) is resumable via `resumeFromRunId`, which returns cached results for completed units and
+re-runs only from the first incomplete one, so a transient failure costs a resume, not a redo; **(3) no
+outward irreversibility** — merging the epics cuts **no release** (the CI `publish` job runs only on
+`refs/tags/*`, verified), so nothing is published, deployed, or tagged autonomously. The standing residual
+is that the merge gate is enforcement-by-prose until branch protection is enabled (R-RISK-1).
+
+**Rate-limit discipline (operator-requested).** The topology is deliberately narrow-concurrency, not max
+fan-out: wave 1 runs ≤3 concurrent epic agents (one per epic; units within an epic are serial), wave 2 ≤2.
+CI-status polling sleeps between polls (≈25 s, capped at ~30 polls ≈ 12 min, then report-pending-and-stop,
+never a tight loop). The Workflow runtime retries an agent on transient API errors before returning null; a
+null/dead agent after those retries is treated as a (possibly rate-limit) HALT — surfaced, not swallowed —
+and the whole run resumes later via `resumeFromRunId`. The per-epic gate-fix loop is capped (3 attempts) so
+a stuck unit cannot burn the budget hammering the API.
+
+**Out of the workflow (R4 — a REQUIRED operator step, tracked).** R4's global `~/.claude/CLAUDE.md` tier
+rule is applied inline with operator confirmation (KTD8), not by an autonomous agent — but Epic 0's success
+("the tier rule is loaded every session") **depends on it**, so it is not optional. U17's reconciliation
+lists R4 explicitly as `applied-inline — operator must confirm done`, so a forgotten R4 shows up as an open
+item rather than silently leaving Epic 0 incomplete.
 
 ## Scope Boundaries
 
@@ -552,17 +587,29 @@ Deferred to Follow-Up Work:
 
 ## Risk Analysis & Mitigation
 
-**Autonomous edits to load-bearing logic (U6 recommender, U10 spec).** A subtle recommender regression
-mis-routes every future job. *Mitigation:* AE1/AE2/overlap/docs-gating tests gate U6; the drift-guard (U5)
-catches purpose-list erosion; full hands-off still gates each PR on the complete CI suite — a red gate
-blocks the auto-merge.
+**R-RISK-1 — `main` is unprotected, so the autonomous merge gate is enforcement-by-prose (the top
+full-hands-off risk).** GitHub requires no checks, so a buggy poll or a gamed gate could land a red PR on
+main. *Mitigation (in-harness):* merge only on all-SUCCESS (pending / null / FAILURE → do-not-merge), plain
+`--squash` not `--admin`, and a gate-fix loop that may not weaken tests / delete assertions / add ignore
+comments (cap 3). *Mitigation (operator, recommended):* enable branch protection with the 5 checks so
+GitHub enforces the gate — the real fix that removes the enforcement-by-prose residual; an infra call left
+to the operator.
+
+**Autonomous edits to load-bearing logic (U6 recommender, U10 spec) + the gate-fix loop gaming its own
+oracle.** A subtle recommender regression mis-routes every future job; worse, an unattended "fix until
+green" agent could make a red gate pass by weakening the very test that guards it. *Mitigation:*
+AE1/AE2/overlap/docs-gating tests gate U6; the drift-guard (U5) catches purpose-list erosion; the harness
+SPEC forbids test/assertion-weakening and ignore-comments in gate-fixes and caps the loop, so the oracle
+stays trustworthy; a red gate blocks the merge.
 
 **`marketplace.json` double-`]` corruption during the U2 triad bumps.** *Mitigation:* `python3 -m json.tool`
 validation in U2; U7 makes it structurally unrepresentable thereafter (and U7 is in the parallel first
 wave).
 
 **Cross-epic `saga.py` conflict (U3 vs U4).** *Mitigation:* KTD9 rebase-before-merge; both are small,
-additive edits.
+additive edits authored in disjoint regions. **A genuine rebase conflict in saga.py is NOT auto-resolved** —
+the epic halts unmerged for operator review (KTD9 guardrail), rather than an autonomous agent reconciling
+load-bearing code.
 
 **Cheap-tier budget exhaustion in generated agents (R9).** *Mitigation:* U10 bakes the
 `workflow_structuredoutput_budget` lesson (cap output, mandatory emit, skim, batch) into emitted cheap-tier
@@ -570,6 +617,12 @@ agents; re-run only failed indices.
 
 **PR/CI volume (5 epic PRs + CI each).** *Mitigation:* epic-grouped PRs (not per-unit) keep it to ~5 CI
 runs; epics parallelize; a budget floor checkpoints for resume.
+
+**API rate limits during the unattended run (operator-requested).** Many tiered agents + polling loops risk
+throttling. *Mitigation:* narrow concurrency (≤3 wave-1 / ≤2 wave-2 agents, serial units within an epic),
+CI polls sleep ≈25 s and cap out to report-pending (no tight loop), the runtime retries transient API
+errors, and a post-retry dead agent HALTs the run resumably (`resumeFromRunId`) rather than failing hard.
+A rate-limit interruption costs a resume, not a restart.
 
 ## Dependencies / Assumptions
 
@@ -581,8 +634,15 @@ runs; epics parallelize; a budget floor checkpoints for resume.
   `adversarial_confidence` already a recommender trigger (`lifecycle_state.py:163`); `cc-workflows-ultracode`
   carried in persisted sagas (why R8 freezes it); recommender tested in `tests/test_saga_plugin.py`; the two
   validators are `marketplace/validator/validate.py` + `scripts/validate_plugins.py`.
+- **Doc-review-verified (full-hands-off):** the CI `publish` job runs **only** on `refs/tags/*`
+  (`.github/workflows/ci.yml:158`), so merging the epics cuts no release autonomously; and `main` is
+  currently **unprotected** (no GitHub-required checks) — the merge gate is the harness's poll discipline,
+  which R-RISK-1 hardens and recommends fixing via branch protection.
 - **Assumption:** the Workflow tool's per-agent `model`/`effort` overrides and `budget` API are stable —
   R3, R9, R12 and this campaign's own harness depend on them.
+- **Assumption (resumability):** the harness is restart-safe via `resumeFromRunId` — completed `agent()`
+  calls return cached results, so any HALT (preflight drift, a dead/rate-limited agent, exhausted budget, a
+  saga.py conflict) resumes from the first incomplete unit rather than from scratch.
 - **Release-surface obligation (cross-cutting):** every epic that changes plugin behavior bumps the release
   triad in the same PR (CLAUDE.md §6). Epics 0-2 modify saga; Epic 3 adds hooks to a plugin; Epic 4 adds an
   agent — each carries it.

--- a/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
+++ b/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
@@ -41,11 +41,22 @@ export const meta = {
 //
 // Each epic runs its units SERIALLY on ONE worktree+branch (no intra-epic race)
 // and lands as ONE PR. Epics run in parallel; cross-epic saga.py overlap (U3 vs U4)
-// resolves by rebase-before-merge (KTD9). The oracle is the test suite + the two
-// validators + the drift-guards -- a red gate blocks the auto-merge.
+// resolves by rebase-before-merge (KTD9) -- a genuine saga.py conflict HALTS the epic
+// unmerged rather than auto-resolving load-bearing code.
 //
-// Resume: re-run with {scriptPath, resumeFromRunId}. Merge agents probe for an
-// already-open/merged PR and a pre-existing worktree, so a re-run skips landed epics.
+// MERGE GATE (main is UNPROTECTED -- verified; no GitHub-required checks): the gate is
+// the agent's poll discipline alone, so merge with plain `--squash` (NOT --admin, which
+// would bypass nothing) ONLY when all 5 checks are conclusively SUCCESS. The gate-fix
+// loop may not weaken tests to pass (SPEC rule 5). Recommend the operator enable branch
+// protection so GitHub enforces the gate (plan R-RISK-1).
+//
+// RATE LIMITS: narrow concurrency (<=3 wave-1 / <=2 wave-2 agents; serial units within
+// an epic); CI polls sleep ~25s and cap out (no tight loop); a post-retry dead agent is
+// a (possibly rate-limit) HALT, resumable -- never swallowed.
+//
+// Resume: re-run with {scriptPath, resumeFromRunId} -- completed agent() calls return
+// cached results, so any HALT resumes from the first incomplete unit. Merge agents also
+// probe for an already-open/merged PR and a pre-existing worktree.
 // =============================================================================
 
 const REPO = '/Users/jefcox/workspace/infiquetra/infiquetra-claude-plugins'
@@ -64,6 +75,9 @@ const SPEC =
   '(3) Follow repo commit/PR conventions (`type(scope): description`, atomic); NEVER add attribution lines ' +
   '("Generated with", "Co-authored-by") to commits, PRs, or any content. ' +
   '(4) Feature-bearing units add real tests at the repo-relative path the plan names; run them before reporting done. ' +
+  '(5) ORACLE INTEGRITY (main is unprotected -- the gate is the ONLY guard): NEVER weaken a test, delete an assertion, ' +
+  'loosen a threshold, or add `# type: ignore` / `# noqa` to make a check pass. If the code is wrong, fix the CODE; if you ' +
+  'cannot pass the gate with a legitimate in-scope fix in <=3 attempts, STOP and leave the work unmerged for review. ' +
   'Your final message IS the structured return value -- no human-facing prose.'
 
 // ---- structured-return schemas ----
@@ -146,15 +160,19 @@ async function runEpic(epicId, phaseTitle, branch, units) {
   // Gate + PR + auto-merge -- FULL HANDS-OFF (KTD3): merge when CI is green, no human checkpoint.
   const merge = await agent(
     SPEC +
-      '\n\nEPIC MERGE STEP for ' + epicId + ' (worktree ' + dir + ', branch ' + branch + '). FULL HANDS-OFF -- merge when green.\n' +
+      '\n\nEPIC MERGE STEP for ' + epicId + ' (worktree ' + dir + ', branch ' + branch + '). FULL HANDS-OFF -- but the gate is the ONLY guard (main is unprotected).\n' +
       '1) From WITHIN ' + dir + ' run the full local gate: `ruff format --check .`; `ruff check .`; ' +
       '`python3 scripts/validate_plugins.py`; `python3 marketplace/validator/validate.py`; `uv run pytest`; `uv run mypy plugins/`. ' +
-      'If any FAILS, fix it in the worktree (small, in-scope fixes only) and re-run until all pass. Set gatePassed accordingly.\n' +
-      '2) `git -C ' + dir + ' fetch origin && git -C ' + dir + ' rebase origin/main` -- resolve conflicts by integrating BOTH sides ' +
-      '(watch plugins/saga/scripts/saga.py and .claude-plugin/marketplace.json). Re-run the gate if the rebase changed anything.\n' +
+      'If any FAILS, fix the CODE in the worktree (small, in-scope) and re-run -- per SPEC rule 5 NEVER weaken a test/assertion or add ignore-comments to pass. ' +
+      'Cap: <=3 fix attempts; if still red, set gatePassed=false, leave the PR unmerged, and return (do NOT merge a red epic).\n' +
+      '2) `git -C ' + dir + ' fetch origin && git -C ' + dir + ' rebase origin/main`. If the rebase CONFLICTS in a load-bearing logic file ' +
+      '(plugins/saga/scripts/saga.py, lifecycle_state.py): do NOT auto-resolve -- `git rebase --abort`, set merged=false, reason="saga.py rebase conflict -- needs review", and return. ' +
+      'Resolve only trivial non-logic conflicts (CHANGELOG / marketplace.json) by integrating both sides; re-run the gate if the rebase changed anything.\n' +
       '3) Push and open a PR (`gh pr create`; title "' + epicId + ': <summary>"). Probe first: if a PR for this branch already exists, reuse it; if already MERGED, set merged=true and skip to step 5.\n' +
-      '4) Poll the 5 REQUIRED checks (Tests (Python 3.12) / Validate Plugins / Lint / Type Check / Security Scan). "Publish Plugin" SKIPPED is expected and NOT a failure. ' +
-      'When all 5 are SUCCESS, squash-merge: `gh pr merge --squash --admin --delete-branch`. If any required check FAILS, do NOT merge -- set ciGreen=false, merged=false, and report the failing check.\n' +
+      '4) Poll the 5 checks (Tests (Python 3.12) / Validate Plugins / Lint / Type Check / Security Scan); "Publish Plugin" SKIPPED is expected (it runs only on refs/tags/*). ' +
+      'POLL DISCIPLINE: check, then sleep ~25s; cap ~30 polls (~12 min); do NOT tight-loop. Merge ONLY when ALL 5 are conclusively SUCCESS -- treat pending / null / FAILURE as do-not-merge. ' +
+      'Then `gh pr merge --squash --delete-branch` (plain; NOT --admin -- there is nothing to bypass and the gate must not be circumvented). ' +
+      'If any check FAILS or stays pending past the cap: set ciGreen=false, merged=false, leave the PR open, and report it.\n' +
       '5) `git -C ' + REPO + ' worktree remove ' + dir + ' --force` (ignore if already gone).\n' +
       'Return EPIC_SCHEMA. merged=true ONLY if the squash-merge actually landed on origin/main.',
     { schema: EPIC_SCHEMA, label: epicId + ' gate+merge', phase: phaseTitle, model: 'sonnet', effort: 'high' }
@@ -330,10 +348,11 @@ const final = await agent(
     '\n\nUNIT U17 -- FINAL verification + journal. Work in a fresh worktree ' + WT + '/final on branch feat/campaign-final off origin/main.\n' +
     '1) Run the FULL gate fleet-wide from that worktree (ruff format --check, ruff check, both validators, uv run pytest, uv run mypy plugins/) and confirm GREEN.\n' +
     '2) Write the campaign DECISIONS.md + LEARNINGS.md entries this campaign earned (KTD1-KTD10; the dead-wiring/source-fidelity lessons if any surfaced).\n' +
-    '3) Write a reconciliation report under docs/analysis/2026-06-21-saga-tiering-execution-campaign-report.md mapping EVERY R-ID (R1-R18) to its landed unit ' +
-    'and listing any unit whose epic did not merge (epics merged: ' + JSON.stringify(epicsLanded) + '). NO silent skips.\n' +
-    '4) Gate, open a PR, poll the 5 required checks, and squash-merge when green (full hands-off). Remove the worktree.\n' +
-    'Return FINAL_SCHEMA (rIdsTotal=18).',
+    '3) Write a reconciliation report under docs/analysis/2026-06-21-saga-tiering-execution-campaign-report.md mapping EVERY R-ID (R1-R18) to its landed unit, ' +
+    'flagging R4 explicitly as "applied-inline -- operator confirm done" (no unit builds it) and listing any epic left as an UNMERGED open PR ' +
+    '(epics merged: ' + JSON.stringify(epicsLanded) + '). NO silent skips.\n' +
+    '4) Gate, open a PR, then merge with the SAME discipline as the epic merge step (poll with ~25s sleeps, merge ONLY on all-5-SUCCESS, plain `gh pr merge --squash --delete-branch`, NOT --admin). Remove the worktree.\n' +
+    'Return FINAL_SCHEMA (rIdsTotal=18; rIdsCovered = R-IDs with a landed unit; R4 counts only once the operator confirms the inline edit).',
   { schema: FINAL_SCHEMA, label: 'U17 final + journal', phase: 'Final', model: 'opus', effort: 'high' }
 )
 

--- a/docs/reviews/2026-06-21-saga-tiering-and-execution-campaign-plan-review.md
+++ b/docs/reviews/2026-06-21-saga-tiering-and-execution-campaign-plan-review.md
@@ -1,0 +1,75 @@
+---
+title: Doc Review — Saga Tiering & Execution-Mechanism Campaign Plan (full-hands-off readiness)
+type: review
+date: 2026-06-21
+target: docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md
+---
+
+# Doc Review — Saga Tiering & Execution-Mechanism Campaign Plan
+
+**Verdict: READY to drive `/work` (full-hands-off), with one recommended operator action.** Eight findings;
+the two P1s are fixed in place, the P2 conflict/enforcement risks are mitigated, and the single standing
+recommendation (enable branch protection) is an infra call that the hardened harness already compensates
+for. No P0. No unresolved P0/P1 — `/work` will not block.
+
+## Review-result contract
+
+| Field | Value |
+|---|---|
+| Target | `docs/plans/2026-06-21-saga-tiering-and-execution-campaign-plan.md` |
+| Sibling reviewed | `docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js` (the executable harness) |
+| Reviewed revision | working tree off `b73b688`; safe fixes applied in this review |
+| Lens | standard readiness + **explicit full-hands-off readiness** (operator-requested) + rate-limit consciousness (operator-requested) |
+| Blocked | No (no unresolved P0/P1) |
+| Findings | 8 — 1 fixed-with-residual-recommendation, 2 fixed, 2 fixed, 3 residual/noted |
+| Fixes applied | plan: KTD3, KTD9, Safety model (+full-hands-off + rate-limit subsections), U17, Risk Analysis (+R-RISK-1, rate-limit, oracle-gaming), Dependencies. harness: SPEC rule 5, header notes, merge step (drop `--admin`, poll discipline, conflict HALT, fix-loop cap), U17 prompt |
+| Linked plan / saga | plan above; saga `task-saga-tiering-execution-campaign`; DECISIONS `#saga-tiering-execution-campaign-plan` |
+
+## Readiness summary
+
+The plan was already structurally sound (R-IDs/U-IDs mapped, per-unit tiers, AEs, citations). The
+full-hands-off lens surfaced the real risk: **`main` is unprotected** (verified — HTTP 404 "Branch not
+protected"), so the autonomous merge gate was enforcement-by-prose, and the harness used a `--admin` bypass
+plus a "fix until green" loop that could game its own oracle. Those are now closed in both artifacts. The
+publish path was verified safe (the CI `publish` job runs only on `refs/tags/*`, so merging epics cuts no
+release). Rate-limit consciousness was added per the operator's request.
+
+## Findings by priority
+
+| ID | Pri | Finding | Status |
+|---|---|---|---|
+| F1 | P1 | `main` unprotected → the autonomous merge gate is the agent's poll discipline alone; `--admin` bypassed the only guard | **Fixed** (harness: plain `--squash`, merge only on all-SUCCESS, conflict/fix guardrails) + **residual recommendation** → enable branch protection (F1b, P2) |
+| F2 | P1 | No rate-limit consciousness for an unattended multi-agent run (operator-requested) | **Fixed** — narrow concurrency, poll sleeps + cap, resumable dead-agent HALT, fix-loop cap; plan + harness |
+| F3 | P1 | The "fix until green" loop could pass a red gate by weakening the test that guards it | **Fixed** — SPEC rule 5 (no test/assertion-weakening, no ignore-comments) + 3-attempt cap; Risk row |
+| F4 | P2 | R4 (global tier rule) is outside the workflow with no enforcement; Epic 0 success depends on it | **Fixed** — U17 reconciliation flags R4 `applied-inline — operator confirm done`; marked REQUIRED |
+| F5 | P2 | Autonomous rebase conflict resolution in load-bearing `saga.py` (U3 ∥ U4) | **Fixed** — KTD9 guardrail; harness aborts the rebase and leaves the epic unmerged for review |
+| F1b | P2 | Branch protection not enabled (the proper fix for F1) | **Open — recommended operator action** (infra; harness compensates meanwhile) |
+| F6 | P3 | Fresh re-run without `resumeFromRunId` has weaker per-unit idempotency than the resume path | **Noted** — `resumeFromRunId` is the supported recovery path; merge agents also probe existing PRs |
+| F7 | P3 | Harness hardcodes the absolute `REPO` path | **Noted** — reference precedent; fine for single-operator/single-machine; flagged for portability |
+
+## Applied fixes
+
+Plan: hardened KTD3 (merge reality + no `--admin` + oracle-integrity), KTD9 (conflict HALT), the Safety
+model (added Full-hands-off-readiness and Rate-limit-discipline subsections + REQUIRED-R4 tracking), U17
+(reconciliation flags R4 + unmerged epics), Risk Analysis (new R-RISK-1, oracle-gaming, rate-limit rows;
+tightened the saga.py-conflict row), and Dependencies (publish-on-tags + unprotected-main + resumability).
+
+Harness: SPEC rule 5 (oracle integrity); header notes (merge gate + rate limits + resume); merge step
+(dropped `--admin` → plain `--squash`, all-SUCCESS-only with ~25s poll sleeps and a cap, saga.py-conflict
+abort, 3-attempt fix cap); U17 prompt (R4 + unmerged-epic reconciliation, same merge discipline).
+`node --check` clean.
+
+## Verified-safe (not findings)
+
+- The CI `publish` job is `if: startsWith(github.ref, 'refs/tags/')` (`.github/workflows/ci.yml:158`) — so
+  the unattended run publishes/tags/deploys nothing; merges land on `main` only.
+- Citations spot-checked accurate: `lifecycle_state.py:158/163`, `saga.py:71`, `plan/SKILL.md:253`,
+  `team-execution/SKILL.md:234`, recommender tests in `tests/test_saga_plugin.py`, validators at
+  `marketplace/validator/validate.py` + `scripts/validate_plugins.py`.
+
+## Residual risk
+
+The strongest remaining lever is the operator's: with `main` unprotected, the merge gate is the harness's
+poll discipline (now hardened, but still prose). Enabling branch protection with the 5 checks would move the
+gate into GitHub's enforcement and is the recommended hardening before — or alongside — the first `/work`
+run. Everything else is mitigated or noted.


### PR DESCRIPTION
## What

`/doc-review` of the campaign plan with the operator's **full-hands-off readiness** + **rate-limit** lenses. Verdict: **READY** to drive `/work`; no unresolved P0/P1.

## The finding that mattered

`main` is **unprotected** (verified — HTTP 404 "Branch not protected"), so the autonomous merge gate was enforcement-by-prose, and the harness used a `--admin` bypass plus a "fix until green" loop that could game its own oracle. Closed in both the plan and the harness.

## Fixes applied (plan + harness)

- **Merge gate** — drop `--admin` → plain `gh pr merge --squash`; merge only on all-5-checks-SUCCESS (pending/null/FAILURE → do-not-merge); ~25s poll sleeps + cap (no tight loop).
- **Oracle integrity** — SPEC rule 5: the gate-fix loop may not weaken tests, delete assertions, or add ignore-comments; 3-attempt cap.
- **Rate-limit discipline** (operator-requested) — narrow concurrency (≤3 wave-1 / ≤2 wave-2), resumable dead-agent HALT, documented `resumeFromRunId` recovery.
- **saga.py conflict** — autonomous rebase-conflict resolution in load-bearing code is barred; the epic halts unmerged for review.
- **R4 tracking** — U17 reconciliation flags the global-rule edit as `applied-inline — operator confirm done` so it can't be silently skipped.

## Verified-safe

The CI `publish` job runs only on `refs/tags/*` (`ci.yml:158`) — the unattended run cuts no release. Citations spot-checked accurate. `node --check` clean.

## Files

- `docs/plans/…-plan.md` (hardened) · `docs/plans/…campaign.workflow.js` (hardened) · `docs/reviews/2026-06-21-…-plan-review.md` (new)

## Standing recommendation

Enable branch protection with the 5 checks so GitHub enforces the merge gate (the proper fix for the unprotected-main risk). Infra call; the hardened harness compensates meanwhile.

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe
