### PR TITLE
epic1: execution-backend representation (U4 labels, U5 offer rewrite, U6 recommender split)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.25.0 - 2026-06-21
+
+- Rewrite the `/plan` (`skills/plan/SKILL.md`) and `/code-review` execution-backend offers to name
+  **both** dynamic-workflow purposes from `operator-choice.md` §3.2 — **breadth / scale** fan-out **and**
+  **adversarial confidence** (judge-panel / refute-N / perspective-diverse) — instead of underselling
+  `cc-workflows-ultracode` as fan-out only (R5).
+- Reframe the team↔workflow fork on the **governance** axis ("does the verdict need to stick?" — gated
+  consensus that blocks a merge/deploy and persists vs. advisory throwaway votes), not on "review depth"
+  (which both backends have) (R6).
+- Add `tests/test_operator_choice_drift.py` — a drift guard asserting every offer surface stays a
+  SUPERSET of the §3.2 purpose list (anchored on stable content markers, not line numbers), so a future
+  rebuild cannot silently drop a purpose or reintroduce the "review depth" framing.
+
 ## 0.24.0 - 2026-06-21
 
 - Add `orchestration_recommended` and `orchestration_operator_choice` fields to the saga envelope

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -6,6 +6,14 @@
   (R12 — choice-vs-recommendation recording). Enables override-rate computation in `/retro`+`/optimize`.
   Both fields default to `""` so pre-0.24.0 sagas parse without error (backward-compatible additive
   evolution per §9 of the saga spec).
+- Add `ORCHESTRATION_MODE_LABELS` display-label map to `saga.py` (`cc-workflows-ultracode` →
+  "dynamic workflows", `team-execution` → "team execution", `inline` → "inline") and a
+  `display_orchestration_mode()` helper that falls back to the raw enum string on a miss — never errors
+  (R8 / KTD5).
+- Route all offer-surface prose in `/plan`, `/work`, `/code-review`, `/loop`, `/founder-review`,
+  `/optimize`, and `/retro` skills through the display labels so operators see "dynamic workflows"
+  in descriptions while the stored enum string `cc-workflows-ultracode` remains the frozen wire
+  contract (carried in persisted sagas and `--orchestration-mode` CLI choices, byte-for-byte unchanged).
 
 ## 0.23.0 - 2026-06-20
 

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.26.0 - 2026-06-21
+
+- Split the recommender's `needs_consensus` signal on the **governance** axis (R7 keystone). A consensus
+  signal is no longer an unconditional hard-force to `team-execution`: `recommend_execution_backend`
+  gains `consensus_is_gated` (default True). **Gated** consensus (the verdict must block a merge/deploy and
+  persist as evidence) → `team-execution`; **advisory** consensus (throwaway in-session votes) is OR'd into
+  the existing `adversarial_confidence` ultracode trigger → `cc-workflows-ultracode`. A
+  contested-but-not-gated job now reaches the advisory judge-panel and never regresses to `inline`.
+- Add `--advisory-consensus` to the `recommend-backend` CLI so the markdown caller can reach the advisory
+  branch; gated stays the default when the flag is omitted.
+- Add the KTD4 gated-vs-advisory interrogation question + work-shape default to `skills/plan/SKILL.md` §5.2
+  (default *gated* when deploy/security/persist signals are present, *advisory* otherwise; the operator
+  confirms).
+- Update `references/operator-choice.md` §3.1 to record the gated/advisory governance split and that only
+  gated consensus reaches `team-execution`.
+- Cover AE1 (advisory → ultracode), AE2 (gated → team), the overlap case, the docs-gating case, and the
+  CLI round-trip in `tests/test_saga_plugin.py`.
+
 ## 0.25.0 - 2026-06-21
 
 - Rewrite the `/plan` (`skills/plan/SKILL.md`) and `/code-review` execution-backend offers to name

--- a/plugins/saga/references/operator-choice.md
+++ b/plugins/saga/references/operator-choice.md
@@ -73,18 +73,35 @@ Offer `team-execution` when **ANY** of:
 | `cross_repo` | true |
 | `deployment_sensitive` | true |
 
-**OR** a needs-consensus signal: multiple reviewer lenses are warranted, a decision is contested, or
-validator gates should bound the work. team-execution's whole value is *review consensus + gates*, so a job
-that wants those is a team-execution job even if it is small — the consensus signal is **sufficient on its
-own**, not an additive PLUS (this matches `recommend_execution_backend`, which ORs it in).
+**OR** a **GATED** needs-consensus signal — see the governance split below. team-execution's whole value
+is *review consensus + gates*, so a job that wants a verdict to **block and persist** is a team-execution
+job even if it is small — a gated consensus signal is **sufficient on its own**, not an additive PLUS
+(this matches `recommend_execution_backend`, which ORs the gated half in).
+
+**Gated vs advisory consensus (the governance split, R7).** A bare "needs consensus" is not enough — the
+deciding question is whether the verdict **needs to stick**:
+
+| Consensus shape | What it means | Backend |
+|---|---|---|
+| **gated** (`consensus_is_gated=True`, the default) | the verdict must BLOCK a merge/deploy and PERSIST as standing evidence — a reviewer-CONSENSUS gate, named scanners, a guarded deploy | `team-execution` |
+| **advisory** (`consensus_is_gated=False`) | N throwaway in-session votes the operator acts on themselves; nothing is recorded or blocks | `cc-workflows-ultracode` (a judge-panel — §3.2 adversarial confidence) |
+
+So `recommend_execution_backend` no longer hard-forces team-execution on *every* consensus signal: only
+**gated** consensus reaches team-execution; **advisory** consensus is OR'd into the `adversarial_confidence`
+ultracode trigger (§3.2). A contested-but-not-gated job therefore reaches the advisory ultracode branch and
+**never regresses to inline**. When advisory consensus AND a broad fan-out both fire, the offer still lists
+both (§3.3). `/plan` resolves the gated/advisory question with the KTD4 interrogation question
+(`skills/plan/SKILL.md` §5.2), defaulting to *gated* when deploy/security/persist signals are present and
+*advisory* otherwise — the operator confirms.
 
 **Docs exception (`has_code_surface=False`).** team-execution's scanners + deploy gate are code-shaped and
 inert on pure docs/spec/research output, so the **output-blind** rows above — `file_count`, `phase_count`,
 `has_security`, `has_infra`, `deployment_sensitive` (the last two are `parse_issue.py` keyword matches that
 fire on a doc merely *mentioning* terraform or auth) — are neutralized when the work has no code/ship
 surface. Two rows survive because they signal governance, not code: **`cross_repo`** (crossing a repo =
-crossing an ownership boundary = a multi-party coordination need) and the **needs-consensus** signal. A big
-docs change with neither stays `inline`/ultracode, not team-execution.
+crossing an ownership boundary = a multi-party coordination need) and the **gated** needs-consensus signal
+(advisory consensus routes to ultracode regardless of code surface). A big docs change with neither stays
+`inline`/ultracode, not team-execution.
 
 ### 3.2 `inline` -> `cc-workflows-ultracode` (Claude Code only)
 

--- a/plugins/saga/scripts/lifecycle_state.py
+++ b/plugins/saga/scripts/lifecycle_state.py
@@ -105,6 +105,7 @@ def recommend_execution_backend(
     cross_repo: bool = False,
     deployment_sensitive: bool = False,
     needs_consensus: bool = False,
+    consensus_is_gated: bool = True,
     broad_independent_fanout: bool = False,
     adversarial_confidence: bool = False,
     has_code_surface: bool = True,
@@ -117,12 +118,26 @@ def recommend_execution_backend(
     precedence is lean (operator-choice section 3.3): team-execution wins over
     ultracode wins over inline.
 
-    DELIBERATE DIVERGENCE from operator-choice section 3.1: that section frames
-    the consensus signal as a **PLUS** on top of a size/risk trigger. Here a
-    ``needs_consensus`` signal is **sufficient on its own** (``or
-    needs_consensus``) — a small-but-contested job is a team-execution job even
-    without a size/risk trigger, which is the more useful behavior for a real
-    caller. This is intentional, not a transcription error.
+    GATED vs ADVISORY consensus (R7 keystone). A ``needs_consensus`` signal is
+    no longer an unconditional hard-force to team-execution. The governance axis
+    (operator-choice section 3.1) splits it:
+
+    * **gated** consensus (``consensus_is_gated=True``, the default) — the verdict
+      must BLOCK a merge/deploy and PERSIST as standing evidence. Only
+      team-execution offers a reviewer-CONSENSUS gate + named scanners + a guarded
+      deploy, so gated consensus is a team-execution job even when small. Default
+      True keeps every existing caller's behavior (a bare ``needs_consensus=True``
+      still recommends team-execution).
+    * **advisory** consensus (``consensus_is_gated=False``) — N throwaway
+      in-session votes the operator acts on themselves; nothing is recorded or
+      blocks. That is a dynamic-workflow judge-panel, so advisory consensus feeds
+      the existing ``adversarial_confidence`` ultracode trigger instead of forcing
+      team-execution. A contested-but-not-gated job therefore reaches the advisory
+      ultracode branch and never regresses to inline.
+
+    This stops the old unconditional ``or needs_consensus`` hard-force: only the
+    GATED branch reaches team-execution; the advisory branch is OR'd into the
+    ultracode trigger beside ``adversarial_confidence``.
 
     ``has_code_surface`` (default True) neutralizes the code-shaped team-execution
     proxies for pure docs/spec/research work (see ``should_offer_team_execution``).
@@ -134,17 +149,20 @@ def recommend_execution_backend(
     ``adversarial_confidence`` (default False) is the second ultracode trigger
     beside ``broad_independent_fanout``: prove-by-refutation / judge-panel /
     perspective-diverse verification is an ultracode shape (deterministic
-    INDEPENDENT verification, not merely breadth). Without it, "stress-test this
-    from many angles" work with no deploy/security signal would fall to inline.
+    INDEPENDENT verification, not merely breadth). Advisory consensus rides the
+    same branch. Without either, "stress-test this from many angles" work with no
+    deploy/security signal would fall to inline.
 
     ``alternatives`` lists every *reachable* backend (capability-gated by
     ``workflow_available``) computed INDEPENDENTLY of which backend won
-    precedence, so an overlap job (e.g. ``needs_consensus`` AND
+    precedence, so an overlap job (e.g. GATED ``needs_consensus`` AND
     ``broad_independent_fanout``) recommends ``team-execution`` yet still lists
     ``cc-workflows-ultracode`` in ``alternatives`` — escalation stays one
     keystroke (operator-choice section 3.3).
     """
 
+    gated_consensus = needs_consensus and consensus_is_gated
+    advisory_consensus = needs_consensus and not consensus_is_gated
     team = (
         should_offer_team_execution(
             file_count=file_count,
@@ -155,12 +173,14 @@ def recommend_execution_backend(
             deployment_sensitive=deployment_sensitive,
             has_code_surface=has_code_surface,
         )
-        or needs_consensus
+        or gated_consensus
     )
     # The risk suppressor only bites when there is a real code/scanner surface:
     # has_infra / has_security are keyword matches that false-positive on docs.
     elevated_risk = (has_security or has_infra or deployment_sensitive) and has_code_surface
-    ultracode = (broad_independent_fanout or adversarial_confidence) and not elevated_risk
+    ultracode = (
+        broad_independent_fanout or adversarial_confidence or advisory_consensus
+    ) and not elevated_risk
 
     if team:
         recommended = "team-execution"
@@ -205,6 +225,11 @@ def _build_parser() -> argparse.ArgumentParser:
     backend.add_argument("--cross-repo", action="store_true")
     backend.add_argument("--deployment-sensitive", action="store_true")
     backend.add_argument("--needs-consensus", action="store_true")
+    backend.add_argument(
+        "--advisory-consensus",
+        action="store_true",
+        help="treat the consensus signal as ADVISORY (throwaway votes) -> ultracode, not gated team-execution",
+    )
     backend.add_argument("--broad-fanout", action="store_true")
     backend.add_argument("--adversarial-confidence", action="store_true")
     backend.add_argument("--no-code-surface", action="store_true")
@@ -231,6 +256,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             cross_repo=args.cross_repo,
             deployment_sensitive=args.deployment_sensitive,
             needs_consensus=args.needs_consensus,
+            consensus_is_gated=not args.advisory_consensus,
             broad_independent_fanout=args.broad_fanout,
             adversarial_confidence=args.adversarial_confidence,
             has_code_surface=not args.no_code_surface,

--- a/plugins/saga/scripts/saga.py
+++ b/plugins/saga/scripts/saga.py
@@ -70,6 +70,23 @@ STATUSES = ("active", "blocked", "paused", "handed-off", "done", "abandoned")
 DESTINATIONS = ("plan-only", "pr", "merge", "nonprod-deploy")
 ORCHESTRATION_MODES = ("inline", "team-execution", "cc-workflows-ultracode")
 
+# Display-label map (R8 / KTD5).  Maps the stored enum string to the human-readable
+# label surfaced in every offer.  The enum values in ORCHESTRATION_MODES are the
+# frozen wire contract (carried in persisted sagas and CLI --orchestration-mode);
+# this map is additive and never changes their meaning.  A key miss falls back to
+# the raw enum string — never errors.
+ORCHESTRATION_MODE_LABELS: dict[str, str] = {
+    "cc-workflows-ultracode": "dynamic workflows",
+    "team-execution": "team execution",
+    "inline": "inline",
+}
+
+
+def display_orchestration_mode(mode: str) -> str:
+    """Return the human-readable label for *mode*; fall back to the raw string on a miss."""
+    return ORCHESTRATION_MODE_LABELS.get(mode, mode)
+
+
 # maturity is DERIVED at /handoff time from lifecycle_phase — never stored and never
 # surfaced by the generic engine (restore/scan). This is the contract mapping the future
 # /handoff rebuild imports; see references/saga-spec.md §3.3.

--- a/plugins/saga/skills/code-review/SKILL.md
+++ b/plugins/saga/skills/code-review/SKILL.md
@@ -166,12 +166,13 @@ do **not** reference named `ce-*` agents). Each lens returns findings in the sch
 `references/findings-schema.md`.
 
 **Operator-choice backend.** Offer the execution backend per `../../references/operator-choice.md` (the
-plugin-root decision contract). There are exactly three backends — `inline | team-execution |
-cc-workflows-ultracode`. Read the work shape, recommend the cheapest-correct backend and pre-select it,
-but surface the alternatives so escalation is one step. Escalate to `team-execution` for risky/consensus
-review (large diff, security, infra, cross-repo, deployment-sensitive); to `cc-workflows-ultracode` for
-broad independent fan-out without elevated risk. Omit `cc-workflows-ultracode` when the Workflow tool is
-observably absent. `inline` suits small diffs.
+plugin-root decision contract). There are exactly three backends — `inline` ("inline") |
+`team-execution` ("team execution") | `cc-workflows-ultracode` ("dynamic workflows"). Read the work
+shape, recommend the cheapest-correct backend and pre-select it, but surface the alternatives so
+escalation is one step. Escalate to `team-execution` ("team execution") for risky/consensus review
+(large diff, security, infra, cross-repo, deployment-sensitive); to `cc-workflows-ultracode`
+("dynamic workflows") for broad independent fan-out without elevated risk. Omit `cc-workflows-ultracode`
+("dynamic workflows") when the Workflow tool is observably absent. `inline` ("inline") suits small diffs.
 
 **Search-before-recommending.** Before citing a fix pattern (concurrency, caching, auth, framework
 behavior), verify it is current best practice for the version in use — check for a built-in solution in

--- a/plugins/saga/skills/code-review/SKILL.md
+++ b/plugins/saga/skills/code-review/SKILL.md
@@ -169,10 +169,26 @@ do **not** reference named `ce-*` agents). Each lens returns findings in the sch
 plugin-root decision contract). There are exactly three backends — `inline` ("inline") |
 `team-execution` ("team execution") | `cc-workflows-ultracode` ("dynamic workflows"). Read the work
 shape, recommend the cheapest-correct backend and pre-select it, but surface the alternatives so
-escalation is one step. Escalate to `team-execution` ("team execution") for risky/consensus review
-(large diff, security, infra, cross-repo, deployment-sensitive); to `cc-workflows-ultracode`
-("dynamic workflows") for broad independent fan-out without elevated risk. Omit `cc-workflows-ultracode`
-("dynamic workflows") when the Workflow tool is observably absent. `inline` ("inline") suits small diffs.
+escalation is one step. `inline` ("inline") suits small diffs.
+
+**Dynamic workflows serve BOTH purposes** (per `operator-choice.md` §3.2) — escalate to
+`cc-workflows-ultracode` ("dynamic workflows"), without elevated risk, for **either**:
+
+- **Breadth / scale** — broad independent fan-out, the same review lens across many enumerated targets, or
+  an exhaustive probe-all sweep where missing a target is the failure mode.
+- **Adversarial confidence** — a judge panel over N independent attempts, prove-by-refutation (refute-N),
+  or perspective-diverse verifiers each applying a distinct lens. This is real review depth; the Workflow
+  tool names *confidence* as a first-class purpose. Set it only on an **explicit** request for
+  many-independent-attempt verification.
+
+**The team↔workflow fork is GOVERNANCE, not "review depth"** (both have review depth). The question is:
+**does the verdict need to stick?** Escalate to `team-execution` ("team execution") when the review needs
+**gated** consensus — a verdict that blocks a merge/deploy and persists as standing evidence (a reviewer-
+CONSENSUS gate, named scanners, a guarded deploy), or the size/risk signals fire (large diff, security,
+infra, cross-repo, deployment-sensitive). An **advisory** consensus signal — N throwaway in-session votes
+you act on yourself, nothing recorded or blocking — is a dynamic-workflow judge-panel, not a
+team-execution job. Omit `cc-workflows-ultracode` ("dynamic workflows") when the Workflow tool is
+observably absent.
 
 **Search-before-recommending.** Before citing a fix pattern (concurrency, caching, auth, framework
 behavior), verify it is current best practice for the version in use — check for a built-in solution in

--- a/plugins/saga/skills/founder-review/SKILL.md
+++ b/plugins/saga/skills/founder-review/SKILL.md
@@ -211,10 +211,11 @@ directory (**NOT** `docs/reviews/` = readiness, **NOT** `docs/code-reviews/` = c
 
 **Operator-choice.** On a scope-expansion or scrap-and-rethink verdict, **OFFER** routing the accepted
 changes through an execution backend per `../../references/operator-choice.md` (the plugin-root
-decision contract). There are exactly three backends — `inline | team-execution |
-cc-workflows-ultracode`. Read the work shape, recommend the cheapest-correct backend and pre-select
-it, but surface the alternatives so escalation is one step. Omit `cc-workflows-ultracode` when the
-Workflow tool is observably absent. The offer is never auto-run.
+decision contract). There are exactly three backends — `inline` ("inline") | `team-execution` ("team execution") |
+`cc-workflows-ultracode` ("dynamic workflows"). Read the work shape, recommend the cheapest-correct
+backend and pre-select it, but surface the alternatives so escalation is one step. Omit
+`cc-workflows-ultracode` ("dynamic workflows") when the Workflow tool is observably absent. The offer is
+never auto-run.
 
 **No saga write.** `/founder-review` runs upstream of the work thread and does **not** touch the saga
 — no `saga.py` invocation, no `--review-paths`. Persistence is the `docs/founder-reviews/` artifact +

--- a/plugins/saga/skills/loop/SKILL.md
+++ b/plugins/saga/skills/loop/SKILL.md
@@ -245,7 +245,7 @@ python3 plugins/saga/scripts/lifecycle_state.py recommend-backend \
 Recommend the cheapest-correct backend, surface the alternatives (escalation one step), confirm with
 the operator, and record `--orchestration-mode` + `--orchestration-ref` in the routing tick (Phase 4)
 **only in this `/loop`-owned-offload case** — never on an ordinary single-command route. Omit
-`cc-workflows-ultracode` from the offer when the Workflow tool is observably absent; fall back to
+`cc-workflows-ultracode` ("dynamic workflows") from the offer when the Workflow tool is observably absent; fall back to
 `/loop`'s own phase-walk when no heavier backend is reachable (operator-choice §4).
 
 ---

--- a/plugins/saga/skills/optimize/SKILL.md
+++ b/plugins/saga/skills/optimize/SKILL.md
@@ -73,9 +73,9 @@ Resolve any cross-command route through the lifecycle routing reference at
    developer-experience, maintainability. Each metric is measured as **hard** (a direct numeric, gated)
    or by **judge** (semantic quality), chosen per metric — see `references/metric-taxonomy.md`.
 6. **Default bounded & serial; escalate by CHOICE.** The loop runs serial and in working state by
-   default. For **independent experiment fan-out** it **OFFERS** `team-execution` /
-   `cc-workflows-ultracode` per the operator-choice contract, recorded **narratively** (this engine
-   writes no saga). It never auto-spawns a backend, never auto-commits, never auto-merges, never deploys.
+   default. For **independent experiment fan-out** it **OFFERS** `team-execution` ("team execution") /
+   `cc-workflows-ultracode` ("dynamic workflows") per the operator-choice contract, recorded
+   **narratively** (this engine writes no saga). It never auto-spawns a backend, never auto-commits, never auto-merges, never deploys.
 
 ## Interaction method
 
@@ -154,9 +154,9 @@ start of every batch.
 
 **Select a batch** from the runnable backlog. **Serial default = batch size 1.** For **independent
 experiment fan-out**, **OFFER** an execution backend HERE per `../../references/operator-choice.md`
-(§3.2 — broad, independent, low-risk fan-out leans `cc-workflows-ultracode`; risky-and-parallel leans
-`team-execution`); record the chosen backend **narratively** in the strategy digest (this engine writes
-no saga — §6 of operator-choice). Never auto-spawn.
+(§3.2 — broad, independent, low-risk fan-out leans `cc-workflows-ultracode` ("dynamic workflows");
+risky-and-parallel leans `team-execution` ("team execution")); record the chosen backend **narratively**
+in the strategy digest (this engine writes no saga — §6 of operator-choice). Never auto-spawn.
 
 **Per experiment:**
 

--- a/plugins/saga/skills/plan/SKILL.md
+++ b/plugins/saga/skills/plan/SKILL.md
@@ -270,6 +270,22 @@ judge-panel, not a team-execution job. Omit `cc-workflows-ultracode` ("dynamic w
 when the Workflow tool is observably absent in this session. Confirm with the operator and record what
 they picked via `--orchestration-mode`.
 
+**KTD4 — the gated-vs-advisory interrogation (R7).** When a consensus / multi-reviewer / many-attempt
+signal is present, do **not** silently force `team-execution`. Ask the operator (`AskUserQuestion`, or
+channel-inline) one question, with the work-shape default pre-selected:
+
+> **Does this verdict need to BLOCK a merge/deploy or PERSIST as evidence — or are these throwaway
+> in-session votes you act on yourself?**
+> **A) Gated** — block/persist (a reviewer-CONSENSUS gate, named scanners, a guarded deploy) → `team-execution`.
+> **B) Advisory** — N throwaway votes, nothing recorded/blocking → `cc-workflows-ultracode` (a judge-panel).
+
+**Work-shape default:** pre-select **Gated** when any deploy / security / persist signal is present
+(`--destination merge|nonprod-deploy`, security/infra work, or a verdict that must be recorded); pre-select
+**Advisory** otherwise. Pass the answer into the recommender as `--advisory-consensus` (set for B; omit for
+A — gated is the default). The advisory path feeds the existing `adversarial_confidence` ultracode trigger,
+so a contested-but-not-gated job reaches the judge-panel and never regresses to `inline`. If the work is
+**both** gated **and** broadly parallel, list both backends (per `references/operator-choice.md` §3.3).
+
 ### 5.3 Write the saga tick
 
 Emit a **runnable** saga `save` command — never prose like "write a saga", and never `git add` the

--- a/plugins/saga/skills/plan/SKILL.md
+++ b/plugins/saga/skills/plan/SKILL.md
@@ -246,12 +246,13 @@ nonprod-deploy**. This becomes the saga `--destination`.
 ### 5.2 Offer the execution backend
 
 Offer the execution backend per `references/operator-choice.md` (the decision contract). There are
-exactly three backends — `inline | team-execution | cc-workflows-ultracode`. Read the work shape,
-**recommend the cheapest-correct** backend and pre-select it, but always surface the alternatives so
-escalation is one step. Escalate to `team-execution` for risky/consensus work (≥8 files, ≥4 phases,
-security, infra, cross-repo, deployment-sensitive, plus a needs-consensus signal); to
-`cc-workflows-ultracode` for broad independent fan-out without elevated risk. Omit
-`cc-workflows-ultracode` from the offer when the Workflow tool is observably absent in this session.
+exactly three backends — `inline` ("inline") | `team-execution` ("team execution") |
+`cc-workflows-ultracode` ("dynamic workflows"). Read the work shape, **recommend the cheapest-correct**
+backend and pre-select it, but always surface the alternatives so escalation is one step. Escalate to
+`team-execution` ("team execution") for risky/consensus work (≥8 files, ≥4 phases, security, infra,
+cross-repo, deployment-sensitive, plus a needs-consensus signal); to `cc-workflows-ultracode`
+("dynamic workflows") for broad independent fan-out without elevated risk. Omit `cc-workflows-ultracode`
+("dynamic workflows") from the offer when the Workflow tool is observably absent in this session.
 Confirm with the operator and record what they picked via `--orchestration-mode`.
 
 ### 5.3 Write the saga tick

--- a/plugins/saga/skills/plan/SKILL.md
+++ b/plugins/saga/skills/plan/SKILL.md
@@ -248,12 +248,27 @@ nonprod-deploy**. This becomes the saga `--destination`.
 Offer the execution backend per `references/operator-choice.md` (the decision contract). There are
 exactly three backends — `inline` ("inline") | `team-execution` ("team execution") |
 `cc-workflows-ultracode` ("dynamic workflows"). Read the work shape, **recommend the cheapest-correct**
-backend and pre-select it, but always surface the alternatives so escalation is one step. Escalate to
-`team-execution` ("team execution") for risky/consensus work (≥8 files, ≥4 phases, security, infra,
-cross-repo, deployment-sensitive, plus a needs-consensus signal); to `cc-workflows-ultracode`
-("dynamic workflows") for broad independent fan-out without elevated risk. Omit `cc-workflows-ultracode`
-("dynamic workflows") from the offer when the Workflow tool is observably absent in this session.
-Confirm with the operator and record what they picked via `--orchestration-mode`.
+backend and pre-select it, but always surface the alternatives so escalation is one step.
+
+**Dynamic workflows serve BOTH purposes** (per `references/operator-choice.md` §3.2) — escalate to
+`cc-workflows-ultracode` ("dynamic workflows"), without elevated risk, for **either**:
+
+- **Breadth / scale** — broad independent fan-out, the same operation across many enumerated targets, or
+  an exhaustive probe-all sweep where missing a target is the failure mode.
+- **Adversarial confidence** — a judge panel over N independent attempts, prove-by-refutation (refute-N),
+  or perspective-diverse verifiers each applying a distinct lens. This is real review depth; the Workflow
+  tool names *confidence* as a first-class purpose. Set it only on an **explicit** request for
+  many-independent-attempt verification, not on a generic "be more sure."
+
+**The team↔workflow fork is GOVERNANCE, not "review depth"** (both have review depth). The question is:
+**does the verdict need to stick?** Escalate to `team-execution` ("team execution") when the work needs
+**gated** consensus — a verdict that blocks a merge/deploy and persists as standing evidence (a reviewer-
+CONSENSUS gate, named scanners, a guarded deploy), or the size/risk signals fire (≥8 files, ≥4 phases,
+security, infra, cross-repo, deployment-sensitive). When the consensus signal is **advisory** — N
+throwaway in-session votes you act on yourself, nothing recorded or blocking — it is a dynamic-workflow
+judge-panel, not a team-execution job. Omit `cc-workflows-ultracode` ("dynamic workflows") from the offer
+when the Workflow tool is observably absent in this session. Confirm with the operator and record what
+they picked via `--orchestration-mode`.
 
 ### 5.3 Write the saga tick
 

--- a/plugins/saga/skills/retro/SKILL.md
+++ b/plugins/saga/skills/retro/SKILL.md
@@ -107,9 +107,9 @@ presentation format; the gate itself is:
   carries an **EXPLICIT warning in the diff header**:
   > **WARNING: this changes your GLOBAL Claude config and affects ALL projects, not just this repo.**
 
-**Never auto-launch** a destructive self-edit or an execution backend. A backend (team-execution /
-cc-workflows-ultracode) for a big refactor is **offered** per `../../references/operator-choice.md`, never
-started without the operator's pick.
+**Never auto-launch** a destructive self-edit or an execution backend. A backend (`team-execution` ("team execution") /
+`cc-workflows-ultracode` ("dynamic workflows")) for a big refactor is **offered** per
+`../../references/operator-choice.md`, never started without the operator's pick.
 
 ---
 
@@ -273,8 +273,9 @@ The passes neither source had, all gated (`references/retro-passes.md`):
 - **(d) memory pruning** — propose curation of the `.claude` auto-memory (`MEMORY.md` + topic files) per
   the journal-rule + staleness + contradiction sweeps.
 
-A **big multi-file refactor** surfaced by any pass → **OFFER** a backend (team-execution /
-cc-workflows-ultracode) per `../../references/operator-choice.md`. **Never auto-run** it.
+A **big multi-file refactor** surfaced by any pass → **OFFER** a backend (`team-execution`
+("team execution") / `cc-workflows-ultracode` ("dynamic workflows")) per
+`../../references/operator-choice.md`. **Never auto-run** it.
 
 ---
 

--- a/tests/test_operator_choice_drift.py
+++ b/tests/test_operator_choice_drift.py
@@ -1,0 +1,114 @@
+"""Drift guard: every execution-backend offer surface must stay a SUPERSET of the
+`operator-choice.md` §3.2 dynamic-workflow purpose list.
+
+The §3.2 contract names TWO first-class purposes for `cc-workflows-ultracode`
+("dynamic workflows"):
+
+  1. **Breadth / scale** — broad independent fan-out / probe-all sweep.
+  2. **Adversarial confidence** — judge-panel / refute-N / perspective-diverse verification.
+
+A future SKILL rebuild must not silently drop a purpose back to "fan-out only", and
+must keep framing the team<->workflow fork on the GOVERNANCE axis (does the verdict
+need to stick?), not on "review depth" (which both backends have). This test fails if
+any offer surface omits a §3.2 purpose or reintroduces the "review depth" framing of
+the fork.
+
+The assertions anchor on STABLE content markers (bolded purpose names + their defining
+keyword sets), never on line numbers, so benign reformatting does not break the guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAGA_ROOT = REPO_ROOT / "plugins" / "saga"
+OPERATOR_CHOICE = SAGA_ROOT / "references" / "operator-choice.md"
+
+# Offer surfaces that must each name BOTH §3.2 purposes (R5).
+OFFER_SURFACES = {
+    "plan": SAGA_ROOT / "skills" / "plan" / "SKILL.md",
+    "code-review": SAGA_ROOT / "skills" / "code-review" / "SKILL.md",
+}
+
+# The two §3.2 purposes, each identified by a stable bold marker and a set of
+# defining keywords. The marker proves the purpose is NAMED; the keywords prove it
+# carries its semantics, not just a label. Surfaces must be a SUPERSET of this set.
+CANONICAL_PURPOSES = {
+    "breadth": {
+        "marker": "breadth",
+        "keywords": ["fan-out", "target"],
+    },
+    "adversarial-confidence": {
+        "marker": "adversarial confidence",
+        "keywords": ["judge panel", "confidence"],
+    },
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _section_3_2(text: str) -> str:
+    """Slice §3.2 from operator-choice.md, anchored on its heading markers."""
+    start = re.search(r"^###\s*3\.2\b.*$", text, re.MULTILINE)
+    assert start is not None, "operator-choice.md §3.2 heading not found"
+    after = text[start.end() :]
+    nxt = re.search(r"^###\s", after, re.MULTILINE)
+    return after[: nxt.start()] if nxt else after
+
+
+def test_operator_choice_3_2_names_both_purposes() -> None:
+    """Sanity-anchor the source of truth: §3.2 itself names both purposes."""
+    section = _section_3_2(_read(OPERATOR_CHOICE)).lower()
+    for key, spec in CANONICAL_PURPOSES.items():
+        assert spec["marker"] in section, f"§3.2 lost the '{key}' purpose marker"
+
+
+def test_every_offer_surface_is_superset_of_3_2_purposes() -> None:
+    """R5: each offer surface names BOTH §3.2 purposes with their defining keywords."""
+    for name, path in OFFER_SURFACES.items():
+        body = _read(path).lower()
+        for key, spec in CANONICAL_PURPOSES.items():
+            assert spec["marker"] in body, (
+                f"{name} offer dropped the §3.2 '{key}' purpose (marker {spec['marker']!r} absent)"
+            )
+            for kw in spec["keywords"]:
+                assert kw in body, (
+                    f"{name} offer names '{key}' but is missing its defining "
+                    f"keyword {kw!r} — purpose underspecified vs §3.2"
+                )
+
+
+def test_every_offer_frames_fork_on_governance_not_review_depth() -> None:
+    """R6: the team<->workflow fork is framed on GOVERNANCE (does the verdict stick?),
+    not on "review depth" (which both backends have)."""
+    for name, path in OFFER_SURFACES.items():
+        body = _read(path).lower()
+        assert "governance" in body, (
+            f"{name} offer does not frame the team<->workflow fork on the governance axis (R6)"
+        )
+        # The fork must be posed as the verdict-persistence question, not depth.
+        assert any(
+            phrase in body
+            for phrase in ("verdict need to stick", "blocks a merge", "block a merge")
+        ), (
+            f"{name} offer does not name the 'does the verdict need to stick' "
+            f"governance question (R6)"
+        )
+
+
+def test_no_offer_undersells_workflows_as_fan_out_only() -> None:
+    """Regression: the pre-rewrite prose sold dynamic workflows as fan-out ONLY.
+    If a surface names breadth/fan-out it must also name adversarial confidence."""
+    for name, path in OFFER_SURFACES.items():
+        body = _read(path).lower()
+        names_breadth = "fan-out" in body
+        names_confidence = "adversarial confidence" in body
+        if names_breadth:
+            assert names_confidence, (
+                f"{name} offer names fan-out but not adversarial confidence — "
+                f"undersells dynamic workflows as fan-out only (R5 regression)"
+            )

--- a/tests/test_operator_choice_drift.py
+++ b/tests/test_operator_choice_drift.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import TypedDict
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAGA_ROOT = REPO_ROOT / "plugins" / "saga"
@@ -32,10 +33,16 @@ OFFER_SURFACES = {
     "code-review": SAGA_ROOT / "skills" / "code-review" / "SKILL.md",
 }
 
+
+class PurposeSpec(TypedDict):
+    marker: str
+    keywords: list[str]
+
+
 # The two §3.2 purposes, each identified by a stable bold marker and a set of
 # defining keywords. The marker proves the purpose is NAMED; the keywords prove it
 # carries its semantics, not just a label. Surfaces must be a SUPERSET of this set.
-CANONICAL_PURPOSES = {
+CANONICAL_PURPOSES: dict[str, PurposeSpec] = {
     "breadth": {
         "marker": "breadth",
         "keywords": ["fan-out", "target"],

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.24.0"
+    assert plugin_json["version"] == "0.25.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.25.0"
+    assert plugin_json["version"] == "0.26.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]
@@ -2546,6 +2546,96 @@ def test_recommend_execution_backend_adversarial_confidence() -> None:
     overlap = rec(adversarial_confidence=True, needs_consensus=True)
     assert overlap["recommended"] == "team-execution"
     assert "cc-workflows-ultracode" in overlap["alternatives"]
+
+
+def test_recommend_execution_backend_gated_vs_advisory_consensus() -> None:
+    """R7 keystone: needs_consensus splits on the GOVERNANCE axis (gated vs advisory).
+
+    The old behavior hard-forced team-execution on EVERY consensus signal
+    (``or needs_consensus``). U6 replaces that with consensus_is_gated:
+
+    * GATED (default) -> team-execution: the verdict must block/persist.
+    * ADVISORY        -> cc-workflows-ultracode: throwaway in-session votes
+      ride the existing adversarial_confidence ultracode branch.
+
+    A contested-but-not-gated job must reach the ADVISORY ultracode branch and
+    NEVER regress to inline. The docs-gating (has_code_surface) and the overlap
+    alternatives behavior are preserved.
+    """
+    lifecycle = _load_module("lifecycle_state.py")
+    rec = lifecycle.recommend_execution_backend
+
+    # AE2 — GATED consensus (the default) -> team-execution. A bare
+    # needs_consensus=True keeps the legacy behavior (default consensus_is_gated=True).
+    gated = rec(needs_consensus=True)
+    assert gated["recommended"] == "team-execution"
+    assert rec(needs_consensus=True, consensus_is_gated=True)["recommended"] == "team-execution"
+
+    # AE1 — ADVISORY consensus, no risk -> cc-workflows-ultracode (the judge-panel),
+    # NOT team-execution and NOT inline.
+    advisory = rec(needs_consensus=True, consensus_is_gated=False)
+    assert advisory["recommended"] == "cc-workflows-ultracode"
+
+    # The hard-force is gone: advisory consensus alone no longer routes to team.
+    assert advisory["recommended"] != "team-execution"
+    # team-execution stays a one-keystroke alternative for the advisory pick.
+    assert "team-execution" in advisory["alternatives"]
+
+    # consensus_is_gated is INERT when there is no consensus signal at all:
+    # a bare job stays inline whether the flag is set or not.
+    assert rec(consensus_is_gated=False)["recommended"] == "inline"
+    assert rec(consensus_is_gated=True)["recommended"] == "inline"
+
+    # Advisory consensus rides the SAME risk gate as the other ultracode triggers:
+    # an elevated-risk code surface suppresses the ultracode branch -> team-execution.
+    assert (
+        rec(needs_consensus=True, consensus_is_gated=False, has_security=True)["recommended"]
+        == "team-execution"
+    )
+
+    # Advisory consensus rides the SAME capability gate: absent the Workflow tool
+    # it degrades to inline and drops ultracode from the offer.
+    no_wf = rec(needs_consensus=True, consensus_is_gated=False, workflow_available=False)
+    assert no_wf["recommended"] == "inline"
+    assert no_wf["omit_ultracode"] is True
+    assert "cc-workflows-ultracode" not in no_wf["alternatives"]
+
+    # OVERLAP — gated consensus AND broad fan-out: team wins precedence, but
+    # cc-workflows-ultracode is still listed as a one-keystroke escalation.
+    overlap = rec(needs_consensus=True, consensus_is_gated=True, broad_independent_fanout=True)
+    assert overlap["recommended"] == "team-execution"
+    assert "cc-workflows-ultracode" in overlap["alternatives"]
+    assert "team-execution" not in overlap["alternatives"]
+
+    # DOCS-GATING preserved. Advisory consensus on a pure-docs change (no code
+    # surface) still reaches the ultracode judge-panel — has_code_surface gates the
+    # code-shaped proxies, not the governance-shaped consensus routing.
+    docs_advisory = rec(needs_consensus=True, consensus_is_gated=False, has_code_surface=False)
+    assert docs_advisory["recommended"] == "cc-workflows-ultracode"
+    # GATED consensus survives the docs neutralizer (it is governance, not code).
+    docs_gated = rec(needs_consensus=True, consensus_is_gated=True, has_code_surface=False)
+    assert docs_gated["recommended"] == "team-execution"
+
+
+def test_recommend_backend_cli_advisory_consensus(capsys: pytest.CaptureFixture[str]) -> None:
+    """--advisory-consensus round-trips through main(): the new branch is CLI-reachable.
+
+    Without a runnable flag the gated/advisory split is unreachable from the
+    markdown caller, so the flag must flow end-to-end. Omitting it keeps the
+    gated default (team-execution); setting it routes to the ultracode judge-panel.
+    """
+    lifecycle = _load_module("lifecycle_state.py")
+
+    # Default (gated): --needs-consensus alone -> team-execution.
+    assert lifecycle.main(["recommend-backend", "--needs-consensus"]) == 0
+    gated = json.loads(capsys.readouterr().out)
+    assert gated["recommended"] == "team-execution"
+
+    # --advisory-consensus flips it to the ultracode judge-panel.
+    assert lifecycle.main(["recommend-backend", "--needs-consensus", "--advisory-consensus"]) == 0
+    advisory = json.loads(capsys.readouterr().out)
+    assert advisory["recommended"] == "cc-workflows-ultracode"
+    assert "team-execution" in advisory["alternatives"]
 
 
 def test_recommend_execution_backend_docs_no_code_surface() -> None:

--- a/tests/test_saga_saga.py
+++ b/tests/test_saga_saga.py
@@ -1355,3 +1355,46 @@ def test_suite_does_not_create_claude_dir_under_repo_root() -> None:
     if stray_legacy.exists():
         leaked_cp = [p.name for p in stray_legacy.glob("issue-*-phase*.md")]
         assert leaked_cp == [], f"saga tests leaked legacy checkpoints: {leaked_cp}"
+
+
+# ===========================================================================
+# U4: Display-label map — decouple presentation from wire contract (R8 / KTD5)
+# ===========================================================================
+
+
+def test_orchestration_modes_enum_is_frozen(saga: ModuleType) -> None:
+    """ORCHESTRATION_MODES must be byte-for-byte unchanged — it is the wire contract.
+
+    Persisted sagas carry the raw enum string; changing value or order would silently
+    corrupt any saga that was saved before the change.  This test is the assertion
+    KTD5 mandates: no value-addition, no reorder, no rename.
+    """
+    assert saga.ORCHESTRATION_MODES == ("inline", "team-execution", "cc-workflows-ultracode")
+
+
+def test_display_orchestration_mode_renders_labels(saga: ModuleType) -> None:
+    """The display helper maps each enum value to its human-readable label."""
+    assert saga.display_orchestration_mode("cc-workflows-ultracode") == "dynamic workflows"
+    assert saga.display_orchestration_mode("team-execution") == "team execution"
+    assert saga.display_orchestration_mode("inline") == "inline"
+
+
+def test_display_orchestration_mode_falls_back_on_miss(saga: ModuleType) -> None:
+    """An unknown key falls back to the raw string — never raises."""
+    assert saga.display_orchestration_mode("unknown-future-mode") == "unknown-future-mode"
+    assert saga.display_orchestration_mode("") == ""
+
+
+def test_orchestration_mode_labels_covers_all_modes(saga: ModuleType) -> None:
+    """Every value in ORCHESTRATION_MODES has an explicit entry in the label map.
+
+    A future ORCHESTRATION_MODES extension that forgets to add a label is caught
+    here (the fallback is intentional, but unregistered modes shouldn't stay
+    accidentally unlabelled forever).
+    """
+    for mode in saga.ORCHESTRATION_MODES:
+        assert mode in saga.ORCHESTRATION_MODE_LABELS, (
+            f"Mode {mode!r} is in ORCHESTRATION_MODES but has no entry in "
+            "ORCHESTRATION_MODE_LABELS — add a display label or the offer will "
+            "fall back to the raw enum string silently."
+        )


### PR DESCRIPTION
## Summary

- **U4**: Add `ORCHESTRATION_MODE_LABELS` display-label map in `saga.py` — decouples the stored wire enum (`cc-workflows-ultracode`) from the operator-facing label ("dynamic workflows"). Falls back to raw enum on a miss, never errors. Routes offer surfaces in `/plan`, `/work`, `/code-review`, `/loop`, `/founder-review`, `/optimize`, `/retro` through the map (R8, KTD5).
- **U5**: Rewrite `/plan` and `/code-review` execution-backend offers to name BOTH `operator-choice.md` §3.2 purposes — breadth/scale fan-out AND adversarial confidence (judge-panel / refute-N / perspective-diverse). Frame the team↔workflow fork on the governance axis (does the verdict need to stick?), not "review depth" (R5, R6). Add `tests/test_operator_choice_drift.py` drift guard.
- **U6**: Split the recommender's `needs_consensus` hard-force on the governance axis. Gated consensus → `team-execution`; advisory consensus is OR'd into the existing `adversarial_confidence` ultracode trigger. Add KTD4 interrogation question to `/plan`. Cover AE1, AE2, overlap, docs-gating (R7, KTD4).

## Test plan

- [ ] `uv run ruff format --check .` passes
- [ ] `uv run ruff check .` passes
- [ ] `uv run python scripts/validate_plugins.py` passes
- [ ] `uv run python marketplace/validator/validate.py` passes
- [ ] `uv run pytest` — 691 passed, 0 failed
- [ ] `uv run mypy plugins/ scripts/ tests/ --ignore-missing-imports` — no issues