### PR TITLE
epic0: pin model tier on 4 callable ecosystem agents + saga envelope recording (U2, U3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "home-lab-ops",
       "source": "./plugins/home-lab-ops",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "description": "Proxmox VE cluster operations, Ansible pre-flight validation, Ceph management, monitoring guard, and vault helper for home lab infrastructure",
       "author": {
         "name": "Infiquetra",
@@ -37,7 +37,7 @@
     {
       "name": "unifi",
       "source": "./plugins/unifi",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "UniFi Network and Protect CLI for managing UDM devices, clients, VLANs, firewall rules, traffic routes, cameras, PTZ control, and motion events \u2014 dry-run by default, API key auth, no MCP supply chain risk",
       "author": {
         "name": "Infiquetra",
@@ -62,7 +62,7 @@
     {
       "name": "deploy",
       "source": "./plugins/deploy",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "tag-promotion deployment operations for Infiquetra repositories.",
       "author": {
         "name": "Infiquetra",
@@ -132,7 +132,7 @@
     {
       "name": "mission-control",
       "source": "./plugins/mission-control",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "description": "SDLC workflow manager for Infiquetra's Jeff Intent, Asgard, and CAMPPS boards. Adds prepared issue drafts, live schema sync, project fields, labels, metrics, milestones, and rollout helpers via Python CLI.",
       "author": {
         "name": "Infiquetra",

--- a/plugins/deploy/.claude-plugin/plugin.json
+++ b/plugins/deploy/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "tag-promotion deployment operations for Infiquetra repositories.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/deploy/CHANGELOG.md
+++ b/plugins/deploy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2 - 2026-06-21
+
+- `release-orchestrator` agent: pin `model: sonnet` in frontmatter (R1/R2a tiering;
+  release coordination is structured/procedural — Sonnet is the right cost-quality tier).
+
 ## 0.1.0 - 2026-05-29
 
 - Add Infiquetra tag-promotion deploy commands and deploy-state skill.

--- a/plugins/deploy/agents/release-orchestrator.md
+++ b/plugins/deploy/agents/release-orchestrator.md
@@ -2,6 +2,7 @@
 name: release-orchestrator
 description: Coordinate Infiquetra tag-promotion releases, rollback evidence, and hotfix gates
 tools: Read, Glob, Bash, WebFetch
+model: sonnet
 ---
 
 # Release Orchestrator

--- a/plugins/home-lab-ops/.claude-plugin/plugin.json
+++ b/plugins/home-lab-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "home-lab-ops",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Proxmox VE cluster operations, Ansible pre-flight validation, Ceph management, monitoring guard, and vault helper for home lab infrastructure",
   "author": {
     "name": "Infiquetra",

--- a/plugins/home-lab-ops/CHANGELOG.md
+++ b/plugins/home-lab-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2026-06-21
+
+### Changed
+- `homelab-sre` agent: pin `model: opus` in frontmatter (R1/R2a tiering; judgment-heavy SRE
+  diagnosis warrants the richest model).
+
 ## [1.1.0] - 2026-06-01
 
 ### Added

--- a/plugins/home-lab-ops/agents/homelab-sre.md
+++ b/plugins/home-lab-ops/agents/homelab-sre.md
@@ -1,3 +1,9 @@
+---
+name: homelab-sre
+model: opus
+description: SRE agent for the olympus home lab Proxmox/Ceph cluster — triage, Ansible, Ceph ops, VM lifecycle, capacity planning.
+---
+
 # Homelab SRE Agent
 
 ## Role

--- a/plugins/mission-control/.claude-plugin/plugin.json
+++ b/plugins/mission-control/.claude-plugin/plugin.json
@@ -1,11 +1,22 @@
 {
   "name": "mission-control",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "SDLC management for Jeff Intent, Asgard, and CAMPPS: prepared issue drafts, live schema sync, board schemas, labels, project fields, metrics, and card validation.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["sdlc", "github-projects", "kanban", "issues", "labels", "metrics", "sub-issues", "campps", "asgard", "jeff-intent"]
+  "keywords": [
+    "sdlc",
+    "github-projects",
+    "kanban",
+    "issues",
+    "labels",
+    "metrics",
+    "sub-issues",
+    "campps",
+    "asgard",
+    "jeff-intent"
+  ]
 }

--- a/plugins/mission-control/CHANGELOG.md
+++ b/plugins/mission-control/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — mission-control
 
+## [2.2.0] — 2026-06-21
+
+### Changed
+- `sdlc-operator` agent: pin `model: sonnet` (was `inherit`). Orchestration work is
+  structured/mechanical — Sonnet is the right cost-quality tier (R1/R2a tiering).
+
 ## [2.1.0] — 2026-06-17
 
 ### Migration notes

--- a/plugins/mission-control/agents/sdlc-operator.md
+++ b/plugins/mission-control/agents/sdlc-operator.md
@@ -48,7 +48,7 @@ description: |
   - Single metric pull (use metrics skill directly)
   - Quick issue creation for a known type (use issues skill directly)
   - Setting a single project field on a single card (use flow skill directly with `flow set-field`)
-model: inherit
+model: sonnet
 color: orange
 ---
 

--- a/plugins/mission-control/tests/test_prompt_alignment.py
+++ b/plugins/mission-control/tests/test_prompt_alignment.py
@@ -19,7 +19,7 @@ def test_sdlc_manager_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "mission-control")
 
     assert plugin_json["name"] == "mission-control"
-    assert plugin_json["version"] == "2.1.0"
+    assert plugin_json["version"] == "2.2.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/mission-control"
     assert "CAMPPS" in plugin_json["description"]

--- a/plugins/redis-channel/agents/redis-channel-coach.md
+++ b/plugins/redis-channel/agents/redis-channel-coach.md
@@ -1,6 +1,7 @@
 ---
 name: redis-channel-coach
 description: Reference doc for redis-channel session behavior. The load-bearing runtime guidance lives in the MCP server's `instructions=` field (see server/channel.py build_app) so Claude reads it on every turn including notification-triggered ones. This file is a human-readable pointer; subagent invocations not expected.
+tiering_exempt: "KTD7 — reference pointer, not a dispatched subagent; model: pin is inert here"
 ---
 
 The runtime behavior coaching for redis-channel sessions is delivered through the MCP server's `instructions` field — see `server/channel.py::build_app` and the corresponding "MCP Server Instructions" section that Claude Code injects into the system prompt at session start.

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.24.0 - 2026-06-21
+
+- Add `orchestration_recommended` and `orchestration_operator_choice` fields to the saga envelope
+  (R12 — choice-vs-recommendation recording). Enables override-rate computation in `/retro`+`/optimize`.
+  Both fields default to `""` so pre-0.24.0 sagas parse without error (backward-compatible additive
+  evolution per §9 of the saga spec).
+
 ## 0.23.0 - 2026-06-20
 
 - Add the `/promote` skill — the workspace tier of the engineering journal. It promotes the *select few*

--- a/plugins/saga/references/saga-spec.md
+++ b/plugins/saga/references/saga-spec.md
@@ -1,6 +1,6 @@
 # Saga Specification (saga)
 
-**Status:** canonical contract · **schema_version:** `1.0` · **plugin version:** 0.4.0
+**Status:** canonical contract · **schema_version:** `1.0` · **plugin version:** 0.24.0
 **Engine:** [`scripts/saga.py`](../scripts/saga.py)
 **Audience:** the four execution-loop commands (`/plan`, `/work`, `/resume`, `/loop`) implement against this
 file when they are rebuilt. They MUST treat the field names, enum values, and operation semantics below as
@@ -120,6 +120,8 @@ construct a `Saga` (no default); all others have the listed default.
 | `next_step` | str | — | `""` | The one imperative resume anchor (top of `## Remaining`). |
 | `orchestration_mode` | enum | — | `inline` | How work runs — decision contract in `references/operator-choice.md`; **MUST** be in `ORCHESTRATION_MODES`. |
 | `orchestration_ref` | str | — | `""` | Pointer into the orchestration (team name, workflow id, …). |
+| `orchestration_recommended` | str | — | `""` | The backend the recommender suggested for this decision (R12). Empty on older sagas. |
+| `orchestration_operator_choice` | str | — | `""` | The backend the operator actually picked (R12). Differs from `orchestration_mode` when overriding. Empty on older sagas. |
 | `issue_ref` | str | — | `""` | `owner/repo#N` pointer; empty for plan-only / pre-issue work. |
 | `destination` | enum | — | `plan-only` | Routing intent — **MUST** be in `DESTINATIONS`. Mirrors `lifecycle_state`. |
 | `round` | int | — | `0` | Current PR/iteration round. |
@@ -214,6 +216,8 @@ status: active
 next_step: "wire /resume to call saga.restore"
 orchestration_mode: cc-workflows-ultracode
 orchestration_ref: "wf-saga-foundation"
+orchestration_recommended: cc-workflows-ultracode
+orchestration_operator_choice: cc-workflows-ultracode
 issue_ref: "infiquetra/infiquetra-claude-plugins#42"
 destination: pr
 round: 2

--- a/plugins/saga/scripts/saga.py
+++ b/plugins/saga/scripts/saga.py
@@ -149,6 +149,13 @@ class Saga:
     next_step: str = ""
     orchestration_mode: str = "inline"
     orchestration_ref: str = ""
+    # Choice-vs-recommendation recording (R12 — enables override-rate computation in /retro+/optimize).
+    # orchestration_recommended = what the recommender suggested;
+    # orchestration_operator_choice = what the operator actually picked.
+    # Either can differ from orchestration_mode when the operator overrides the recommendation.
+    # Both default to "" so older sagas that lack these fields still parse without error.
+    orchestration_recommended: str = ""
+    orchestration_operator_choice: str = ""
 
     # Pointers (link, never duplicate, another owner's state).
     issue_ref: str = ""  # owner/repo#N (empty for plan-only)
@@ -211,6 +218,8 @@ FRONTMATTER_FIELDS: tuple[str, ...] = (
     "next_step",
     "orchestration_mode",
     "orchestration_ref",
+    "orchestration_recommended",
+    "orchestration_operator_choice",
     "issue_ref",
     "destination",
     "round",

--- a/plugins/unifi/.claude-plugin/plugin.json
+++ b/plugins/unifi/.claude-plugin/plugin.json
@@ -1,11 +1,21 @@
 {
   "name": "unifi",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "UniFi Network and Protect CLI for managing UDM devices, clients, VLANs, firewall rules, cameras, PTZ control, and motion events",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"
   },
   "repository": "https://github.com/infiquetra/infiquetra-claude-plugins",
-  "keywords": ["unifi", "ubiquiti", "network", "protect", "cameras", "home-lab", "udm", "firewall", "vlan"]
+  "keywords": [
+    "unifi",
+    "ubiquiti",
+    "network",
+    "protect",
+    "cameras",
+    "home-lab",
+    "udm",
+    "firewall",
+    "vlan"
+  ]
 }

--- a/plugins/unifi/CHANGELOG.md
+++ b/plugins/unifi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2026-06-21
+
+### Changed
+- `unifi-network-ops` agent: add frontmatter and pin `model: sonnet` (R1/R2a tiering;
+  network ops are structured/investigative, not judgment-heavy decisions).
+
 ## [1.0.0] - 2026-03-17
 
 ### Added

--- a/plugins/unifi/agents/unifi-network-ops.md
+++ b/plugins/unifi/agents/unifi-network-ops.md
@@ -1,3 +1,9 @@
+---
+name: unifi-network-ops
+model: sonnet
+description: Network and surveillance operations agent for the Infiquetra home lab UniFi environment.
+---
+
 # UniFi Network & Protect Operations Agent
 
 ## Role

--- a/tests/test_agent_tiering.py
+++ b/tests/test_agent_tiering.py
@@ -1,0 +1,98 @@
+"""Tests for U2: callable ecosystem agent model pinning (R1, R2a).
+
+Asserts that the 4 callable ecosystem agents carry the expected `model:` value in
+their YAML frontmatter and that the redis-channel-coach is recorded as exempt (KTD7).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import NamedTuple
+
+import pytest
+
+PLUGINS_ROOT = pathlib.Path(__file__).parent.parent / "plugins"
+
+
+def _parse_frontmatter(path: pathlib.Path) -> dict[str, str]:
+    """Extract YAML frontmatter key/value pairs from an agent .md file.
+
+    Returns a dict of top-level scalar fields only (no multi-line / block values).
+    Returns an empty dict if no frontmatter block is found.
+    """
+    text = path.read_text()
+    if not text.startswith("---"):
+        return {}
+    # Extract the block between the first --- and second ---
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end]
+    result: dict[str, str] = {}
+    for line in block.splitlines():
+        # Match top-level key: value lines (not indented block content)
+        m = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*):\s*(.*)", line)
+        if m:
+            result[m.group(1)] = m.group(2).strip().strip('"')
+    return result
+
+
+class AgentSpec(NamedTuple):
+    plugin: str
+    agent_file: str
+    expected_model: str
+
+
+# The 4 callable ecosystem agents and their required model tier (R1, R2a).
+PINNED_AGENTS: list[AgentSpec] = [
+    AgentSpec("home-lab-ops", "homelab-sre.md", "opus"),
+    AgentSpec("mission-control", "sdlc-operator.md", "sonnet"),
+    AgentSpec("unifi", "unifi-network-ops.md", "sonnet"),
+    AgentSpec("deploy", "release-orchestrator.md", "sonnet"),
+]
+
+
+@pytest.mark.parametrize("spec", PINNED_AGENTS, ids=[s.agent_file for s in PINNED_AGENTS])
+def test_agent_model_pin(spec: AgentSpec) -> None:
+    """Each callable ecosystem agent must carry model: <expected> in its frontmatter."""
+    path = PLUGINS_ROOT / spec.plugin / "agents" / spec.agent_file
+    assert path.exists(), f"Agent file missing: {path}"
+    fm = _parse_frontmatter(path)
+    assert "model" in fm, (
+        f"{spec.plugin}/{spec.agent_file} has no `model:` field in frontmatter — "
+        f"add `model: {spec.expected_model}` to the YAML block."
+    )
+    assert fm["model"] == spec.expected_model, (
+        f"{spec.plugin}/{spec.agent_file}: expected `model: {spec.expected_model}`, "
+        f"got `model: {fm['model']}`."
+    )
+
+
+def test_redis_channel_coach_exempt() -> None:
+    """redis-channel/redis-channel-coach is documented exempt from model pinning (KTD7).
+
+    The coach is a reference pointer, not a dispatched subagent — pinning model: on it
+    is inert. The exemption is recorded via tiering_exempt in frontmatter so it is
+    machine-verifiable rather than a comment in a doc.
+    """
+    path = PLUGINS_ROOT / "redis-channel" / "agents" / "redis-channel-coach.md"
+    assert path.exists(), f"Coach file missing: {path}"
+    fm = _parse_frontmatter(path)
+
+    # The coach must NOT have an active model: pin (it is exempt).
+    assert "model" not in fm, (
+        "redis-channel-coach unexpectedly carries a `model:` pin. "
+        "If this agent has become callable, remove the tiering_exempt field and add it "
+        "to PINNED_AGENTS in this test instead."
+    )
+
+    # The exemption must be explicitly documented.
+    assert "tiering_exempt" in fm, (
+        "redis-channel-coach is missing the `tiering_exempt` field. "
+        'Add `tiering_exempt: "KTD7 — reference pointer, not a dispatched subagent; '
+        'model: pin is inert here"` to the frontmatter to record the exemption.'
+    )
+    assert "KTD7" in fm["tiering_exempt"], (
+        "tiering_exempt field must reference KTD7 to link the exemption to its rationale."
+    )

--- a/tests/test_deploy_plugin.py
+++ b/tests/test_deploy_plugin.py
@@ -39,7 +39,7 @@ def test_infiquetra_deploy_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "deploy")
 
     assert plugin_json["name"] == "deploy"
-    assert plugin_json["version"] == "0.1.1"
+    assert plugin_json["version"] == "0.1.2"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/deploy"
     assert "tag-promotion" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.23.0"
+    assert plugin_json["version"] == "0.24.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_saga.py
+++ b/tests/test_saga_saga.py
@@ -1252,6 +1252,90 @@ def test_load_saga_context_journal_matches_issue_and_adr(
 
 
 # ===========================================================================
+# Engine: orchestration choice-vs-recommendation recording (U3 — R12)
+# ===========================================================================
+
+
+def test_orchestration_recommended_and_choice_round_trip(saga: ModuleType) -> None:
+    """Both new fields survive a render→parse round-trip."""
+    s = _make_saga(
+        saga,
+        orchestration_recommended="cc-workflows-ultracode",
+        orchestration_operator_choice="team-execution",
+    )
+    restored = saga.parse_envelope(saga.render_envelope(s))
+    assert restored.orchestration_recommended == "cc-workflows-ultracode"
+    assert restored.orchestration_operator_choice == "team-execution"
+
+
+def test_orchestration_recommended_and_choice_persist_via_save(
+    saga: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fields written through save() are readable via restore()."""
+    _stub_no_git(saga, monkeypatch)
+    s = _make_saga(
+        saga,
+        orchestration_recommended="cc-workflows-ultracode",
+        orchestration_operator_choice="inline",
+    )
+    saga.save(tmp_path, s, now=FIXED_NOW)
+    restored = saga.restore(tmp_path, "issue-42")
+    assert restored is not None
+    assert restored.orchestration_recommended == "cc-workflows-ultracode"
+    assert restored.orchestration_operator_choice == "inline"
+
+
+def test_older_saga_without_recommendation_fields_loads_with_defaults(saga: ModuleType) -> None:
+    """An envelope that lacks orchestration_recommended / orchestration_operator_choice
+    must still parse cleanly -- backward-compatible with pre-U3 sagas.
+
+    Uses render_envelope on a saga WITHOUT the new fields set (relying on their
+    empty-string defaults), then manually strips the two new fields from the rendered
+    text to simulate an older envelope written before U3 existed.
+    """
+    # Build a saga with new fields at default (empty) and render it.
+    s = _make_saga(saga, orchestration_mode="inline")
+    rendered = saga.render_envelope(s)
+    # Strip the two new lines to simulate a pre-U3 envelope.
+    old_envelope_lines = [
+        line
+        for line in rendered.splitlines(keepends=True)
+        if not line.startswith("orchestration_recommended:")
+        and not line.startswith("orchestration_operator_choice:")
+    ]
+    old_envelope = "".join(old_envelope_lines)
+    assert "orchestration_recommended" not in old_envelope
+    assert "orchestration_operator_choice" not in old_envelope
+
+    restored = saga.parse_envelope(old_envelope)
+    # The saga_id / orchestration_mode must survive normally.
+    assert restored.saga_id == "issue-42"
+    assert restored.orchestration_mode == "inline"
+    # New fields default to empty string when absent from the envelope.
+    assert restored.orchestration_recommended == ""
+    assert restored.orchestration_operator_choice == ""
+
+
+def test_orchestration_fields_default_to_empty_string_in_saga(saga: ModuleType) -> None:
+    """The new fields have empty-string defaults so callers need not supply them."""
+    s = _make_saga(saga)
+    assert s.orchestration_recommended == ""
+    assert s.orchestration_operator_choice == ""
+
+
+def test_orchestration_override_rate_fields_present_in_frontmatter_output(saga: ModuleType) -> None:
+    """render_envelope emits both new fields into the frontmatter."""
+    s = _make_saga(
+        saga,
+        orchestration_recommended="team-execution",
+        orchestration_operator_choice="team-execution",
+    )
+    rendered = saga.render_envelope(s)
+    assert "orchestration_recommended: team-execution" in rendered
+    assert "orchestration_operator_choice: team-execution" in rendered
+
+
+# ===========================================================================
 # Suite guard: nothing writes a .claude/ under the repo root during the run.
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- **U2 (R1, R2a):** Pins `model:` frontmatter on the 4 callable ecosystem agents — `home-lab-ops/homelab-sre` → `opus`; `mission-control/sdlc-operator` → `sonnet`; `unifi/unifi-network-ops` → `sonnet`; `deploy/release-orchestrator` → `sonnet`. Documents `redis-channel/redis-channel-coach` exempt (KTD7). Bumps release triad for all 4 touched plugins.
- **U3 (R12):** Extends the saga envelope with `orchestration_recommended` and `orchestration_chosen` fields so override-rate is computable by U13. Backward-compatible: absent-field sagas still load. Bumps saga to 0.24.0.
- **fix:** Updates the hardcoded version pin `0.23.0` → `0.24.0` in the saga contract test, which was missed when U3 bumped the version.

New tests:
- `tests/test_agent_tiering.py` — asserts the 4 agents carry their expected `model:` value and the coach is recorded exempt
- `tests/test_saga_saga.py` — asserts recommendation+choice fields round-trip and absent-field sagas still load

## Test plan
- [ ] `uv run ruff format --check .` — clean
- [ ] `uv run ruff check .` — clean
- [ ] `uv run python scripts/validate_plugins.py` — clean
- [ ] `uv run python marketplace/validator/validate.py` — all 7 plugins valid
- [ ] `uv run pytest` (local, excluding redis collection errors from missing env deps) — 560 passed
- [ ] `uv run mypy plugins/ scripts/ tests/ --ignore-missing-imports` — no issues in 53 files

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe