### PR TITLE
epic3: hook harness (U7 JSON validator, U8 journal nudge, U9 pre-push gate)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.29.0 - 2026-06-21
+
+- Add `tools/gate-manifest.json`: single-source declarative listing of the pre-push gate steps
+  (`ruff format --check`, `ruff check`, `validate_plugins`, `validate marketplace`, `pytest`),
+  each with an `id`, `label`, `command`, and `failure_hint`.  This file is the sole authoritative
+  gate definition — the hook reads it at runtime and never diverges.  Addresses R15 / KTD10
+  (Epic 3 hook harness, U9).
+- Add `plugins/saga/hooks/pre_push_gate_hook.py`: a `PreToolUse` / Bash hook that fires when the
+  Bash tool runs a `git push` command.  Reads `tools/gate-manifest.json` relative to the repo root,
+  runs every step in order, and reports by exception — silent on pass, prints each failed step's
+  label, output, and failure hint to stderr then exits 2 (blocking) on any failure.  Cross-repo-safe:
+  degrades silently when the manifest is absent.  Co-located with U7/U8 in `hooks/hooks.json`.
+- Update `plugins/saga/hooks/hooks.json`: add a `PreToolUse` / `Bash` matcher entry wiring
+  `pre_push_gate_hook.py` into the hook harness alongside the existing JSON validator (U7) and
+  journal nudge (U8).
+- Add `tests/test_pre_push_gate.py`: 20 tests covering manifest structure (5 required step IDs,
+  uniqueness, all fields present), push detection, exit-code contract (silent on pass, exit 2 on
+  failure, exit 0 on non-push/non-Bash/malformed/missing-manifest), failure reporting (all failing
+  steps listed, output echoed, hints included), and the single-source invariant (hook executes
+  manifest-defined steps, not a hard-coded list).
+
 ## 0.28.0 - 2026-06-21
 
 - Add `plugins/saga/hooks/journal_nudge_hook.py`: a non-blocking `PostToolUse` hook (exit 0 always)

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.27.0 - 2026-06-21
+
+- Add `plugins/saga/hooks/hooks.json` and `hooks/validate_json_hook.py`: the repo's first hook.
+  A `PreToolUse` hook that JSON-parses `marketplace.json` and `plugin.json` on every
+  `Edit`/`Write`/`MultiEdit`, asserts balanced brackets, and exits 2 (blocking) with the
+  offending file path and line on failure.  Unrelated files pass through silently (exit 0).
+  Addresses R13 (Epic 3 hook harness).
+
 ## 0.26.0 - 2026-06-21
 
 - Split the recommender's `needs_consensus` signal on the **governance** axis (R7 keystone). A consensus

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.28.0 - 2026-06-21
+
+- Add `plugins/saga/hooks/journal_nudge_hook.py`: a non-blocking `PostToolUse` hook (exit 0 always)
+  that fires on a `feat`/`fix` Bash commit touching code files with no `docs/engineering-journal/`
+  entry staged, and prints a one-line nudge to stderr.  Does not write the entry and does not block.
+  Ships cross-repo-safe: degrades silently when the journal dir is absent or git is unavailable.
+  Co-located with U7 in `hooks/hooks.json` under a new `PostToolUse` / `Bash` matcher.
+  Addresses R14 (Epic 3 hook harness, U8).
+
 ## 0.27.0 - 2026-06-21
 
 - Add `plugins/saga/hooks/hooks.json` and `hooks/validate_json_hook.py`: the repo's first hook.

--- a/plugins/saga/hooks/hooks.json
+++ b/plugins/saga/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Saga plugin hook: validates marketplace.json and plugin.json for valid JSON and balanced brackets on every edit, blocking (exit 2) with the offending line on failure.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate_json_hook.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/saga/hooks/hooks.json
+++ b/plugins/saga/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Saga plugin hooks: (1) validates marketplace.json and plugin.json for valid JSON and balanced brackets on every edit, blocking (exit 2) with the offending line on failure; (2) nudges (non-blocking, exit 0) when a feat/fix commit touches code but stages no docs/engineering-journal/ entry.",
+  "description": "Saga plugin hooks: (1) validates marketplace.json and plugin.json for valid JSON and balanced brackets on every edit, blocking (exit 2) with the offending line on failure; (2) nudges (non-blocking, exit 0) when a feat/fix commit touches code but stages no docs/engineering-journal/ entry; (3) runs the pre-push gate from tools/gate-manifest.json on git push, reporting by exception and blocking (exit 2) on any failure.",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,15 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate_json_hook.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_push_gate_hook.py\""
           }
         ]
       }

--- a/plugins/saga/hooks/hooks.json
+++ b/plugins/saga/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Saga plugin hook: validates marketplace.json and plugin.json for valid JSON and balanced brackets on every edit, blocking (exit 2) with the offending line on failure.",
+  "description": "Saga plugin hooks: (1) validates marketplace.json and plugin.json for valid JSON and balanced brackets on every edit, blocking (exit 2) with the offending line on failure; (2) nudges (non-blocking, exit 0) when a feat/fix commit touches code but stages no docs/engineering-journal/ entry.",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,17 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate_json_hook.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/journal_nudge_hook.py\""
           }
         ]
       }

--- a/plugins/saga/hooks/journal_nudge_hook.py
+++ b/plugins/saga/hooks/journal_nudge_hook.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook: nudge when a feat/fix commit omits a journal entry.
+
+Fires after a Bash tool call that issues a `git commit`.  When the commit
+message starts with `feat` or `fix` and the committed diff touches code files
+but includes NO `docs/engineering-journal/` path, prints a one-line nudge to
+stderr.
+
+Properties (all by design):
+  - NON-blocking: always exits 0.
+  - NON-writing: never creates or edits journal files.
+  - Cross-repo-safe: degrades quietly when the journal dir is absent or git
+    is unavailable.
+
+Exit codes:
+  0 — always (nudge or not, pass or error).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Commit message prefixes that warrant a journal nudge.
+_FEAT_FIX_RE = re.compile(r"^(feat|fix)\b", re.IGNORECASE)
+
+# Extensions considered "code" (not pure docs/config/chore).
+_CODE_EXTENSIONS = frozenset(
+    {
+        ".py",
+        ".js",
+        ".ts",
+        ".tsx",
+        ".jsx",
+        ".sh",
+        ".bash",
+        ".go",
+        ".rs",
+        ".rb",
+        ".java",
+        ".kt",
+        ".swift",
+        ".c",
+        ".cpp",
+        ".h",
+        ".cs",
+        ".php",
+        ".r",
+        ".sql",
+    }
+)
+
+# Prefix that marks a journal entry in the committed diff.
+_JOURNAL_PREFIX = "docs/engineering-journal/"
+
+
+def _is_git_commit_command(command: str) -> bool:
+    """Return True if the shell command performs a `git commit`."""
+    # Match plain `git commit` and `git -C <dir> commit` variants.
+    return bool(re.search(r"\bgit\b.*\bcommit\b", command))
+
+
+def _extract_commit_message(command: str) -> str:
+    """
+    Extract the commit message from a git commit command string.
+
+    Handles `-m "msg"`, `-m 'msg'`, and heredoc-via-$() forms.
+    Returns '' if not found.
+    """
+    # -m "..." or -m '...' (greedy across newlines)
+    m = re.search(r"-m\s+(['\"])(.*?)\1", command, re.DOTALL)
+    if m:
+        return m.group(2)
+    # -m msg (no quotes, single token)
+    m2 = re.search(r"-m\s+(\S+)", command)
+    if m2:
+        return m2.group(1)
+    return ""
+
+
+def _parse_git_dash_c(command: str) -> str | None:
+    """Return the path from `git -C <path>` if present, else None."""
+    m = re.search(r"\bgit\s+-C\s+(['\"]?)([^'\" ]+)\1", command)
+    if m:
+        return m.group(2)
+    return None
+
+
+def _git_show_files(cwd: str | None) -> list[str]:
+    """
+    Return the list of file paths touched by HEAD (the just-committed commit).
+
+    Returns [] on any error (git unavailable, not a repo, etc.).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        # --format= suppresses the commit header; output is one filename per line.
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+
+def _journal_dir_exists(cwd: str | None) -> bool:
+    """Return True if docs/engineering-journal/ exists in the repo root."""
+    base = Path(cwd) if cwd else Path.cwd()
+    # Try to find the repo root via git rev-parse for cross-repo accuracy.
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            base = Path(result.stdout.strip())
+    except Exception:
+        pass
+
+    return (base / "docs" / "engineering-journal").is_dir()
+
+
+def _has_code_files(files: list[str]) -> bool:
+    """Return True if at least one committed file has a code extension."""
+    return any(Path(f).suffix.lower() in _CODE_EXTENSIONS for f in files)
+
+
+def _has_journal_entry(files: list[str]) -> bool:
+    """Return True if at least one committed file is under docs/engineering-journal/."""
+    return any(f.startswith(_JOURNAL_PREFIX) for f in files)
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except Exception:
+        # Malformed envelope — pass through silently.
+        sys.exit(0)
+
+    tool_name: str = payload.get("tool_name", "")
+    tool_input: dict = payload.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command: str = tool_input.get("command", "")
+
+    if not _is_git_commit_command(command):
+        sys.exit(0)
+
+    # Extract the commit message type.
+    msg = _extract_commit_message(command)
+    if not _FEAT_FIX_RE.match(msg):
+        # docs-only, chore, refactor, etc. — stay silent.
+        sys.exit(0)
+
+    # Determine the working directory from `git -C <path>` if present.
+    cwd: str | None = _parse_git_dash_c(command)
+
+    # Cross-repo safety: if the journal dir doesn't exist, degrade silently.
+    if not _journal_dir_exists(cwd):
+        sys.exit(0)
+
+    # Inspect the committed files.
+    files = _git_show_files(cwd)
+    if not files:
+        # Cannot determine committed files — be conservative, stay silent.
+        sys.exit(0)
+
+    if not _has_code_files(files):
+        # Docs-only or non-code commit — no nudge.
+        sys.exit(0)
+
+    if _has_journal_entry(files):
+        # Journal entry present — all good, no nudge.
+        sys.exit(0)
+
+    # Nudge: non-blocking, stderr only.
+    print(
+        "[saga/journal-nudge] Heads up: this feat/fix commit touches code but "
+        "includes no docs/engineering-journal/ entry. "
+        "Add a LEARNINGS.md or DECISIONS.md entry if the change earned one "
+        "(non-obvious fix, pattern decision, tooling choice).",
+        file=sys.stderr,
+    )
+
+    # Always exit 0 — never block.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/saga/hooks/pre_push_gate_hook.py
+++ b/plugins/saga/hooks/pre_push_gate_hook.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: run the pre-push gate and report by exception.
+
+Fires when the Bash tool runs a `git push` command.  Reads the single-source
+gate manifest at ``tools/gate-manifest.json`` (relative to the repo root) and
+executes every step in order.  Passes silently on success (report by
+exception).  On any failure, prints the step label, its output, and the
+failure hint to stderr, then exits 2 (blocking) to prevent the push.
+
+Properties:
+  - SILENT ON PASS: no output when every step is green.
+  - BLOCKING ON FAILURE: exits 2, which prevents the push.
+  - SINGLE SOURCE: adding or removing steps in gate-manifest.json is the
+    only change needed to update the gate — this script never diverges.
+  - CROSS-REPO-SAFE: degrades silently when the manifest is absent (so the
+    hook can be registered globally without breaking repos that lack one).
+
+Exit codes:
+  0 — all steps passed (or not a push command / manifest absent).
+  2 — one or more steps failed (blocking).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_MANIFEST_REL = Path("tools") / "gate-manifest.json"
+
+
+def _is_git_push_command(command: str) -> bool:
+    """
+    Return True if the shell command invokes `git push`.
+
+    Matches:
+      git push ...
+      git -C /path push ...
+      git push --force-with-lease
+
+    Does NOT match:
+      echo 'git push'      (git not at command boundary)
+      git commit -m 'msg'  (different subcommand)
+      git pull ...         (different subcommand)
+    """
+    # git is the first token of a pipeline segment (start of string or after
+    # a pipe/semicolon/&&/||), followed by optional flags+values, then `push`.
+    # `-C <path>` uses a separate token for the value, so we allow arbitrary
+    # intervening non-push tokens before the `push` subcommand.
+    return bool(re.search(r"(?:^|[|;&])\s*git\b[^|;&]*\bpush\b", command))
+
+
+def _find_repo_root(cwd: str | None) -> Path | None:
+    """Return the git repository root, or None if not inside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except Exception:
+        pass
+    return None
+
+
+def _parse_git_dash_c(command: str) -> str | None:
+    """Return the path from `git -C <path>` if present, else None."""
+    m = re.search(r"\bgit\s+-C\s+(['\"]?)([^'\" ]+)\1", command)
+    if m:
+        return m.group(2)
+    return None
+
+
+def _run_step(step: dict, cwd: Path) -> tuple[bool, str]:
+    """
+    Run a single gate step.
+
+    Returns (passed, output) where output is combined stdout+stderr
+    (empty string on pass — caller decides whether to surface it).
+    """
+    cmd: list[str] = step.get("command", [])
+    if not cmd:
+        return True, ""
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=300,
+        )
+    except FileNotFoundError:
+        return False, f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return False, "timed out after 300 s"
+    except Exception as exc:
+        return False, str(exc)
+
+    if result.returncode == 0:
+        return True, ""
+
+    combined = "\n".join(part for part in (result.stdout.rstrip(), result.stderr.rstrip()) if part)
+    return False, combined
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except Exception:
+        # Malformed envelope — pass through silently.
+        sys.exit(0)
+
+    tool_name: str = payload.get("tool_name", "")
+    tool_input: dict = payload.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command: str = tool_input.get("command", "")
+
+    if not _is_git_push_command(command):
+        sys.exit(0)
+
+    # Determine the repo root from `git -C <path>` or cwd.
+    cwd_str = _parse_git_dash_c(command)
+    repo_root = _find_repo_root(cwd_str)
+
+    if repo_root is None:
+        # Not inside a git repo — degrade silently.
+        sys.exit(0)
+
+    manifest_path = repo_root / _MANIFEST_REL
+    if not manifest_path.exists():
+        # No manifest — degrade silently (cross-repo safety).
+        sys.exit(0)
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(
+            f"[saga/pre-push-gate] Cannot read gate manifest: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)  # Manifest unreadable — degrade silently rather than blocking.
+
+    steps: list[dict] = manifest.get("steps", [])
+    if not steps:
+        sys.exit(0)
+
+    failures: list[tuple[str, str, str]] = []  # (label, output, hint)
+
+    for step in steps:
+        label: str = step.get("label", step.get("id", "unknown"))
+        passed, output = _run_step(step, repo_root)
+        if not passed:
+            hint: str = step.get("failure_hint", "")
+            failures.append((label, output, hint))
+
+    if not failures:
+        # All green — silent pass (report by exception).
+        sys.exit(0)
+
+    # Report failures and block the push.
+    print(
+        f"[saga/pre-push-gate] {len(failures)} gate step(s) failed — push blocked.\n",
+        file=sys.stderr,
+    )
+    for label, output, hint in failures:
+        print(f"  FAIL: {label}", file=sys.stderr)
+        if output:
+            for line in output.splitlines():
+                print(f"    {line}", file=sys.stderr)
+        if hint:
+            print(f"    Hint: {hint}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/saga/hooks/validate_json_hook.py
+++ b/plugins/saga/hooks/validate_json_hook.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: validate marketplace.json / plugin.json on edit.
+
+JSON-parses the file being written and asserts balanced brackets.  Exits
+with code 2 (blocking) when the file is invalid, printing the offending
+line to stderr.  All other files pass through silently (exit 0).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+_TARGET_SUFFIXES = ("marketplace.json", "plugin.json")
+
+
+def _find_offending_line(text: str) -> tuple[int, str]:
+    """
+    Return the (1-indexed) line number and text of the first bracket
+    imbalance, or the last line if a generic JSONDecodeError gives no
+    position.
+    """
+    depth = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for ch in line:
+            if ch in "{[":
+                depth += 1
+            elif ch in "}]":
+                depth -= 1
+                if depth < 0:
+                    return lineno, line.rstrip()
+    # depth > 0 means unclosed — report the last line
+    lines = text.splitlines()
+    if lines:
+        return len(lines), lines[-1].rstrip()
+    return 1, ""
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        # Cannot parse the hook envelope itself — pass through, don't block.
+        sys.exit(0)
+
+    tool_name: str = payload.get("tool_name", "")
+    tool_input: dict = payload.get("tool_input", {})
+
+    # Only intercept file-write tools.
+    if tool_name not in ("Edit", "Write", "MultiEdit"):
+        sys.exit(0)
+
+    file_path: str = tool_input.get("file_path", "")
+
+    if not any(file_path.endswith(suffix) for suffix in _TARGET_SUFFIXES):
+        sys.exit(0)
+
+    # Determine the post-edit content to validate.
+    if tool_name == "Write":
+        content = tool_input.get("content", "")
+    elif tool_name == "Edit":
+        # For Edit we only have the snippet being replaced, not the full file.
+        # Read the full current file, apply the replacement in-memory, then
+        # validate.  If we cannot read the file (new file or race) fall
+        # through — don't block a legitimate first write.
+        try:
+            with open(file_path, encoding="utf-8") as fh:
+                existing = fh.read()
+        except OSError:
+            sys.exit(0)
+
+        old_string: str = tool_input.get("old_string", "")
+        new_string: str = tool_input.get("new_string", "")
+        replace_all: bool = tool_input.get("replace_all", False)
+        if replace_all:
+            content = existing.replace(old_string, new_string)
+        else:
+            content = existing.replace(old_string, new_string, 1)
+    elif tool_name == "MultiEdit":
+        try:
+            with open(file_path, encoding="utf-8") as fh:
+                content = fh.read()
+        except OSError:
+            sys.exit(0)
+
+        for edit in tool_input.get("edits", []):
+            old = edit.get("old_string", "")
+            new = edit.get("new_string", "")
+            replace_all = edit.get("replace_all", False)
+            content = content.replace(old, new) if replace_all else content.replace(old, new, 1)
+    else:
+        sys.exit(0)
+
+    # Validate JSON.
+    try:
+        json.loads(content)
+    except json.JSONDecodeError:
+        lineno, line_text = _find_offending_line(content)
+        print(
+            f"[saga/validate-json] {file_path}: invalid JSON after edit — "
+            f"first bracket imbalance or parse error near line {lineno}:\n  {line_text}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_journal_nudge_hook.py
+++ b/tests/test_journal_nudge_hook.py
@@ -1,0 +1,456 @@
+"""
+AE6 tests for the journal-omission nudge hook (U8, R14).
+
+Covers:
+- feat/fix commit touching code with no journal entry -> nudge printed to stderr,
+  exit 0 (non-blocking).
+- feat/fix commit that INCLUDES a docs/engineering-journal/ file -> no nudge.
+- docs-only commit (type != feat/fix) -> silent, exit 0.
+- chore commit -> silent, exit 0.
+- non-Bash tool -> pass-through, exit 0.
+- non-commit Bash command -> pass-through, exit 0.
+- Cross-repo safety: graceful when journal dir absent (no error, no nudge).
+- Hook never writes any file.
+- Hook script exists and is importable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+HOOK_SCRIPT = ROOT / "plugins" / "saga" / "hooks" / "journal_nudge_hook.py"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(payload: dict) -> subprocess.CompletedProcess:
+    """Run the hook script with the given JSON payload on stdin."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+def _bash_payload(command: str) -> dict:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+def _load_hook_module():
+    """Import the hook module dynamically (no package install needed)."""
+    spec = importlib.util.spec_from_file_location("journal_nudge_hook", HOOK_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_main_patched(
+    mod, payload: dict, *, files: list[str] | None, journal_exists: bool
+) -> tuple[int, str]:
+    """
+    Call mod.main() with stdin from payload and captured stderr.
+
+    Returns (exit_code, stderr_text).
+    """
+    old_stdin = sys.stdin
+    old_stderr = sys.stderr
+    captured = io.StringIO()
+    sys.stdin = io.StringIO(json.dumps(payload))
+    sys.stderr = captured
+
+    exit_code: int = 0
+    patches = [patch.object(mod, "_journal_dir_exists", return_value=journal_exists)]
+    if files is not None:
+        patches.append(patch.object(mod, "_git_show_files", return_value=files))
+
+    try:
+        with patches[0]:
+            if len(patches) > 1:
+                with patches[1]:
+                    mod.main()
+            else:
+                mod.main()
+    except SystemExit as e:
+        exit_code = e.code if isinstance(e.code, int) else 0
+    finally:
+        sys.stdin = old_stdin
+        sys.stderr = old_stderr
+
+    return exit_code, captured.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# File existence
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_exists() -> None:
+    """The nudge hook script must exist at the expected path."""
+    assert HOOK_SCRIPT.exists(), f"Missing hook script: {HOOK_SCRIPT}"
+
+
+def test_hooks_json_registers_post_tool_use() -> None:
+    """hooks.json must have a PostToolUse section wiring journal_nudge_hook.py."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    assert "PostToolUse" in data["hooks"], "hooks.json must have a PostToolUse section"
+    entries = data["hooks"]["PostToolUse"]
+    commands = [
+        h["command"]
+        for entry in entries
+        for h in entry.get("hooks", [])
+        if h.get("type") == "command"
+    ]
+    assert any("journal_nudge_hook" in cmd for cmd in commands), (
+        "PostToolUse must reference journal_nudge_hook.py"
+    )
+
+
+def test_hooks_json_still_valid_json() -> None:
+    """hooks.json (now with both hooks) must still parse as valid JSON."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    assert "hooks" in data
+    assert "PreToolUse" in data["hooks"]
+    assert "PostToolUse" in data["hooks"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests via module import (fast, no subprocess git calls)
+# ---------------------------------------------------------------------------
+
+
+def test_is_git_commit_command_detects_commit() -> None:
+    mod = _load_hook_module()
+    assert mod._is_git_commit_command('git commit -m "feat: add stuff"')
+    assert mod._is_git_commit_command('git -C /some/path commit -m "fix: bug"')
+    assert mod._is_git_commit_command("git commit --allow-empty -m 'chore: bump'")
+
+
+def test_is_git_commit_command_rejects_non_commit() -> None:
+    mod = _load_hook_module()
+    assert not mod._is_git_commit_command("git status")
+    assert not mod._is_git_commit_command("git push origin main")
+    assert not mod._is_git_commit_command("git log --oneline -5")
+    assert not mod._is_git_commit_command("echo hello")
+    assert not mod._is_git_commit_command("")
+
+
+def test_extract_commit_message_double_quote() -> None:
+    mod = _load_hook_module()
+    assert mod._extract_commit_message('git commit -m "feat: add hook"') == "feat: add hook"
+
+
+def test_extract_commit_message_single_quote() -> None:
+    mod = _load_hook_module()
+    assert mod._extract_commit_message("git commit -m 'fix(scope): bug'") == "fix(scope): bug"
+
+
+def test_extract_commit_message_unquoted() -> None:
+    mod = _load_hook_module()
+    msg = mod._extract_commit_message("git commit -m chore")
+    assert msg == "chore"
+
+
+def test_extract_commit_message_not_found() -> None:
+    mod = _load_hook_module()
+    assert mod._extract_commit_message("git commit") == ""
+
+
+def test_feat_fix_re_matches_feat_and_fix() -> None:
+    mod = _load_hook_module()
+    assert mod._FEAT_FIX_RE.match("feat: add hook")
+    assert mod._FEAT_FIX_RE.match("fix: correct bug")
+    assert mod._FEAT_FIX_RE.match("feat(scope): add thing")
+    assert mod._FEAT_FIX_RE.match("Fix: case-insensitive")
+
+
+def test_feat_fix_re_ignores_other_types() -> None:
+    mod = _load_hook_module()
+    assert not mod._FEAT_FIX_RE.match("chore: bump")
+    assert not mod._FEAT_FIX_RE.match("docs: update")
+    assert not mod._FEAT_FIX_RE.match("refactor: clean up")
+    assert not mod._FEAT_FIX_RE.match("test: add unit tests")
+
+
+def test_has_code_files_detects_python() -> None:
+    mod = _load_hook_module()
+    assert mod._has_code_files(["plugins/saga/scripts/saga.py"])
+    assert mod._has_code_files(["src/main.ts", "README.md"])
+
+
+def test_has_code_files_false_for_markdown_only() -> None:
+    mod = _load_hook_module()
+    assert not mod._has_code_files(["docs/plan.md", "README.md"])
+    assert not mod._has_code_files(["docs/engineering-journal/LEARNINGS.md"])
+
+
+def test_has_journal_entry_true() -> None:
+    mod = _load_hook_module()
+    files = [
+        "plugins/saga/scripts/saga.py",
+        "docs/engineering-journal/LEARNINGS.md",
+    ]
+    assert mod._has_journal_entry(files)
+
+
+def test_has_journal_entry_false() -> None:
+    mod = _load_hook_module()
+    files = [
+        "plugins/saga/scripts/saga.py",
+        "tests/test_saga_saga.py",
+    ]
+    assert not mod._has_journal_entry(files)
+
+
+def test_parse_git_dash_c_extracts_path() -> None:
+    mod = _load_hook_module()
+    cmd = "git -C /some/repo commit -m 'fix: bug'"
+    assert mod._parse_git_dash_c(cmd) == "/some/repo"
+
+
+def test_parse_git_dash_c_returns_none_when_absent() -> None:
+    mod = _load_hook_module()
+    assert mod._parse_git_dash_c('git commit -m "feat: thing"') is None
+
+
+# ---------------------------------------------------------------------------
+# AE6: Integration — non-blocking, non-writing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """
+    Set up a minimal fake git repo with docs/engineering-journal/ present
+    and a Python file committed.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Create the journal dir so the cross-repo guard passes.
+    (repo / "docs" / "engineering-journal").mkdir(parents=True)
+    (repo / "docs" / "engineering-journal" / ".gitkeep").write_text("")
+
+    # Create a Python file.
+    (repo / "main.py").write_text("def main(): pass\n")
+
+    # Initial commit (so HEAD exists and git show works).
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "chore: initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    return repo
+
+
+def test_ae6_code_feat_commit_no_journal_produces_nudge(fake_repo: Path) -> None:
+    """AE6 core: feat commit with a code file but no journal -> nudge in stderr, exit 0."""
+    mod = _load_hook_module()
+    command = f'git -C {fake_repo} commit -m "feat: improve main"'
+    payload = _bash_payload(command)
+
+    exit_code, stderr = _run_main_patched(mod, payload, files=["main.py"], journal_exists=True)
+
+    assert exit_code == 0, f"Expected exit 0 (non-blocking); got {exit_code}"
+    assert "journal-nudge" in stderr, f"Expected nudge; got: {stderr!r}"
+
+
+def test_ae6_code_feat_commit_with_journal_no_nudge() -> None:
+    """AE6: feat commit that includes a journal file -> no nudge."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "feat: add hook"')
+
+    exit_code, stderr = _run_main_patched(
+        mod,
+        payload,
+        files=["main.py", "docs/engineering-journal/LEARNINGS.md"],
+        journal_exists=True,
+    )
+
+    assert exit_code == 0
+    assert "journal-nudge" not in stderr
+
+
+def test_ae6_docs_only_commit_is_silent() -> None:
+    """AE6: docs-only commit (type = docs, no code) -> silent."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "docs: update README"')
+
+    exit_code, stderr = _run_main_patched(mod, payload, files=None, journal_exists=True)
+
+    assert exit_code == 0
+    assert stderr == ""
+
+
+def test_ae6_chore_commit_is_silent() -> None:
+    """AE6: chore commit -> silent regardless of files."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "chore: bump versions"')
+
+    exit_code, stderr = _run_main_patched(
+        mod, payload, files=["pyproject.toml", "saga.py"], journal_exists=True
+    )
+
+    assert exit_code == 0
+    assert stderr == ""
+
+
+def test_ae6_fix_commit_no_journal_produces_nudge() -> None:
+    """AE6: fix commit with code, no journal -> nudge (same as feat)."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "fix(scope): correct off-by-one"')
+
+    exit_code, stderr = _run_main_patched(
+        mod, payload, files=["plugins/saga/scripts/saga.py"], journal_exists=True
+    )
+
+    assert exit_code == 0
+    assert "journal-nudge" in stderr
+
+
+def test_ae6_code_only_no_journal_still_exits_0() -> None:
+    """AE6: hook is NON-blocking -- even when nudge fires, exit code is 0."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "feat: add stuff"')
+
+    exit_code, _ = _run_main_patched(mod, payload, files=["src/main.py"], journal_exists=True)
+
+    assert exit_code == 0, "Hook must never block (exit 0 always)"
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo safety: journal dir absent -> silent, no error
+# ---------------------------------------------------------------------------
+
+
+def test_cross_repo_no_journal_dir_is_silent() -> None:
+    """When docs/engineering-journal/ is absent, degrade silently (exit 0, no output)."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "feat: some feature"')
+
+    exit_code, stderr = _run_main_patched(mod, payload, files=["main.py"], journal_exists=False)
+
+    assert exit_code == 0
+    assert stderr == "", "Must be silent when journal dir is absent (cross-repo safety)"
+
+
+def test_cross_repo_git_unavailable_is_silent() -> None:
+    """When git show fails (not a repo, etc.), degrade silently."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "feat: thing"')
+
+    # files=[] simulates _git_show_files returning empty (failure case)
+    exit_code, stderr = _run_main_patched(mod, payload, files=[], journal_exists=True)
+
+    assert exit_code == 0
+    assert stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# Non-Bash tool and non-commit command -> pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_passes_through() -> None:
+    """A non-Bash tool -> exit 0, no output."""
+    result = _run_hook(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "foo.md"},
+        }
+    )
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_non_commit_bash_command_passes_through() -> None:
+    """A Bash command that is not a git commit -> exit 0, no output."""
+    result = _run_hook(_bash_payload("git status"))
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_non_git_bash_command_passes_through() -> None:
+    """A non-git Bash command -> exit 0, no output."""
+    result = _run_hook(_bash_payload("echo hello"))
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# Hook never writes any file (R14 property)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_does_not_write_any_file(tmp_path: Path) -> None:
+    """The nudge hook must not create or modify any file."""
+    mod = _load_hook_module()
+    payload = _bash_payload('git commit -m "feat: something"')
+
+    files_before = set(tmp_path.rglob("*"))
+
+    _run_main_patched(mod, payload, files=["main.py"], journal_exists=True)
+
+    files_after = set(tmp_path.rglob("*"))
+    assert files_before == files_after, "Hook must not write any files"
+
+
+# ---------------------------------------------------------------------------
+# Subprocess integration: raw hook invocation
+# ---------------------------------------------------------------------------
+
+
+def test_hook_exits_0_on_malformed_input() -> None:
+    """Malformed JSON input -> exit 0, no crash."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not json at all {{{",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Expected exit 0 on bad JSON; got {result.returncode}"
+
+
+def test_hook_exits_0_on_empty_input() -> None:
+    """Empty stdin -> exit 0."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0

--- a/tests/test_marketplace_hook.py
+++ b/tests/test_marketplace_hook.py
@@ -1,0 +1,280 @@
+"""
+AE5 tests for the marketplace / plugin.json validation hook.
+
+Covers:
+- Valid JSON on marketplace.json / plugin.json → hook exits 0 (pass)
+- Invalid JSON (unbalanced bracket) on marketplace.json → hook exits 2 (block) + prints offending line
+- Unrelated file → hook exits 0 regardless of content
+- Write tool with invalid content → blocked
+- Edit tool that would produce invalid JSON → blocked
+- Edit tool that produces valid JSON → passes
+- Hook is callable as a standalone script
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+HOOK_SCRIPT = ROOT / "plugins" / "saga" / "hooks" / "validate_json_hook.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(payload: dict) -> subprocess.CompletedProcess:
+    """Run the hook script with the given JSON payload on stdin."""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+def _write_payload(file_path: str, content: str) -> dict:
+    return {
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": file_path,
+            "content": content,
+        },
+    }
+
+
+def _edit_payload(file_path: str, old_string: str, new_string: str) -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": file_path,
+            "old_string": old_string,
+            "new_string": new_string,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook file existence
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_exists() -> None:
+    """The hook script must exist at the expected path."""
+    assert HOOK_SCRIPT.exists(), f"Missing hook script: {HOOK_SCRIPT}"
+
+
+def test_hooks_json_exists() -> None:
+    """hooks.json must exist in the saga plugin's hooks/ dir."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    assert hooks_json.exists(), f"Missing hooks.json: {hooks_json}"
+
+
+def test_hooks_json_is_valid() -> None:
+    """hooks.json must itself be parseable JSON."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    assert "hooks" in data
+
+
+def test_hooks_json_wires_pretooluse() -> None:
+    """hooks.json must register a PreToolUse hook."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    assert "PreToolUse" in data["hooks"], "hooks.json must have a PreToolUse section"
+    entries = data["hooks"]["PreToolUse"]
+    assert len(entries) > 0, "PreToolUse must have at least one entry"
+    # Each entry must have hooks with a command type
+    commands = [
+        h["command"]
+        for entry in entries
+        for h in entry.get("hooks", [])
+        if h.get("type") == "command"
+    ]
+    assert any("validate_json_hook" in cmd for cmd in commands), (
+        "PreToolUse must reference validate_json_hook.py"
+    )
+
+
+def test_hooks_json_matcher_covers_write_edit() -> None:
+    """The matcher must cover Edit, Write, and MultiEdit."""
+    hooks_json = ROOT / "plugins" / "saga" / "hooks" / "hooks.json"
+    data = json.loads(hooks_json.read_text())
+    entries = data["hooks"]["PreToolUse"]
+    matchers = [e.get("matcher", "") for e in entries]
+    combined = "|".join(matchers)
+    for tool in ("Edit", "Write", "MultiEdit"):
+        assert tool in combined, f"matcher must include {tool}; got matchers={matchers}"
+
+
+# ---------------------------------------------------------------------------
+# AE5: Valid JSON → exit 0 (pass)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_marketplace_json_passes() -> None:
+    """A syntactically correct marketplace.json Write → exit 0."""
+    valid = json.dumps({"name": "infiquetra-plugins", "plugins": [], "version": "3.0.0"})
+    result = _run_hook(_write_payload(".claude-plugin/marketplace.json", valid))
+    assert result.returncode == 0, f"Expected pass; stderr={result.stderr!r}"
+
+
+def test_valid_plugin_json_passes() -> None:
+    """A syntactically correct plugin.json Write → exit 0."""
+    valid = json.dumps({"name": "saga", "version": "0.24.0"})
+    result = _run_hook(_write_payload("plugins/saga/.claude-plugin/plugin.json", valid))
+    assert result.returncode == 0, f"Expected pass; stderr={result.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# AE5: Unbalanced brackets → exit 2 (block) + offending line named
+# ---------------------------------------------------------------------------
+
+
+def test_unbalanced_bracket_marketplace_json_is_blocked() -> None:
+    """An unbalanced-bracket marketplace.json Write → exit 2, offending line in stderr."""
+    broken = '{"name": "infiquetra-plugins", "plugins": []\n]}\n]'
+    result = _run_hook(_write_payload(".claude-plugin/marketplace.json", broken))
+    assert result.returncode == 2, (
+        f"Expected exit 2 (block); got {result.returncode}, stderr={result.stderr!r}"
+    )
+    # stderr must mention the file path
+    assert "marketplace.json" in result.stderr, f"stderr must name the file; got: {result.stderr!r}"
+    # stderr must indicate a line number
+    assert "line" in result.stderr, f"stderr must name the offending line; got: {result.stderr!r}"
+
+
+def test_unbalanced_bracket_plugin_json_is_blocked() -> None:
+    """An unbalanced-bracket plugin.json Write → exit 2, offending line in stderr."""
+    broken = '{"name": "saga", "version": "0.24.0"'  # missing closing }
+    result = _run_hook(_write_payload("plugins/saga/.claude-plugin/plugin.json", broken))
+    assert result.returncode == 2, (
+        f"Expected exit 2 (block); got {result.returncode}, stderr={result.stderr!r}"
+    )
+    assert "plugin.json" in result.stderr, f"stderr must name the file; got: {result.stderr!r}"
+    assert "line" in result.stderr, f"stderr must name the offending line; got: {result.stderr!r}"
+
+
+def test_extra_closing_bracket_is_blocked() -> None:
+    """The classic double-] corruption pattern → exit 2."""
+    # Reproduce the known marketplace.json double-] bug
+    broken = '{"plugins": []\n]\n}'
+    result = _run_hook(_write_payload(".claude-plugin/marketplace.json", broken))
+    assert result.returncode == 2, (
+        f"Expected exit 2; got {result.returncode}, stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unrelated files → exit 0 (pass-through)
+# ---------------------------------------------------------------------------
+
+
+def test_unrelated_file_passes_regardless_of_content() -> None:
+    """An Edit/Write on a non-JSON-target file is not blocked, even if content is garbage."""
+    result = _run_hook(_write_payload("plugins/saga/skills/plan/SKILL.md", "}{broken}{"))
+    assert result.returncode == 0, f"Expected pass-through; stderr={result.stderr!r}"
+
+
+def test_unrelated_python_file_passes() -> None:
+    """A .py file write is never blocked by this hook."""
+    result = _run_hook(_write_payload("plugins/saga/scripts/saga.py", "def foo(): pass"))
+    assert result.returncode == 0, f"Expected pass-through; stderr={result.stderr!r}"
+
+
+def test_non_write_tool_passes() -> None:
+    """A Bash tool call is never intercepted."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hello"},
+    }
+    result = _run_hook(payload)
+    assert result.returncode == 0, f"Expected pass-through; stderr={result.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# Edit tool: simulate post-edit validation
+# ---------------------------------------------------------------------------
+
+
+def test_edit_producing_valid_json_passes(tmp_path: Path) -> None:
+    """An Edit that results in valid JSON → exit 0."""
+    target = tmp_path / "plugin.json"
+    target.write_text('{"name": "saga", "version": "0.23.0"}')
+
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": str(target),
+            "old_string": '"0.23.0"',
+            "new_string": '"0.24.0"',
+        },
+    }
+    result = _run_hook(payload)
+    assert result.returncode == 0, f"Expected pass; stderr={result.stderr!r}"
+
+
+def test_edit_producing_invalid_json_is_blocked(tmp_path: Path) -> None:
+    """An Edit that results in invalid JSON → exit 2."""
+    target = tmp_path / "marketplace.json"
+    target.write_text('{"plugins": []}')
+
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": str(target),
+            "old_string": "[]",
+            "new_string": "[}",  # introduce imbalance
+        },
+    }
+    result = _run_hook(payload)
+    assert result.returncode == 2, (
+        f"Expected block; got {result.returncode}, stderr={result.stderr!r}"
+    )
+    assert "marketplace.json" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Offending-line helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def _load_hook_module():
+    """Import the hook module dynamically (no package install needed)."""
+    spec = importlib.util.spec_from_file_location("validate_json_hook", HOOK_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_find_offending_line_extra_closer() -> None:
+    """_find_offending_line returns the correct line for an extra ]."""
+    mod = _load_hook_module()
+    text = '{"plugins": []}\n]\n'
+    lineno, line_text = mod._find_offending_line(text)
+    assert lineno == 2, f"Expected line 2 (the extra ]); got {lineno}"
+    assert "]" in line_text
+
+
+def test_find_offending_line_unclosed() -> None:
+    """_find_offending_line returns the last line for unclosed brackets."""
+    mod = _load_hook_module()
+    text = '{"name": "saga"'
+    lineno, line_text = mod._find_offending_line(text)
+    assert lineno == 1
+
+
+def test_find_offending_line_valid_returns_last() -> None:
+    """_find_offending_line on balanced JSON returns last line (depth stays 0)."""
+    mod = _load_hook_module()
+    text = '{"a": 1}\n'
+    # No imbalance at all, returns last line
+    lineno, _ = mod._find_offending_line(text)
+    assert lineno >= 1

--- a/tests/test_pre_push_gate.py
+++ b/tests/test_pre_push_gate.py
@@ -373,7 +373,8 @@ class TestManifestDrivesHook:
 
         def capturing_run_step(step: dict, cwd: Path) -> tuple[bool, str]:
             executed_step_ids.append(step.get("id", ""))
-            return original_run_step(step, cwd)
+            result: tuple[bool, str] = original_run_step(step, cwd)
+            return result
 
         with (
             patch.object(sys, "stdin") as mock_stdin,

--- a/tests/test_pre_push_gate.py
+++ b/tests/test_pre_push_gate.py
@@ -1,0 +1,390 @@
+"""
+tests/test_pre_push_gate.py
+
+Unit tests for U9 (R15, KTD10):
+  - tools/gate-manifest.json  — single-source declarative gate definition
+  - plugins/saga/hooks/pre_push_gate_hook.py — the hook runner
+
+Contract under test:
+  1. The manifest exists, is valid JSON, and lists the 5 expected gate steps.
+  2. The manifest is the single source of truth: the hook reads it at runtime.
+  3. The hook is silent on an all-green tree (report by exception).
+  4. The hook reports failures and exits 2 (blocking) when any step fails.
+  5. The hook ignores non-push Bash commands.
+  6. The hook degrades silently when the manifest is absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent
+MANIFEST_PATH = REPO_ROOT / "tools" / "gate-manifest.json"
+HOOK_PATH = REPO_ROOT / "plugins" / "saga" / "hooks" / "pre_push_gate_hook.py"
+
+# ---------------------------------------------------------------------------
+# Helpers — load the hook module without installing it
+# ---------------------------------------------------------------------------
+
+
+def _load_hook_module() -> Any:
+    """Dynamically import the hook script as a module."""
+    spec = importlib.util.spec_from_file_location("pre_push_gate_hook", HOOK_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Manifest tests
+# ---------------------------------------------------------------------------
+
+
+class TestGateManifest:
+    """Verify the declarative gate manifest is well-formed and complete."""
+
+    def test_manifest_exists(self) -> None:
+        assert MANIFEST_PATH.exists(), f"gate manifest not found: {MANIFEST_PATH}"
+
+    def test_manifest_is_valid_json(self) -> None:
+        text = MANIFEST_PATH.read_text(encoding="utf-8")
+        data = json.loads(text)  # raises on invalid JSON
+        assert isinstance(data, dict)
+
+    def test_manifest_has_steps(self) -> None:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        steps = data.get("steps")
+        assert isinstance(steps, list) and len(steps) > 0, "manifest must have at least one step"
+
+    def test_manifest_step_ids_are_unique(self) -> None:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        ids = [s.get("id") for s in data["steps"]]
+        assert len(ids) == len(set(ids)), f"duplicate step IDs: {ids}"
+
+    def test_manifest_contains_required_gate_steps(self) -> None:
+        """
+        The manifest must list all 5 CI gate steps (per R15 + spec §U9):
+          ruff format --check, ruff check, validate_plugins, validate marketplace, pytest
+        """
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        step_ids = {s.get("id") for s in data["steps"]}
+        required = {
+            "ruff-format",
+            "ruff-lint",
+            "validate-plugins",
+            "validate-marketplace",
+            "pytest",
+        }
+        missing = required - step_ids
+        assert not missing, f"gate manifest is missing required steps: {missing}"
+
+    def test_every_step_has_command(self) -> None:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        for step in data["steps"]:
+            assert step.get("command"), f"step {step.get('id')!r} has no command"
+
+    def test_every_step_has_label(self) -> None:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        for step in data["steps"]:
+            assert step.get("label"), f"step {step.get('id')!r} has no label"
+
+    def test_every_step_has_failure_hint(self) -> None:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        for step in data["steps"]:
+            assert step.get("failure_hint"), f"step {step.get('id')!r} has no failure_hint"
+
+
+# ---------------------------------------------------------------------------
+# Hook module unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_payload(command: str, tool_name: str = "Bash") -> str:
+    """Return a JSON hook envelope string for the given tool invocation."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+
+
+class TestPrePushGateHookDetection:
+    """Verify command detection helpers."""
+
+    @pytest.fixture
+    def hook(self) -> Any:
+        return _load_hook_module()
+
+    def test_git_push_is_detected(self, hook: Any) -> None:
+        assert hook._is_git_push_command("git push origin main")
+        assert hook._is_git_push_command("git -C /some/path push --force-with-lease")
+        assert hook._is_git_push_command("git push")
+
+    def test_non_push_is_not_detected(self, hook: Any) -> None:
+        assert not hook._is_git_push_command("git commit -m 'fix: something'")
+        assert not hook._is_git_push_command("git pull origin main")
+        assert not hook._is_git_push_command("echo 'git push'")
+
+    def test_git_dash_c_extraction(self, hook: Any) -> None:
+        assert hook._parse_git_dash_c("git -C /tmp/repo push") == "/tmp/repo"
+        assert hook._parse_git_dash_c("git push origin main") is None
+
+
+class TestPrePushGateHookExitBehavior:
+    """Verify that the hook exits correctly based on push detection and step results."""
+
+    @pytest.fixture
+    def hook(self) -> Any:
+        return _load_hook_module()
+
+    def test_non_bash_tool_exits_0(self, hook: Any) -> None:
+        """Non-Bash tools must pass through silently."""
+        payload = json.dumps({"tool_name": "Edit", "tool_input": {"file_path": "foo.py"}})
+        with patch.object(sys, "stdin") as mock_stdin:
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+        assert exc_info.value.code == 0
+
+    def test_non_push_bash_command_exits_0(self, hook: Any) -> None:
+        """A Bash git commit must not trigger the gate."""
+        payload = _make_payload("git commit -m 'fix: oops'")
+        with patch.object(sys, "stdin") as mock_stdin:
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+        assert exc_info.value.code == 0
+
+    def test_malformed_payload_exits_0(self, hook: Any) -> None:
+        """Malformed JSON envelope must degrade silently."""
+        with patch.object(sys, "stdin") as mock_stdin:
+            mock_stdin.read.return_value = "not-json"
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+        assert exc_info.value.code == 0
+
+    def test_missing_manifest_exits_0(self, hook: Any, tmp_path: Path) -> None:
+        """When the manifest is absent the hook must degrade silently."""
+        payload = _make_payload("git push origin main")
+
+        # Point the hook at a tmp repo root that has no manifest.
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+        assert exc_info.value.code == 0
+
+    def test_all_steps_pass_exits_0_silently(self, hook: Any, tmp_path: Path) -> None:
+        """A clean tree must exit 0 with no output (report by exception)."""
+        # Build a minimal manifest with one always-passing step.
+        manifest = {
+            "steps": [
+                {
+                    "id": "always-pass",
+                    "label": "always pass",
+                    "command": [sys.executable, "-c", ""],
+                    "failure_hint": "n/a",
+                }
+            ]
+        }
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "gate-manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        payload = _make_payload("git push origin main")
+
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+        assert exc_info.value.code == 0
+
+    def test_failing_step_exits_2_and_reports(
+        self, hook: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A seeded failure must exit 2 and print the failure to stderr."""
+        manifest = {
+            "steps": [
+                {
+                    "id": "always-fail",
+                    "label": "always fail",
+                    "command": [sys.executable, "-c", "import sys; sys.exit(1)"],
+                    "failure_hint": "Fix the thing.",
+                }
+            ]
+        }
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "gate-manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        payload = _make_payload("git push origin main")
+
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "always fail" in captured.err
+        assert "Fix the thing." in captured.err
+        assert "blocked" in captured.err
+
+    def test_multiple_failures_all_reported(
+        self, hook: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """All failing steps must be reported, not just the first."""
+        manifest = {
+            "steps": [
+                {
+                    "id": "fail-a",
+                    "label": "step A",
+                    "command": [sys.executable, "-c", "import sys; sys.exit(1)"],
+                    "failure_hint": "Hint A",
+                },
+                {
+                    "id": "pass-b",
+                    "label": "step B",
+                    "command": [sys.executable, "-c", ""],
+                    "failure_hint": "Hint B",
+                },
+                {
+                    "id": "fail-c",
+                    "label": "step C",
+                    "command": [sys.executable, "-c", "import sys; sys.exit(1)"],
+                    "failure_hint": "Hint C",
+                },
+            ]
+        }
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "gate-manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        payload = _make_payload("git push origin main")
+
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        # Both failures must be named; the passing step must not appear.
+        assert "step A" in captured.err
+        assert "step C" in captured.err
+        assert "Hint A" in captured.err
+        assert "Hint C" in captured.err
+
+    def test_failing_step_output_is_included(
+        self, hook: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The step's stdout/stderr must be echoed in the failure report."""
+        manifest = {
+            "steps": [
+                {
+                    "id": "loud-fail",
+                    "label": "loud fail",
+                    "command": [
+                        sys.executable,
+                        "-c",
+                        "import sys; print('UNIQUE_OUTPUT_TOKEN'); sys.exit(1)",
+                    ],
+                    "failure_hint": "Fix loudly.",
+                }
+            ]
+        }
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "gate-manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        payload = _make_payload("git push origin main")
+
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit) as exc_info:
+                hook.main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "UNIQUE_OUTPUT_TOKEN" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke: manifest drives the actual gate commands
+# ---------------------------------------------------------------------------
+
+
+class TestManifestDrivesHook:
+    """
+    Verify that the manifest's command list, not a hard-coded list inside the
+    hook, is what the hook executes.  This is the single-source property (R15).
+    """
+
+    def test_hook_reads_manifest_not_hardcoded_commands(self, tmp_path: Path) -> None:
+        """
+        Place a manifest with a canary step command.  Verify the hook invokes
+        that command (not a hard-coded list).  We monkey-patch _run_step to
+        capture which steps were executed.
+        """
+        hook = _load_hook_module()
+
+        canary_id = "canary-step-12345"
+        manifest = {
+            "steps": [
+                {
+                    "id": canary_id,
+                    "label": "canary",
+                    "command": [sys.executable, "-c", ""],
+                    "failure_hint": "n/a",
+                }
+            ]
+        }
+        (tmp_path / "tools").mkdir()
+        (tmp_path / "tools" / "gate-manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+        payload = _make_payload("git push origin main")
+
+        executed_step_ids: list[str] = []
+        original_run_step = hook._run_step
+
+        def capturing_run_step(step: dict, cwd: Path) -> tuple[bool, str]:
+            executed_step_ids.append(step.get("id", ""))
+            return original_run_step(step, cwd)
+
+        with (
+            patch.object(sys, "stdin") as mock_stdin,
+            patch.object(hook, "_find_repo_root", return_value=tmp_path),
+            patch.object(hook, "_run_step", side_effect=capturing_run_step),
+        ):
+            mock_stdin.read.return_value = payload
+            with pytest.raises(SystemExit):
+                hook.main()
+
+        assert canary_id in executed_step_ids, (
+            f"hook did not execute the manifest-defined step {canary_id!r}; "
+            f"executed: {executed_step_ids}"
+        )

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.28.0"
+    assert plugin_json["version"] == "0.29.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.27.0"
+    assert plugin_json["version"] == "0.28.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.26.0"
+    assert plugin_json["version"] == "0.27.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tools/gate-manifest.json
+++ b/tools/gate-manifest.json
@@ -1,0 +1,35 @@
+{
+  "description": "Single-source pre-push gate manifest. The hook at plugins/saga/hooks/pre_push_gate_hook.py reads this file and runs every step in order. Add or remove steps here to change what the gate checks — the hook never diverges.",
+  "steps": [
+    {
+      "id": "ruff-format",
+      "label": "ruff format --check",
+      "command": ["uv", "run", "python", "-m", "ruff", "format", "--check", "."],
+      "failure_hint": "Run `uv run python -m ruff format .` to auto-fix formatting."
+    },
+    {
+      "id": "ruff-lint",
+      "label": "ruff check",
+      "command": ["uv", "run", "python", "-m", "ruff", "check", "."],
+      "failure_hint": "Run `uv run python -m ruff check --fix .` to apply safe auto-fixes."
+    },
+    {
+      "id": "validate-plugins",
+      "label": "validate plugin manifests",
+      "command": ["uv", "run", "python", "scripts/validate_plugins.py"],
+      "failure_hint": "Fix plugin manifest errors reported above."
+    },
+    {
+      "id": "validate-marketplace",
+      "label": "validate marketplace registry",
+      "command": ["uv", "run", "python", "marketplace/validator/validate.py"],
+      "failure_hint": "Fix marketplace.json errors reported above."
+    },
+    {
+      "id": "pytest",
+      "label": "pytest",
+      "command": ["uv", "run", "python", "-m", "pytest"],
+      "failure_hint": "Fix failing tests before pushing."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **U7 (R13):** `PreToolUse` hook that JSON-parses `marketplace.json`/`plugin.json` on every `Edit`/`Write`/`MultiEdit`, asserts balanced brackets, exits 2 (blocking) with the offending line on failure.
- **U8 (R14):** Non-blocking `PostToolUse` hook that nudges (no write, no block) when a `feat`/`fix` commit touches code with no staged `docs/engineering-journal/` entry. Cross-repo-safe.
- **U9 (R15):** `tools/gate-manifest.json` — single-source declarative gate listing the 5 pre-push steps. `PreToolUse`/Bash hook reads it at runtime and reports by exception (silent on pass, exit 2 on any failure).
- Saga bumped 0.26.0 → 0.29.0 (three triad bumps for U7/U8/U9); test version pins and mypy no-any-return fix included.

## Test plan

- [ ] `tests/test_marketplace_hook.py` — unbalanced JSON blocks, valid JSON passes
- [ ] `tests/test_journal_nudge_hook.py` — code feat/fix without journal nudges; docs-only is silent
- [ ] `tests/test_pre_push_gate.py` — manifest structure, push detection, exit-code contract, single-source invariant
- [ ] Full gate: 760 tests pass, ruff clean, mypy clean, both validators pass

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe