### PR TITLE
fix(saga): pure-literal meta.description so the campaign harness can launch

### DIFF
--- a/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
+++ b/docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js
@@ -1,10 +1,7 @@
 export const meta = {
   name: 'saga-tiering-execution-campaign',
   description:
-    'Build the saga tiering + execution-mechanism campaign (5 epics, 17 units) with a per-unit {model,effort} tier on every step. ' +
-    'Epic-isolated PRs, full hands-off auto-merge when CI is green. Opus for judgment (offer rewrite, recommender split, the spec ' +
-    'emitter, degradation, final verify); Sonnet for bounded builds; Haiku for the preflight existence check. Control-flow only — ' +
-    'every agent reads the plan as its authoritative spec.',
+    'Build the saga tiering + execution-mechanism campaign (5 epics, 17 units) with a per-unit {model,effort} tier on every step. Epic-isolated PRs, full hands-off auto-merge when CI is green. Opus for judgment (offer rewrite, recommender split, the spec emitter, degradation, final verify); Sonnet for bounded builds; Haiku for the preflight existence check. Control-flow only -- every agent reads the plan as its authoritative spec.',
   phases: [
     { title: 'Preflight' },
     { title: 'Epic 0 - Tiering', model: 'sonnet' },


### PR DESCRIPTION
## What

`meta.description` in the campaign execution harness was built with `+` string concatenation. The Workflow tool's meta-extractor requires a **pure literal** and rejected it (`meta must be a pure literal: non-literal node type ... BinaryExpression`), so the harness could not launch despite `node --check` passing.

## Fix

Collapse the description into a single string literal. No other `meta` field was concatenated; `name` and `phases` were already literals. Behavior, topology, the 17 units, and per-unit model/effort tiers are unchanged.

Found at `/work` launch time when the Workflow tool refused the script.

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe