### PR TITLE
epic4: cheap executor + release guards (U14 mechanical executor, U15 triad guard, U16 SHA-stamp + stale-main guard)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/plugins/redis-channel/CHANGELOG.md
+++ b/plugins/redis-channel/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `redis-channel` plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-21
 
 ### Added — Phase 6 polish: configure command + auto-refresh symlink + ARCHITECTURE.md (v0.5.0)
 

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.30.0 - 2026-06-21
+
+- Add `plugins/saga/agents/mechanical-executor.md`: cheap-tier (haiku, Bash-only)
+  op-discriminated executor agent for deterministic mechanical ops dispatched by saga
+  commands.  Approved ops: `census` (file enumeration), `file-exist` (path presence),
+  `json-validate` (JSON parse check), `grep-count` (pattern match count), `link-check`
+  (HTTP 2xx probe).  Unknown ops are rejected with a clear error message — never guessed.
+  The agent is inert until called; it has no auto-trigger.  Addresses R16 / Epic 4 (U14).
+- Update `plugins/saga/skills/work/references/execution-strategy.md`: add a `mechanical-executor`
+  dispatch paragraph to the subagent dispatch section, naming the approved ops, the haiku/Bash-only
+  scope, the op-discriminated rejection contract, and an example dispatch payload.  Wires the
+  agent into the saga `/work` dispatch path without duplicating agent prose.
+
 ## 0.29.0 - 2026-06-21
 
 - Add `tools/gate-manifest.json`: single-source declarative listing of the pre-push gate steps

--- a/plugins/saga/agents/mechanical-executor.md
+++ b/plugins/saga/agents/mechanical-executor.md
@@ -1,0 +1,161 @@
+---
+name: mechanical-executor
+model: haiku
+tools: Bash
+description: |
+  Cheap-tier Bash-only executor for mechanical, deterministic saga ops:
+  census (file enumeration), file-exist (path presence), json-validate (JSON parse
+  check), grep-count (pattern match count), and link-check (HTTP HEAD 200 probe).
+  Dispatched explicitly by saga commands — inert until called.  Unknown ops are
+  rejected with a clear error; never guessed or silently skipped.
+
+  Do NOT use this agent for judgment tasks, code authoring, prose drafting, or
+  anything requiring read/write of non-bash content.  Those belong to the calling
+  saga skill.  This agent runs ONE op per invocation and exits.
+
+  DISPATCH FORMAT (pass as the agent's entire input):
+    op: <census|file-exist|json-validate|grep-count|link-check>
+    <op-specific fields below>
+
+  census:
+    glob: <shell glob pattern relative to repo root>
+    Returns: count + newline-separated file list
+
+  file-exist:
+    paths: <newline-separated list of repo-relative paths>
+    Returns: per-path PRESENT / MISSING lines, exit 0 even when files are missing
+      (absence is reported as data, not an error)
+
+  json-validate:
+    file: <repo-relative path to a JSON file>
+    Returns: VALID or INVALID + the first error line/column
+
+  grep-count:
+    pattern: <grep -E extended regex>
+    dir: <repo-relative directory to search (recursive)>
+    Returns: total match count + per-file breakdown
+
+  link-check:
+    urls: <newline-separated list of URLs>
+    Returns: per-URL OK (HTTP 2xx) or FAIL (status / error)
+---
+
+# Mechanical Executor
+
+You are a **cheap-tier, Bash-only, op-discriminated executor** for the Infiquetra saga
+plugin.  You run exactly **one mechanical operation** per invocation, report results
+as plain text to stdout, and exit.
+
+## Identity and constraints
+
+- **Model**: haiku.  You are intentionally cheap.  Judgment is not your job.
+- **Tool scope**: Bash only.  You may not read files with Read/Edit/Write/Glob tools.
+  Use `bash` commands (`find`, `ls`, `jq`, `grep`, `curl`) instead.
+- **Inert until called**: you have no trigger conditions and no auto-activation.
+  The calling saga skill dispatches you with an explicit op payload.
+- **Op-discriminated**: if the `op:` field is absent or not in the approved list, you
+  MUST output the following rejection and stop — never guess what the caller intended:
+
+  ```
+  ERROR: unknown op "<value>".
+  Approved ops: census, file-exist, json-validate, grep-count, link-check.
+  No work was performed.
+  ```
+
+## Op contract
+
+### census
+Enumerate files matching a shell glob.
+
+Input fields:
+- `glob` — shell glob pattern (relative to repo root), e.g. `plugins/*/agents/*.md`
+
+Output:
+```
+COUNT: <n>
+FILES:
+<path1>
+<path2>
+...
+```
+
+Bash recipe (run from repo root):
+```bash
+glob="<value>"
+files=$(find . -path "./$glob" | sort)
+count=$(echo "$files" | grep -c '.' || echo 0)
+echo "COUNT: $count"
+echo "FILES:"
+echo "$files"
+```
+
+### file-exist
+Check whether a list of paths exist on disk.
+
+Input fields:
+- `paths` — newline-separated list of repo-relative paths
+
+Output: one line per path, `PRESENT: <path>` or `MISSING: <path>`.
+Exit 0 regardless — missing files are data, not errors.
+
+### json-validate
+Parse a JSON file and assert it is valid.
+
+Input fields:
+- `file` — repo-relative path to the JSON file
+
+Output:
+- `VALID: <file>` on success
+- `INVALID: <file> — <error description>` on parse failure
+
+Bash recipe:
+```bash
+python3 -m json.tool <file> > /dev/null 2>&1 \
+  && echo "VALID: <file>" \
+  || { err=$(python3 -m json.tool <file> 2>&1 | head -1); echo "INVALID: <file> — $err"; }
+```
+
+### grep-count
+Count pattern matches across a directory tree.
+
+Input fields:
+- `pattern` — extended regex (grep -E)
+- `dir` — repo-relative directory to search (recursive)
+
+Output:
+```
+TOTAL: <n>
+BY_FILE:
+<path>: <count>
+...
+```
+
+Bash recipe:
+```bash
+grep -rE --count "<pattern>" <dir> 2>/dev/null | grep -v ':0$' | sort -t: -k2 -rn
+```
+
+### link-check
+Probe a list of URLs with HTTP HEAD requests.
+
+Input fields:
+- `urls` — newline-separated list of URLs
+
+Output: one line per URL, `OK (<status>): <url>` or `FAIL (<status>|error): <url>`.
+Use `curl --silent --head --max-time 10 --write-out "%{http_code}" --output /dev/null`.
+
+## Output discipline
+
+- Print results to stdout only.  No preamble, no markdown, no explanation beyond the
+  structured fields above.
+- On an unknown op, print the rejection block above and exit 0 (the error is data to the
+  caller, not a fatal crash).
+- On a Bash error inside a known op, print `ERROR: <op> failed — <stderr line>` and exit 1.
+
+## What you do NOT do
+
+- You do not perform code review, analysis, judgment, or planning.
+- You do not write files (no Write/Edit tools — Bash only).
+- You do not call other agents or skills.
+- You do not auto-trigger on any event.
+- You do not accept or handle ops outside the approved list.

--- a/plugins/saga/skills/work/references/execution-strategy.md
+++ b/plugins/saga/skills/work/references/execution-strategy.md
@@ -69,12 +69,27 @@ constraints below mitigate them.
 
 ## Subagent dispatch (U-ID preservation)
 
-Use the generic `Explore` / `Task` agents (this plugin has no `agents/` dir — do **not** reference named
-`ce-*` agents). For each unit, give the subagent: the full plan path (overall context), the unit's Goal /
-Files / Approach / Execution note / Patterns / Test scenarios / Verification, any resolved
+Use the generic `Explore` / `Task` agents for judgment and code-authoring units.  Do **not** reference
+named `ce-*` agents.  For each unit, give the subagent: the full plan path (overall context), the
+unit's Goal / Files / Approach / Execution note / Patterns / Test scenarios / Verification, any resolved
 deferred-implementation questions, and the instruction to check the unit's test scenarios against all
 four applicable categories (happy / edge / error / integration) and supplement gaps. **Preserve the
 U-ID** in the dispatch and in everything the subagent reports back.
+
+**Mechanical units (census, file-exist checks, JSON validation, grep counts, link checks) should use
+the `mechanical-executor` agent** (`plugins/saga/agents/mechanical-executor.md`) instead of a generic
+`Task` agent.  The mechanical executor runs on haiku (cheap tier), is Bash-only, and is op-discriminated
+— pass it a single `op:` payload; it rejects unknown ops rather than guessing.  Dispatch it inline
+(not as a parallel subagent) because its output feeds the calling phase directly.  Example dispatch
+payload:
+
+```
+op: census
+glob: plugins/*/agents/*.md
+```
+
+The mechanical executor is **inert until called** — it has no auto-trigger and takes no action without
+an explicit dispatch from the calling skill.
 
 - **Worktree-isolated:** subagents may stage, commit, and run their unit's tests inside their own worktree
   branch. After the batch, merge those branches in dependency order; on a merge conflict, abort

--- a/tests/test_mechanical_executor.py
+++ b/tests/test_mechanical_executor.py
@@ -1,0 +1,279 @@
+"""Tests for U14: cheap-tier mechanical executor agent (R16).
+
+Asserts:
+- The agent file exists at the expected path.
+- Frontmatter pins model: haiku (cheap tier, R1).
+- Frontmatter pins tools: Bash (Bash-only scope, R16).
+- The approved op list is declared and complete (census, file-exist, json-validate,
+  grep-count, link-check).
+- The op-discrimination rejection contract is documented (unknown op → rejected, not guessed).
+- The agent body carries the inert-until-called guarantee (no auto-trigger).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+PLUGINS_ROOT = pathlib.Path(__file__).parent.parent / "plugins"
+AGENT_PATH = PLUGINS_ROOT / "saga" / "agents" / "mechanical-executor.md"
+
+APPROVED_OPS = {"census", "file-exist", "json-validate", "grep-count", "link-check"}
+
+# Judgment / authoring tools that the agent must NOT list in its tools: field.
+NON_BASH_TOOLS = {"Read", "Edit", "Write", "Glob", "Grep", "WebFetch", "WebSearch"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(path: pathlib.Path) -> dict[str, str]:
+    """Extract YAML frontmatter key/value pairs from the agent .md file.
+
+    Returns top-level scalar fields only.  Returns an empty dict when no
+    frontmatter block is found.
+    """
+    text = path.read_text()
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end]
+    result: dict[str, str] = {}
+    for line in block.splitlines():
+        m = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*):\s*(.*)", line)
+        if m:
+            result[m.group(1)] = m.group(2).strip().strip('"')
+    return result
+
+
+def _agent_body(path: pathlib.Path) -> str:
+    """Return the body of the agent file (everything after the frontmatter block)."""
+    text = path.read_text()
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    return text[end + 4 :]  # skip past the closing '---\n'
+
+
+# ---------------------------------------------------------------------------
+# Existence
+# ---------------------------------------------------------------------------
+
+
+def test_agent_file_exists() -> None:
+    """The mechanical-executor agent file must exist at the canonical path."""
+    assert AGENT_PATH.exists(), (
+        f"mechanical-executor agent missing at {AGENT_PATH}. "
+        "Create plugins/saga/agents/mechanical-executor.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter: model tier
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_model_is_haiku() -> None:
+    """model: must be haiku — the cheap tier (R1, R16)."""
+    fm = _parse_frontmatter(AGENT_PATH)
+    assert "model" in fm, (
+        "mechanical-executor.md has no `model:` field in frontmatter. Add `model: haiku`."
+    )
+    assert fm["model"] == "haiku", (
+        f"mechanical-executor model is `{fm['model']}`, expected `haiku`. "
+        "This agent must run on the cheap tier (R1, R16)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter: tool scope (Bash-only)
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_tools_is_bash_only() -> None:
+    """tools: must be `Bash` (Bash-only scope, R16).
+
+    The field may be a single value `Bash` or a comma/space-separated list
+    that reduces to just `Bash`.  No non-Bash tools (Read, Edit, Write, Glob,
+    Grep, WebFetch, WebSearch, …) are permitted.
+    """
+    fm = _parse_frontmatter(AGENT_PATH)
+    assert "tools" in fm, (
+        "mechanical-executor.md has no `tools:` field in frontmatter. "
+        "Add `tools: Bash` to enforce the Bash-only scope."
+    )
+    raw_tools = fm["tools"]
+    # Normalise: split on commas/spaces, lowercase, strip
+    tool_names = {t.strip() for t in re.split(r"[,\s]+", raw_tools) if t.strip()}
+    assert tool_names == {"Bash"}, (
+        f"mechanical-executor tools field lists {tool_names!r}; expected exactly {{'Bash'}}. "
+        "This agent is Bash-only (R16) — remove all non-Bash tool entries."
+    )
+
+
+@pytest.mark.parametrize("forbidden_tool", sorted(NON_BASH_TOOLS))
+def test_tools_field_excludes_non_bash_tools(forbidden_tool: str) -> None:
+    """Each non-Bash tool must NOT appear in the tools: field."""
+    fm = _parse_frontmatter(AGENT_PATH)
+    raw_tools = fm.get("tools", "")
+    tool_names = {t.strip() for t in re.split(r"[,\s]+", raw_tools) if t.strip()}
+    assert forbidden_tool not in tool_names, (
+        f"mechanical-executor lists `{forbidden_tool}` in its tools: field. "
+        "Only `Bash` is permitted (R16)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Op-discrimination: approved op list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", sorted(APPROVED_OPS))
+def test_approved_op_documented_in_body(op: str) -> None:
+    """Every approved op must be documented in the agent body."""
+    body = _agent_body(AGENT_PATH)
+    assert op in body, (
+        f"Approved op `{op}` is not documented in mechanical-executor.md body. "
+        "Add a section describing its input fields and output format."
+    )
+
+
+def test_all_approved_ops_listed_together() -> None:
+    """The agent body must name all approved ops together in the rejection contract.
+
+    This ensures the error message a caller receives on an unknown op is complete —
+    listing only some ops would be a misleading contract.
+    """
+    body = _agent_body(AGENT_PATH)
+    # The ops should appear together in an enumeration (the rejection block)
+    for op in APPROVED_OPS:
+        assert op in body, (
+            f"Op `{op}` absent from mechanical-executor.md body. "
+            "All approved ops must be listed in the rejection/contract section."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Op-discrimination: unknown op rejection
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_op_rejection_documented() -> None:
+    """The agent body must document that unknown ops are rejected (not guessed).
+
+    This is the op-discrimination contract (R16): an unknown op produces a
+    deterministic ERROR output, never a best-guess action.
+    """
+    body = _agent_body(AGENT_PATH)
+    # The body must mention rejection / error for unknown ops
+    assert "unknown op" in body.lower(), (
+        "mechanical-executor.md does not document the unknown-op rejection contract. "
+        "Add language stating that unknown ops produce an ERROR and are never guessed."
+    )
+
+
+def test_rejection_does_not_guess() -> None:
+    """The rejection contract must say the op is rejected, not guessed."""
+    body = _agent_body(AGENT_PATH)
+    body_lower = body.lower()
+    # Must say "reject" OR "not guess" / "never guess"
+    assert "reject" in body_lower or "never guess" in body_lower or "not guess" in body_lower, (
+        "mechanical-executor.md must state that unknown ops are rejected, not guessed. "
+        "Add explicit language: 'rejected, not guessed' or 'never guess'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inert-until-called guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_inert_until_called_documented() -> None:
+    """The agent body must assert it is inert until called (no auto-trigger, R16)."""
+    body = _agent_body(AGENT_PATH)
+    body_lower = body.lower()
+    assert "inert" in body_lower, (
+        "mechanical-executor.md does not mention being inert until called. "
+        "Add language stating the agent has no auto-trigger and takes no action "
+        "without an explicit dispatch from the calling skill."
+    )
+
+
+def test_no_auto_trigger_in_description() -> None:
+    """The frontmatter description must not describe auto-trigger conditions.
+
+    Agents with trigger conditions can be auto-activated by the harness; this agent
+    must only run when explicitly dispatched.  The description may use words like
+    'Dispatched explicitly' but should not define trigger phrases.
+    """
+    fm = _parse_frontmatter(AGENT_PATH)
+    desc = fm.get("description", "")
+    # Forbidden: trigger phrases that auto-activate the agent
+    forbidden_patterns = [
+        r"triggers on",
+        r"trigger when",
+        r"activate when",
+        r"auto.trigger",
+    ]
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, desc, re.IGNORECASE), (
+            f"mechanical-executor frontmatter description contains a trigger pattern "
+            f"({pattern!r}) — this agent must be inert until explicitly dispatched."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch wiring present in work/references/execution-strategy.md
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_wiring_references_mechanical_executor() -> None:
+    """execution-strategy.md must mention the mechanical-executor dispatch contract.
+
+    This is the saga-skill-level wiring: the reference doc that /work consults for
+    subagent dispatch must instruct callers to route mechanical ops to this agent.
+    """
+    strategy_path = (
+        PLUGINS_ROOT / "saga" / "skills" / "work" / "references" / "execution-strategy.md"
+    )
+    assert strategy_path.exists(), f"execution-strategy.md not found at {strategy_path}"
+    body = strategy_path.read_text()
+    assert "mechanical-executor" in body, (
+        "execution-strategy.md does not reference the mechanical-executor agent. "
+        "Add a dispatch paragraph directing callers to use this agent for mechanical ops."
+    )
+
+
+def test_dispatch_wiring_names_bash_only_scope() -> None:
+    """execution-strategy.md dispatch paragraph must name the Bash-only scope."""
+    strategy_path = (
+        PLUGINS_ROOT / "saga" / "skills" / "work" / "references" / "execution-strategy.md"
+    )
+    body = strategy_path.read_text()
+    # The wiring section must describe the Bash-only constraint so callers know
+    # not to pass non-Bash tasks to this agent.
+    assert "bash" in body.lower(), (
+        "execution-strategy.md dispatch paragraph does not mention Bash-only scope. "
+        "Add language clarifying this agent is Bash-only."
+    )
+
+
+def test_dispatch_wiring_names_op_rejection() -> None:
+    """execution-strategy.md dispatch paragraph must mention op-discrimination."""
+    strategy_path = (
+        PLUGINS_ROOT / "saga" / "skills" / "work" / "references" / "execution-strategy.md"
+    )
+    body = strategy_path.read_text()
+    body_lower = body.lower()
+    assert "op" in body_lower and ("reject" in body_lower or "discriminat" in body_lower), (
+        "execution-strategy.md does not mention op-discrimination. "
+        "Add a note that the mechanical-executor rejects unknown ops."
+    )

--- a/tests/test_release_rituals.py
+++ b/tests/test_release_rituals.py
@@ -1,0 +1,439 @@
+"""Tests for U16: SHA-stamp stager + stale-main-after-squash guard (R18).
+
+Two tools close the remaining this-repo-local release rituals:
+
+1. ``tools/sha_stamp_stager.py`` — reads the real squash SHA from
+   ``gh pr view --json mergeCommit``, finds placeholder lines in the journal,
+   and **stages** the substitution.  Never blind-applies; operator reviews the
+   staged diff before committing.
+
+2. ``tools/stale_main_guard.py`` — detects when local ``main`` is behind
+   ``origin/main`` (after a squash-merge) and emits a loud warning.
+   Auto-fast-forwards when main is clean.  Non-blocking (exit 0 always).
+   Must not false-fire when main is current, and must handle worktree sessions
+   without auto-forwarding the wrong branch.
+
+Both tools are THIS-REPO-LOCAL: they do not assume cross-repo idioms and must
+never false-fire on a legitimately current main.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers: dynamic module import (tools/ is not a package)
+# ---------------------------------------------------------------------------
+
+_TOOLS_ROOT = Path(__file__).parent.parent / "tools"
+
+
+def _load_module(name: str):  # type: ignore[return]
+    """Load a module from tools/ by filename."""
+    path = _TOOLS_ROOT / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"Cannot load {path}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# SHA-stamp stager tests
+# ---------------------------------------------------------------------------
+
+
+class TestShaStampStager:
+    """Tests for tools/sha_stamp_stager.py."""
+
+    @pytest.fixture()
+    def stager(self):
+        return _load_module("sha_stamp_stager")
+
+    # -- _find_placeholder_files ---------------------------------------------
+
+    def test_find_placeholder_finds_marked_file(self, stager: Any, tmp_path: Path) -> None:
+        """Files containing the placeholder are returned."""
+        marked = tmp_path / "LEARNINGS.md"
+        marked.write_text("## 2026-06-21\n\nPR squash: PENDING_SHA\n")
+        unmarked = tmp_path / "DECISIONS.md"
+        unmarked.write_text("## A decision\n\nNo placeholder here.\n")
+
+        result = stager._find_placeholder_files(tmp_path, "PENDING_SHA")
+        assert marked in result
+        assert unmarked not in result
+
+    def test_find_placeholder_returns_empty_when_none(self, stager: Any, tmp_path: Path) -> None:
+        """An empty list is returned when no file contains the placeholder."""
+        (tmp_path / "clean.md").write_text("No markers here.\n")
+        result = stager._find_placeholder_files(tmp_path, "PENDING_SHA")
+        assert result == []
+
+    def test_find_placeholder_finds_multiple_files(self, stager: Any, tmp_path: Path) -> None:
+        """All files containing the placeholder are returned."""
+        for name in ("A.md", "B.md", "C.md"):
+            (tmp_path / name).write_text(f"entry for {name}: PENDING_SHA\n")
+        result = stager._find_placeholder_files(tmp_path, "PENDING_SHA")
+        assert len(result) == 3
+
+    def test_find_placeholder_skips_binary(self, stager: Any, tmp_path: Path) -> None:
+        """Binary files are silently skipped even if they contain the byte sequence."""
+        binary = tmp_path / "data.bin"
+        binary.write_bytes(b"\x00\x01PENDING_SHA\x02\xff")
+        result = stager._find_placeholder_files(tmp_path, "PENDING_SHA")
+        # Must not raise; the binary file may or may not appear depending on
+        # whether the byte sequence decodes — the important thing is no crash.
+        assert isinstance(result, list)
+
+    def test_find_placeholder_custom_placeholder(self, stager: Any, tmp_path: Path) -> None:
+        """A non-default placeholder string is respected."""
+        f = tmp_path / "notes.md"
+        f.write_text("SHA: SHA-TODO\n")
+        result = stager._find_placeholder_files(tmp_path, "SHA-TODO")
+        assert f in result
+        # Default placeholder should NOT match
+        result_default = stager._find_placeholder_files(tmp_path, "PENDING_SHA")
+        assert f not in result_default
+
+    # -- _build_diff ---------------------------------------------------------
+
+    def test_build_diff_contains_sha(self, stager: Any, tmp_path: Path) -> None:
+        """The diff output contains the real SHA in the '+' lines."""
+        f = tmp_path / "entry.md"
+        f.write_text("squash: PENDING_SHA\n")
+        diff = stager._build_diff(f, "PENDING_SHA", "abc1234def5678")
+        assert "abc1234def5678" in diff
+        assert "PENDING_SHA" in diff  # in the removed '-' lines
+
+    def test_build_diff_shows_removal_and_addition(self, stager: Any, tmp_path: Path) -> None:
+        """Unified diff has both '-' (removal) and '+' (addition) lines."""
+        f = tmp_path / "entry.md"
+        f.write_text("sha: PENDING_SHA\n")
+        diff = stager._build_diff(f, "PENDING_SHA", "deadbeef")
+        assert "-sha: PENDING_SHA" in diff
+        assert "+sha: deadbeef" in diff
+
+    def test_build_diff_no_change_when_placeholder_absent(
+        self, stager: Any, tmp_path: Path
+    ) -> None:
+        """When the placeholder is absent, the diff is empty."""
+        f = tmp_path / "clean.md"
+        f.write_text("No placeholder.\n")
+        diff = stager._build_diff(f, "PENDING_SHA", "abc1234")
+        # No +/- lines → empty diff (unified_diff returns nothing for equal content)
+        assert diff == ""
+
+    # -- _apply_substitution -------------------------------------------------
+
+    def test_apply_substitution_replaces_all_occurrences(self, stager: Any, tmp_path: Path) -> None:
+        """Every occurrence of the placeholder is replaced."""
+        f = tmp_path / "multi.md"
+        f.write_text("sha1: PENDING_SHA\nsha2: PENDING_SHA\n")
+        stager._apply_substitution(f, "PENDING_SHA", "cafebabe")
+        result = f.read_text()
+        assert "PENDING_SHA" not in result
+        assert result.count("cafebabe") == 2
+
+    def test_apply_substitution_preserves_surrounding_text(
+        self, stager: Any, tmp_path: Path
+    ) -> None:
+        """Text around the placeholder is preserved exactly."""
+        f = tmp_path / "entry.md"
+        original = "PR #123 squash: PENDING_SHA — merged 2026-06-21\n"
+        f.write_text(original)
+        stager._apply_substitution(f, "PENDING_SHA", "aabbccdd")
+        result = f.read_text()
+        assert result == "PR #123 squash: aabbccdd — merged 2026-06-21\n"
+
+    # -- _squash_sha_from_pr (mocked) ----------------------------------------
+
+    def test_squash_sha_returns_oid_for_merged_pr(self, stager: Any) -> None:
+        """_squash_sha_from_pr returns the mergeCommit.oid for a MERGED PR."""
+        payload = json.dumps(
+            {"state": "MERGED", "mergeCommit": {"oid": "abc123def456abc123def456abc123def456abc1"}}
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=payload, stderr="")
+            sha = stager._squash_sha_from_pr(42)
+        assert sha == "abc123def456abc123def456abc123def456abc1"
+
+    def test_squash_sha_exits_on_open_pr(self, stager: Any) -> None:
+        """_squash_sha_from_pr exits 1 if the PR is not yet merged."""
+        payload = json.dumps({"state": "OPEN", "mergeCommit": None})
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=payload, stderr="")
+            with pytest.raises(SystemExit) as exc_info:
+                stager._squash_sha_from_pr(99)
+        assert exc_info.value.code == 1
+
+    def test_squash_sha_exits_on_gh_failure(self, stager: Any) -> None:
+        """_squash_sha_from_pr exits 1 if gh returns non-zero."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+            with pytest.raises(SystemExit) as exc_info:
+                stager._squash_sha_from_pr(1)
+        assert exc_info.value.code == 1
+
+    # -- main (dry-run) -------------------------------------------------------
+
+    def test_main_dry_run_does_not_stage(self, stager: Any, tmp_path: Path) -> None:
+        """--dry-run shows the diff but does not call git add."""
+        # Set up a fake journal dir with a placeholder.
+        journal_dir = tmp_path / "docs" / "engineering-journal"
+        journal_dir.mkdir(parents=True)
+        entry = journal_dir / "LEARNINGS.md"
+        entry.write_text("squash SHA: PENDING_SHA\n")
+
+        # Mock: gh returns a merged PR; git rev-parse returns tmp_path; git add
+        # should NOT be called.
+        def _fake_run(args, **kwargs):
+            if "rev-parse" in args:
+                return MagicMock(returncode=0, stdout=str(tmp_path), stderr="")
+            if "gh" in args and "pr" in args:
+                payload = json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergeCommit": {"oid": "deadbeef12345678deadbeef12345678deadbeef"},
+                    }
+                )
+                return MagicMock(returncode=0, stdout=payload, stderr="")
+            if "git" in args and "add" in args:
+                raise AssertionError("git add must NOT be called in --dry-run mode")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=_fake_run):
+            rc = stager.main(
+                ["--pr", "10", "--search-root", "docs/engineering-journal", "--dry-run"]
+            )
+        assert rc == 0
+
+    def test_main_no_placeholder_exits_zero(self, stager: Any, tmp_path: Path) -> None:
+        """main exits 0 with a 'nothing to stage' message when no placeholder found."""
+        journal_dir = tmp_path / "docs" / "engineering-journal"
+        journal_dir.mkdir(parents=True)
+        (journal_dir / "clean.md").write_text("no placeholders here\n")
+
+        def _fake_run(args, **kwargs):
+            if "rev-parse" in args:
+                return MagicMock(returncode=0, stdout=str(tmp_path), stderr="")
+            if "gh" in args:
+                payload = json.dumps(
+                    {
+                        "state": "MERGED",
+                        "mergeCommit": {"oid": "cafe1234cafe1234cafe1234cafe1234cafe1234"},
+                    }
+                )
+                return MagicMock(returncode=0, stdout=payload, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=_fake_run):
+            rc = stager.main(["--pr", "5", "--search-root", "docs/engineering-journal"])
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Stale-main guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestStaleMainGuard:
+    """Tests for tools/stale_main_guard.py."""
+
+    @pytest.fixture()
+    def guard(self):
+        return _load_module("stale_main_guard")
+
+    # -- _commits_behind -----------------------------------------------------
+
+    def test_commits_behind_returns_int(self, guard: Any) -> None:
+        """_commits_behind parses the integer stdout from git rev-list."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3", stderr="")
+            count = guard._commits_behind()
+        assert count == 3
+
+    def test_commits_behind_returns_zero_when_current(self, guard: Any) -> None:
+        """_commits_behind returns 0 when main is up to date."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="0", stderr="")
+            count = guard._commits_behind()
+        assert count == 0
+
+    def test_commits_behind_returns_none_on_error(self, guard: Any) -> None:
+        """_commits_behind returns None when the git command fails."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=128, stdout="", stderr="fatal: unknown revision"
+            )
+            count = guard._commits_behind()
+        assert count is None
+
+    # -- _is_worktree --------------------------------------------------------
+
+    def test_is_worktree_false_when_dirs_equal(self, guard: Any) -> None:
+        """_is_worktree returns False when --git-dir == --git-common-dir."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="/repo/.git", stderr=""),
+                MagicMock(returncode=0, stdout="/repo/.git", stderr=""),
+            ]
+            assert guard._is_worktree() is False
+
+    def test_is_worktree_true_when_dirs_differ(self, guard: Any) -> None:
+        """_is_worktree returns True when --git-dir and --git-common-dir differ."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="/repo/.git/worktrees/epic4", stderr=""),
+                MagicMock(returncode=0, stdout="/repo/.git", stderr=""),
+            ]
+            assert guard._is_worktree() is True
+
+    # -- run_guard (the main logic, _fetch=False for unit tests) -------------
+
+    def test_guard_silent_when_current(self, guard: Any, capsys) -> None:
+        """No output when main is up to date (count == 0).
+
+        This is the most important false-fire guard: a legitimately current
+        main must produce ZERO output.
+        """
+        with (
+            patch.object(guard, "_commits_behind", return_value=0),
+        ):
+            rc = guard.run_guard(_fetch=False)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert captured.out == ""
+
+    def test_guard_silent_when_behind_returns_none(self, guard: Any, capsys) -> None:
+        """No output when _commits_behind returns None (no remote branch, etc.)."""
+        with patch.object(guard, "_commits_behind", return_value=None):
+            rc = guard.run_guard(_fetch=False)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_guard_warns_in_worktree(self, guard: Any, capsys) -> None:
+        """In a worktree session, emits a warning but does NOT auto-fast-forward."""
+        with (
+            patch.object(guard, "_commits_behind", return_value=2),
+            patch.object(guard, "_is_worktree", return_value=True),
+            patch.object(guard, "_current_branch", return_value="feat/some-branch"),
+            patch.object(guard, "_fast_forward_main") as mock_ff,
+        ):
+            rc = guard.run_guard(_fetch=False)
+
+        assert rc == 0
+        mock_ff.assert_not_called()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "worktree" in captured.err
+        assert "2" in captured.err
+
+    def test_guard_warns_when_not_on_main(self, guard: Any, capsys) -> None:
+        """Not on main branch: warn but do not attempt fast-forward."""
+        with (
+            patch.object(guard, "_commits_behind", return_value=1),
+            patch.object(guard, "_is_worktree", return_value=False),
+            patch.object(guard, "_current_branch", return_value="feat/other"),
+            patch.object(guard, "_fast_forward_main") as mock_ff,
+        ):
+            rc = guard.run_guard(_fetch=False)
+
+        assert rc == 0
+        mock_ff.assert_not_called()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    def test_guard_auto_ff_when_on_main_and_clean(self, guard: Any, capsys) -> None:
+        """On main with a clean tree: auto-fast-forward and confirm."""
+        with (
+            patch.object(guard, "_commits_behind", return_value=3),
+            patch.object(guard, "_is_worktree", return_value=False),
+            patch.object(guard, "_current_branch", return_value="main"),
+            patch.object(guard, "_working_tree_is_clean", return_value=True),
+            patch.object(guard, "_fast_forward_main", return_value=True),
+        ):
+            rc = guard.run_guard(_fetch=False)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Should confirm the fast-forward, not just warn
+        assert "Auto-fast-forwarded" in captured.err
+        assert "3" in captured.err
+
+    def test_guard_warns_when_on_main_but_dirty(self, guard: Any, capsys) -> None:
+        """On main with uncommitted changes: warn but skip auto-fast-forward."""
+        with (
+            patch.object(guard, "_commits_behind", return_value=1),
+            patch.object(guard, "_is_worktree", return_value=False),
+            patch.object(guard, "_current_branch", return_value="main"),
+            patch.object(guard, "_working_tree_is_clean", return_value=False),
+            patch.object(guard, "_fast_forward_main") as mock_ff,
+        ):
+            rc = guard.run_guard(_fetch=False)
+
+        assert rc == 0
+        mock_ff.assert_not_called()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "uncommitted" in captured.err
+
+    def test_guard_warns_on_ff_failure(self, guard: Any, capsys) -> None:
+        """When auto-fast-forward fails, still emits a warning (non-blocking)."""
+        with (
+            patch.object(guard, "_commits_behind", return_value=1),
+            patch.object(guard, "_is_worktree", return_value=False),
+            patch.object(guard, "_current_branch", return_value="main"),
+            patch.object(guard, "_working_tree_is_clean", return_value=True),
+            patch.object(guard, "_fast_forward_main", return_value=False),
+        ):
+            rc = guard.run_guard(_fetch=False)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+    def test_guard_always_exits_zero(self, guard: Any) -> None:
+        """run_guard returns 0 in all branches — it is strictly non-blocking."""
+        scenarios = [
+            # (behind, is_worktree, branch, clean, ff_result)
+            (0, False, "main", True, True),
+            (1, True, "feat/x", True, True),
+            (2, False, "feat/y", True, True),
+            (3, False, "main", True, True),
+            (3, False, "main", False, False),
+            (3, False, "main", True, False),
+            (None, False, "main", True, True),
+        ]
+        for behind, in_wt, branch, clean, ff_ok in scenarios:
+            with (
+                patch.object(guard, "_commits_behind", return_value=behind),
+                patch.object(guard, "_is_worktree", return_value=in_wt),
+                patch.object(guard, "_current_branch", return_value=branch),
+                patch.object(guard, "_working_tree_is_clean", return_value=clean),
+                patch.object(guard, "_fast_forward_main", return_value=ff_ok),
+            ):
+                rc = guard.run_guard(_fetch=False)
+            assert rc == 0, f"Expected 0 for scenario {(behind, in_wt, branch, clean, ff_ok)}"
+
+    # -- False-fire guard (the spec's key correctness property) ---------------
+
+    def test_no_false_fire_on_current_main(self, guard: Any, capsys) -> None:
+        """The stale-main guard MUST NOT emit any output when main is current.
+
+        This is the primary false-fire prevention test specified in U16.
+        A guard that warns on a current main would train the operator to ignore
+        it — defeating its purpose.
+        """
+        with patch.object(guard, "_commits_behind", return_value=0):
+            guard.run_guard(_fetch=False)
+        captured = capsys.readouterr()
+        assert captured.out == "", "No stdout output on current main"
+        assert captured.err == "", "No stderr output on current main"

--- a/tests/test_release_triad.py
+++ b/tests/test_release_triad.py
@@ -1,0 +1,328 @@
+"""Tests for U15: release-triad sync guard (R17).
+
+Asserts that the three version-bearing surfaces for every plugin stay in sync:
+
+  1. ``plugins/<name>/.claude-plugin/plugin.json``  — ``"version"`` field
+  2. ``.claude-plugin/marketplace.json``            — ``plugins[].version`` for the plugin
+  3. ``plugins/<name>/CHANGELOG.md``               — first ``## <version>`` heading
+
+When all three agree the triad is clean.  When any surface diverges the test
+fails with a message that names the drifting surface and its version so the
+author knows exactly which file to update.
+
+Design notes
+------------
+- "Fires only on version-bearing changes" — the guard is a static assertion on
+  the current on-disk state.  If all three surfaces agree, the guard passes
+  (no false fire on a non-version-bearing edit).  If they disagree, someone
+  bumped one surface and forgot the others — that is the failure this guard
+  catches (R17).
+- CHANGELOG version detection: we extract the first version heading that
+  appears in the file.  We support the four heading formats used across this
+  repo:
+    - ``## [1.2.0] - 2026-06-21``    (home-lab-ops, unifi, team-execution, mission-control)
+    - ``## [1.2.0] — 2026-06-21``    (em-dash variant)
+    - ``## 0.1.2 - 2026-06-21``      (deploy, saga — bare version, hyphen-dash)
+    - ``## 0.1.2 — 2026-06-21``      (bare version, em-dash)
+    - ``## [Unreleased]``            (skipped — not a version marker)
+  The first match wins; ``[Unreleased]`` headings are ignored.
+- Parametrised by plugin name: failures are reported per-plugin, not as a
+  single monolithic assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+PLUGINS_ROOT = REPO_ROOT / "plugins"
+MARKETPLACE_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+
+# All plugins registered in marketplace.json.  This list is derived from the
+# marketplace itself so the test stays in lockstep without a hardcoded list.
+def _plugin_names_from_marketplace() -> list[str]:
+    data = json.loads(MARKETPLACE_PATH.read_text())
+    return [p["name"] for p in data.get("plugins", [])]
+
+
+ALL_PLUGINS: list[str] = _plugin_names_from_marketplace()
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+_CHANGELOG_VERSION_RE = re.compile(
+    r"^##\s+"
+    r"(?:\[)?"  # optional opening bracket
+    r"(?!Unreleased)"  # skip [Unreleased] headings
+    r"(\d+\.\d+\.\d+)"  # capture semver X.Y.Z
+    r"(?:\])?"  # optional closing bracket
+    r"(?:\s*[-—].*)?$",  # optional date suffix (hyphen or em-dash)
+    re.MULTILINE,
+)
+
+
+def _version_from_plugin_json(plugin_name: str) -> str | None:
+    """Return the ``version`` field from ``plugins/<name>/.claude-plugin/plugin.json``."""
+    path = PLUGINS_ROOT / plugin_name / ".claude-plugin" / "plugin.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return data.get("version")
+
+
+def _version_from_marketplace(plugin_name: str) -> str | None:
+    """Return this plugin's ``version`` from ``.claude-plugin/marketplace.json``."""
+    data = json.loads(MARKETPLACE_PATH.read_text())
+    for entry in data.get("plugins", []):
+        if entry.get("name") == plugin_name:
+            return entry.get("version")
+    return None
+
+
+def _version_from_changelog(plugin_name: str) -> str | None:
+    """Return the first released version heading found in the plugin CHANGELOG.
+
+    ``## [Unreleased]`` headings are skipped.  Returns ``None`` if the file
+    does not exist or contains no recognised version heading.
+    """
+    path = PLUGINS_ROOT / plugin_name / "CHANGELOG.md"
+    if not path.exists():
+        return None
+    text = path.read_text()
+    m = _CHANGELOG_VERSION_RE.search(text)
+    if m:
+        return m.group(1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a human-readable drift report
+# ---------------------------------------------------------------------------
+
+
+def _drift_message(
+    plugin: str, plugin_json_ver: str | None, mkt_ver: str | None, cl_ver: str | None
+) -> str:
+    lines = [f"Release-triad mismatch for plugin '{plugin}':"]
+    lines.append(f"  plugin.json                : {plugin_json_ver!r}")
+    lines.append(f"  marketplace.json           : {mkt_ver!r}")
+    lines.append(f"  CHANGELOG.md (first release): {cl_ver!r}")
+    drifters = []
+    canonical = plugin_json_ver  # plugin.json is the ground-truth source of truth
+    if mkt_ver != canonical:
+        drifters.append(f"marketplace.json (has {mkt_ver!r}, expected {canonical!r})")
+    if cl_ver != canonical:
+        drifters.append(f"CHANGELOG.md (has {cl_ver!r}, expected {canonical!r})")
+    if drifters:
+        lines.append("  Drifting surface(s): " + "; ".join(drifters))
+    lines.append(
+        "  Fix: bump all three surfaces to the same version in the same commit (CLAUDE.md §6)."
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("plugin_name", ALL_PLUGINS)
+def test_plugin_json_exists(plugin_name: str) -> None:
+    """Every registered plugin must have a plugin.json at the canonical path."""
+    path = PLUGINS_ROOT / plugin_name / ".claude-plugin" / "plugin.json"
+    assert path.exists(), (
+        f"plugin.json missing for '{plugin_name}' at {path}. "
+        "Create it with a 'version' field matching the marketplace entry."
+    )
+
+
+@pytest.mark.parametrize("plugin_name", ALL_PLUGINS)
+def test_changelog_exists(plugin_name: str) -> None:
+    """Every registered plugin must have a CHANGELOG.md."""
+    path = PLUGINS_ROOT / plugin_name / "CHANGELOG.md"
+    assert path.exists(), (
+        f"CHANGELOG.md missing for '{plugin_name}' at {path}. "
+        "Create it with a versioned heading matching plugin.json."
+    )
+
+
+@pytest.mark.parametrize("plugin_name", ALL_PLUGINS)
+def test_release_triad_in_sync(plugin_name: str) -> None:
+    """plugin.json, marketplace.json, and CHANGELOG.md must all agree on version.
+
+    Fires only when at least one surface disagrees — a clean triad always passes.
+    """
+    pjson_ver = _version_from_plugin_json(plugin_name)
+    mkt_ver = _version_from_marketplace(plugin_name)
+    cl_ver = _version_from_changelog(plugin_name)
+
+    assert pjson_ver is not None, f"'{plugin_name}' plugin.json has no 'version' field."
+    assert mkt_ver is not None, f"'{plugin_name}' not found in marketplace.json plugins array."
+    assert cl_ver is not None, (
+        f"'{plugin_name}' CHANGELOG.md has no recognised version heading. "
+        "Add a heading like '## [X.Y.Z] - YYYY-MM-DD' or '## X.Y.Z - YYYY-MM-DD'."
+    )
+
+    all_agree = pjson_ver == mkt_ver == cl_ver
+    assert all_agree, _drift_message(plugin_name, pjson_ver, mkt_ver, cl_ver)
+
+
+# ---------------------------------------------------------------------------
+# Seed-mismatch fixtures: verify the guard actually catches drift
+# ---------------------------------------------------------------------------
+
+
+def test_guard_catches_marketplace_drift(tmp_path: pathlib.Path) -> None:
+    """Seeded mismatch: marketplace.json has a wrong version → guard fires."""
+    # Build a minimal triad
+    plugin_dir = tmp_path / "plugins" / "myplugin" / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(json.dumps({"name": "myplugin", "version": "1.0.0"}))
+
+    changelog = tmp_path / "plugins" / "myplugin" / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n\n- initial release\n")
+
+    mkt_path = tmp_path / ".claude-plugin" / "marketplace.json"
+    mkt_path.parent.mkdir(parents=True)
+    mkt_path.write_text(
+        json.dumps(
+            {
+                "plugins": [{"name": "myplugin", "version": "0.9.0"}]  # wrong — should be 1.0.0
+            }
+        )
+    )
+
+    # Parse directly using the module's helpers, pointing at tmp_path
+    pjson = json.loads((plugin_dir / "plugin.json").read_text()).get("version")
+    mkt_data = json.loads(mkt_path.read_text())
+    mkt_ver = next((p["version"] for p in mkt_data["plugins"] if p["name"] == "myplugin"), None)
+    cl_text = changelog.read_text()
+    cl_m = _CHANGELOG_VERSION_RE.search(cl_text)
+    cl_ver = cl_m.group(1) if cl_m else None
+
+    assert pjson == "1.0.0"
+    assert cl_ver == "1.0.0"
+    # The mismatch: mkt_ver should differ
+    assert mkt_ver == "0.9.0"
+    assert mkt_ver != pjson, "test setup: marketplace version should be wrong"
+    # The guard condition that test_release_triad_in_sync would trigger
+    all_agree = pjson == mkt_ver == cl_ver
+    assert not all_agree, "Seeded mismatch was not detected — guard logic is broken."
+
+
+def test_guard_catches_changelog_drift(tmp_path: pathlib.Path) -> None:
+    """Seeded mismatch: CHANGELOG.md has a stale version → guard fires."""
+    plugin_dir = tmp_path / "plugins" / "myplugin" / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(json.dumps({"name": "myplugin", "version": "2.0.0"}))
+
+    changelog = tmp_path / "plugins" / "myplugin" / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [1.9.0] - 2025-12-01\n\n- old release\n")  # stale
+
+    mkt_path = tmp_path / ".claude-plugin" / "marketplace.json"
+    mkt_path.parent.mkdir(parents=True)
+    mkt_path.write_text(json.dumps({"plugins": [{"name": "myplugin", "version": "2.0.0"}]}))
+
+    pjson = json.loads((plugin_dir / "plugin.json").read_text()).get("version")
+    mkt_data = json.loads(mkt_path.read_text())
+    mkt_ver = next((p["version"] for p in mkt_data["plugins"] if p["name"] == "myplugin"), None)
+    cl_text = changelog.read_text()
+    cl_m = _CHANGELOG_VERSION_RE.search(cl_text)
+    cl_ver = cl_m.group(1) if cl_m else None
+
+    assert pjson == "2.0.0"
+    assert mkt_ver == "2.0.0"
+    assert cl_ver == "1.9.0"  # stale
+    all_agree = pjson == mkt_ver == cl_ver
+    assert not all_agree, "Seeded changelog mismatch was not detected — guard logic is broken."
+
+
+def test_guard_passes_on_synced_triad(tmp_path: pathlib.Path) -> None:
+    """All three surfaces agree → guard does not fire."""
+    plugin_dir = tmp_path / "plugins" / "myplugin" / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(json.dumps({"name": "myplugin", "version": "3.1.0"}))
+
+    changelog = tmp_path / "plugins" / "myplugin" / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [3.1.0] - 2026-06-21\n\n- synced release\n")
+
+    mkt_path = tmp_path / ".claude-plugin" / "marketplace.json"
+    mkt_path.parent.mkdir(parents=True)
+    mkt_path.write_text(json.dumps({"plugins": [{"name": "myplugin", "version": "3.1.0"}]}))
+
+    pjson = json.loads((plugin_dir / "plugin.json").read_text()).get("version")
+    mkt_data = json.loads(mkt_path.read_text())
+    mkt_ver = next((p["version"] for p in mkt_data["plugins"] if p["name"] == "myplugin"), None)
+    cl_text = changelog.read_text()
+    cl_m = _CHANGELOG_VERSION_RE.search(cl_text)
+    cl_ver = cl_m.group(1) if cl_m else None
+
+    assert pjson == "3.1.0"
+    assert mkt_ver == "3.1.0"
+    assert cl_ver == "3.1.0"
+    all_agree = pjson == mkt_ver == cl_ver
+    assert all_agree, (
+        f"Synced triad was incorrectly flagged as drifting: "
+        f"plugin.json={pjson!r}, marketplace={mkt_ver!r}, CHANGELOG={cl_ver!r}"
+    )
+
+
+def test_changelog_version_regex_bare_format() -> None:
+    """Regex matches the bare-version format used by saga and deploy CHANGELOGs."""
+    text = "# Changelog\n\n## 0.30.0 - 2026-06-21\n\n- some entry\n"
+    m = _CHANGELOG_VERSION_RE.search(text)
+    assert m is not None, "Regex did not match bare-version CHANGELOG heading."
+    assert m.group(1) == "0.30.0"
+
+
+def test_changelog_version_regex_bracketed_format() -> None:
+    """Regex matches the bracketed format used by home-lab-ops, unifi, etc."""
+    text = "# Changelog\n\n## [1.2.0] - 2026-06-21\n\n### Changed\n"
+    m = _CHANGELOG_VERSION_RE.search(text)
+    assert m is not None, "Regex did not match bracketed CHANGELOG heading."
+    assert m.group(1) == "1.2.0"
+
+
+def test_changelog_version_regex_skips_unreleased() -> None:
+    """Regex skips [Unreleased] and finds the first actual version below it."""
+    text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added — some future thing\n\n"
+        "## [0.5.0] - 2026-06-01\n\n"
+        "- shipped\n"
+    )
+    m = _CHANGELOG_VERSION_RE.search(text)
+    assert m is not None, "Regex did not find a version after [Unreleased]."
+    assert m.group(1) == "0.5.0"
+
+
+def test_changelog_version_regex_em_dash_format() -> None:
+    """Regex matches em-dash date separator (used in mission-control CHANGELOG)."""
+    text = "# Changelog\n\n## [2.2.0] — 2026-06-21\n\n### Changed\n"
+    m = _CHANGELOG_VERSION_RE.search(text)
+    assert m is not None, "Regex did not match em-dash CHANGELOG heading."
+    assert m.group(1) == "2.2.0"
+
+
+def test_drift_message_names_drifting_surface() -> None:
+    """_drift_message names the specific surface(s) that are out of sync."""
+    msg = _drift_message("saga", "0.30.0", "0.29.0", "0.30.0")
+    assert "marketplace.json" in msg
+    assert "0.29.0" in msg
+    assert "Drifting surface" in msg
+    # CHANGELOG agrees — should not be flagged
+    assert "CHANGELOG" not in msg.split("Drifting")[1]
+
+
+def test_drift_message_both_surfaces_named() -> None:
+    """When two surfaces drift, both are named in the drift message."""
+    msg = _drift_message("deploy", "0.1.2", "0.1.0", "0.1.1")
+    assert "marketplace.json" in msg
+    assert "CHANGELOG.md" in msg

--- a/tests/test_release_triad.py
+++ b/tests/test_release_triad.py
@@ -72,16 +72,18 @@ def _version_from_plugin_json(plugin_name: str) -> str | None:
     path = PLUGINS_ROOT / plugin_name / ".claude-plugin" / "plugin.json"
     if not path.exists():
         return None
-    data = json.loads(path.read_text())
-    return data.get("version")
+    data: dict[str, object] = json.loads(path.read_text())
+    v = data.get("version")
+    return str(v) if v is not None else None
 
 
 def _version_from_marketplace(plugin_name: str) -> str | None:
     """Return this plugin's ``version`` from ``.claude-plugin/marketplace.json``."""
-    data = json.loads(MARKETPLACE_PATH.read_text())
+    data: dict[str, list[dict[str, str]]] = json.loads(MARKETPLACE_PATH.read_text())
     for entry in data.get("plugins", []):
         if entry.get("name") == plugin_name:
-            return entry.get("version")
+            v = entry.get("version")
+            return v if v is not None else None
     return None
 
 

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.29.0"
+    assert plugin_json["version"] == "0.30.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]
@@ -1407,11 +1407,17 @@ def test_retro_engine_merge_contract() -> None:
     assert "operator-choice.md" in corpus, "the operator-choice contract must be cited by path"
     for backend in ("inline", "team-execution", "cc-workflows-ultracode"):
         assert backend in corpus, f"the operator-choice backend {backend!r} must be named"
-    # generic-agent fan-out only — this plugin has no agents/ dir.
+    # generic-agent fan-out for non-mechanical work; the agents/ dir now exists but must contain
+    # ONLY the mechanical-executor (the cheap-tier Bash-only agent added by U14/R16).
+    # General Explore/Task fan-out still uses generic agents, not named ce-* agents.
     assert "Explore" in corpus and "Task" in corpus, "the transcript fan-out uses generic agents"
-    assert not (PLUGIN_ROOT / "agents").exists() or not list(
-        (PLUGIN_ROOT / "agents").glob("*.md")
-    ), "this plugin must have no agents/ dir (generic-agent convention)"
+    if (PLUGIN_ROOT / "agents").exists():
+        agent_files = list((PLUGIN_ROOT / "agents").glob("*.md"))
+        agent_names = {f.stem for f in agent_files}
+        assert agent_names == {"mechanical-executor"}, (
+            f"plugins/saga/agents/ must contain ONLY mechanical-executor.md (U14/R16); "
+            f"found: {sorted(agent_names)}. Named ce-* or judgment agents belong outside this dir."
+        )
 
     # --- MECHANISM FLOOR 9: the durable artifact dir (docs/retros/) + journal promotion into the
     # four core files (the markdown journal is the durable sink). ---
@@ -1769,13 +1775,18 @@ def test_investigate_engine_merge_contract() -> None:
     assert re.search(r"parallel read-only", corpus, re.IGNORECASE), (
         "parallel read-only sub-agent dispatch must be OFFERED for evidence-bottlenecked subsystems"
     )
-    # generic-agent fan-out only — this plugin has no agents/ dir.
+    # generic-agent fan-out for non-mechanical work; the agents/ dir now exists but must contain
+    # ONLY the mechanical-executor (the cheap-tier Bash-only agent added by U14/R16).
     assert "Explore" in corpus and "Task" in corpus, (
         "parallel probes use generic Explore/Task agents"
     )
-    assert not (PLUGIN_ROOT / "agents").exists() or not list(
-        (PLUGIN_ROOT / "agents").glob("*.md")
-    ), "this plugin must have no agents/ dir (generic-agent convention)"
+    if (PLUGIN_ROOT / "agents").exists():
+        agent_files = list((PLUGIN_ROOT / "agents").glob("*.md"))
+        agent_names = {f.stem for f in agent_files}
+        assert agent_names == {"mechanical-executor"}, (
+            f"plugins/saga/agents/ must contain ONLY mechanical-executor.md (U14/R16); "
+            f"found: {sorted(agent_names)}. Named ce-* or judgment agents belong outside this dir."
+        )
 
     # --- MECHANISM FLOOR 10: docs/investigations/ artifact + dispatch REFERENCED not restated +
     # /brainstorm route (no /ce-brainstorm). The dispatch-table is one source of truth. ---

--- a/tools/sha_stamp_stager.py
+++ b/tools/sha_stamp_stager.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+SHA-stamp stager (this-repo-local, R18).
+
+After a squash-merge, reads the real squash SHA from ``gh pr view --json
+mergeCommit``, finds every placeholder line in the repo's journal that matches
+a configurable marker, and **stages** the substitution as a reviewable diff.
+It never blind-applies: the operator sees the diff and confirms before commit.
+
+Usage
+-----
+::
+
+    python3 tools/sha_stamp_stager.py --pr 123
+    python3 tools/sha_stamp_stager.py --pr 123 --placeholder SHA-TODO
+    python3 tools/sha_stamp_stager.py --pr 123 --dry-run
+
+Options
+-------
+--pr            GitHub PR number whose squash SHA to look up. Required.
+--placeholder   String that marks SHA placeholders in journal files.
+                Defaults to ``PENDING_SHA``.
+--search-root   Directory tree to search for placeholder lines.
+                Defaults to ``docs/engineering-journal``.
+--dry-run       Print the substitution diff but do NOT stage any files.
+
+Exit codes
+----------
+0   Substitution staged (or nothing to do).
+1   Error (gh unavailable, PR not merged, etc.).
+2   Conflicts or unexpected state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Git / gh helpers
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    """Return the root of the current git repository."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _die("Not inside a git repository.")
+    return Path(result.stdout.strip())
+
+
+def _squash_sha_from_pr(pr_number: int) -> str:
+    """
+    Return the squash commit SHA for a merged PR via ``gh pr view``.
+
+    Exits 1 if the PR is not yet merged or gh is unavailable.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "mergeCommit,state"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _die(
+            f"gh pr view failed for PR #{pr_number}:\n{result.stderr.strip()}\n"
+            "Make sure gh is installed and authenticated."
+        )
+
+    data = json.loads(result.stdout)
+    state: str = data.get("state", "")
+    merge_commit: dict | None = data.get("mergeCommit")
+
+    if state != "MERGED":
+        _die(
+            f"PR #{pr_number} is not merged (state={state!r}). "
+            "The SHA-stamp stager only applies to squash-merged PRs."
+        )
+
+    if not merge_commit or not merge_commit.get("oid"):
+        _die(
+            f"PR #{pr_number} is merged but has no mergeCommit.oid in the API response. "
+            "This can happen for very old PRs or PRs merged without a squash."
+        )
+
+    return merge_commit["oid"]
+
+
+# ---------------------------------------------------------------------------
+# Placeholder scanning
+# ---------------------------------------------------------------------------
+
+
+def _find_placeholder_files(search_root: Path, placeholder: str) -> list[Path]:
+    """
+    Return every file under *search_root* that contains *placeholder*.
+
+    Searches recursively, follows symlinks, skips binary files.
+    """
+    matches: list[Path] = []
+    for path in sorted(search_root.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="strict")
+        except (UnicodeDecodeError, OSError):
+            # Binary or unreadable — skip.
+            continue
+        if placeholder in text:
+            matches.append(path)
+    return matches
+
+
+def _build_diff(path: Path, placeholder: str, sha: str) -> str:
+    """Return a human-readable unified-diff string showing the substitution."""
+    original = path.read_text(encoding="utf-8")
+    updated = original.replace(placeholder, sha)
+
+    # Build a minimal --- / +++ diff.
+    orig_lines = original.splitlines(keepends=True)
+    upd_lines = updated.splitlines(keepends=True)
+
+    import difflib
+
+    diff = list(
+        difflib.unified_diff(
+            orig_lines,
+            upd_lines,
+            fromfile=f"a/{path.name}",
+            tofile=f"b/{path.name}",
+        )
+    )
+    return "".join(diff)
+
+
+def _apply_substitution(path: Path, placeholder: str, sha: str) -> None:
+    """Replace all occurrences of *placeholder* with *sha* in *path*."""
+    original = path.read_text(encoding="utf-8")
+    updated = original.replace(placeholder, sha)
+    path.write_text(updated, encoding="utf-8")
+
+
+def _stage_file(path: Path) -> None:
+    """Stage *path* via ``git add``."""
+    result = subprocess.run(
+        ["git", "add", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _die(f"git add failed for {path}:\n{result.stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _die(msg: str, code: int = 1) -> None:
+    print(f"[sha-stamp-stager] ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stage SHA-stamp substitutions for squash-merged PRs (this-repo-local)."
+    )
+    parser.add_argument("--pr", type=int, required=True, help="Merged PR number.")
+    parser.add_argument(
+        "--placeholder",
+        default="PENDING_SHA",
+        help="Placeholder string to replace (default: PENDING_SHA).",
+    )
+    parser.add_argument(
+        "--search-root",
+        default="docs/engineering-journal",
+        help="Directory to search for placeholder lines (default: docs/engineering-journal).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the diff but do not stage any files.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = _repo_root()
+    search_root = repo_root / args.search_root
+
+    if not search_root.exists():
+        _die(
+            f"Search root '{search_root}' does not exist. "
+            "Run from inside the repo or pass --search-root."
+        )
+
+    # Look up the squash SHA first — fail fast if the PR isn't merged.
+    sha = _squash_sha_from_pr(args.pr)
+    short_sha = sha[:7]
+    print(f"[sha-stamp-stager] PR #{args.pr} squash SHA: {sha} (short: {short_sha})")
+
+    # Find files with the placeholder.
+    placeholder_files = _find_placeholder_files(search_root, args.placeholder)
+    if not placeholder_files:
+        print(
+            f"[sha-stamp-stager] No placeholder '{args.placeholder}' found under "
+            f"'{search_root}'. Nothing to stage."
+        )
+        return 0
+
+    print(
+        f"[sha-stamp-stager] Found {len(placeholder_files)} file(s) with "
+        f"placeholder '{args.placeholder}':"
+    )
+    for p in placeholder_files:
+        print(f"  {p.relative_to(repo_root)}")
+
+    print()
+
+    # Show the diff for each file.
+    for path in placeholder_files:
+        diff = _build_diff(path, args.placeholder, sha)
+        print(f"--- diff: {path.relative_to(repo_root)} ---")
+        print(diff)
+
+    if args.dry_run:
+        print("[sha-stamp-stager] --dry-run: no files staged.")
+        return 0
+
+    # Apply + stage each file.
+    staged: list[Path] = []
+    for path in placeholder_files:
+        _apply_substitution(path, args.placeholder, sha)
+        _stage_file(path)
+        staged.append(path)
+        print(f"[sha-stamp-stager] Staged: {path.relative_to(repo_root)}")
+
+    print()
+    print(
+        f"[sha-stamp-stager] {len(staged)} file(s) staged. "
+        "Review the diff above, then commit with:\n"
+        f"  git commit -m 'chore(journal): fill squash SHA for PR #{args.pr} ({short_sha})'"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/stale_main_guard.py
+++ b/tools/stale_main_guard.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Stale-main-after-squash guard (this-repo-local, R18).
+
+After a squash-merge lands on ``origin/main``, local ``main`` is silently
+behind until explicitly fast-forwarded.  This guard detects that state and
+emits a loud warning before any build agent reads the stale tree — a failure
+mode that cost two builds here (#shipped-on-origin-not-in-stale-local-tree).
+
+Behaviour
+---------
+1. ``git fetch origin`` (with a short timeout — network errors degrade quietly).
+2. Count how many commits local ``main`` is behind ``origin/main``.
+3. If ``count == 0``: silent (exits 0).
+4. If ``count > 0`` AND the working tree is clean (no uncommitted changes):
+   auto-fast-forward ``main`` and print one confirmation line.
+5. If ``count > 0`` AND there are uncommitted changes or we are on a non-main
+   branch: print a loud one-line warning and exit 0 (non-blocking — the guard
+   informs, it does not halt).
+
+Worktree safety
+---------------
+In a bg-worktree session ``git rev-parse --abbrev-ref HEAD`` returns the
+worktree branch, not ``main``.  The guard detects this and omits the
+auto-fast-forward (it would be wrong to mutate ``main`` from inside a
+worktree).  The stale-behind warning is still emitted so the operator knows
+the repo state.
+
+This-repo-local
+---------------
+The guard is scoped to this repo.  It does not assume any cross-repo idiom.
+Do not run it unconditionally in CI or other repos; install it as a
+``SessionStart`` hook (or call it manually after a squash-merge) via
+``hooks/hooks.json`` under a repo-path guard.
+
+Exit codes
+----------
+0   Always (guard is non-blocking).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_MAIN_BRANCH = "main"
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(args: list[str], *, timeout: int = 15) -> tuple[int, str, str]:
+    """Run a subprocess; return (returncode, stdout, stderr)."""
+    try:
+        r = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 1, "", "timed out"
+    except FileNotFoundError:
+        return 1, "", f"{args[0]!r} not found"
+    except Exception as exc:
+        return 1, "", str(exc)
+
+
+def _fetch_origin() -> bool:
+    """
+    Run ``git fetch origin``.
+
+    Returns True on success, False on any error (network, not-a-repo, etc.).
+    Failures are swallowed so the guard degrades quietly.
+    """
+    rc, _, _ = _run(["git", "fetch", "origin"], timeout=20)
+    return rc == 0
+
+
+def _commits_behind() -> int | None:
+    """
+    Return how many commits local ``main`` is behind ``origin/main``.
+
+    Returns None if the comparison cannot be made (no remote tracking branch,
+    not a git repo, etc.).
+    """
+    rc, stdout, _ = _run(["git", "rev-list", "--count", f"{_MAIN_BRANCH}..origin/{_MAIN_BRANCH}"])
+    if rc != 0:
+        return None
+    try:
+        return int(stdout)
+    except ValueError:
+        return None
+
+
+def _current_branch() -> str | None:
+    """Return the currently checked-out branch, or None on detached HEAD / error."""
+    rc, stdout, _ = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    if rc != 0:
+        return None
+    return stdout if stdout != "HEAD" else None  # 'HEAD' = detached
+
+
+def _is_worktree() -> bool:
+    """
+    Return True if we are running inside a git worktree (not the main tree).
+
+    Compares the common git dir with the git dir — in a worktree they differ.
+    """
+    rc_gitdir, gitdir, _ = _run(["git", "rev-parse", "--git-dir"])
+    rc_common, common, _ = _run(["git", "rev-parse", "--git-common-dir"])
+    if rc_gitdir != 0 or rc_common != 0:
+        return False
+    # In the main worktree, both paths resolve to the same directory.
+    # In a linked worktree, --git-dir returns the per-worktree dir
+    # (e.g. .git/worktrees/<name>) while --git-common-dir returns .git.
+    return gitdir != common
+
+
+def _working_tree_is_clean() -> bool:
+    """Return True if there are no uncommitted changes (staged or unstaged)."""
+    rc, stdout, _ = _run(["git", "status", "--porcelain"])
+    if rc != 0:
+        return False  # Treat unknown state as dirty (conservative)
+    return stdout == ""
+
+
+def _fast_forward_main() -> bool:
+    """
+    Fast-forward local ``main`` to ``origin/main``.
+
+    Returns True on success.
+    """
+    rc, _, _ = _run(["git", "fetch", "origin", f"{_MAIN_BRANCH}:{_MAIN_BRANCH}"])
+    return rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_guard(*, _fetch: bool = True) -> int:
+    """
+    Execute the stale-main guard.  Returns 0 always.
+
+    Extracted from ``main()`` for testability (``_fetch=False`` skips the
+    network call in unit tests).
+    """
+    if _fetch:
+        # Degrade quietly on network failure — the count check below will use
+        # whatever FETCH_HEAD git already has.
+        _fetch_origin()
+
+    behind = _commits_behind()
+
+    if behind is None:
+        # Cannot compare (no remote branch, not a repo, etc.) — stay silent.
+        return 0
+
+    if behind == 0:
+        # Up to date — silent.
+        return 0
+
+    # Local main is stale.
+    in_worktree = _is_worktree()
+    current = _current_branch()
+    on_main = current == _MAIN_BRANCH
+
+    if in_worktree:
+        # Cannot safely fast-forward main from inside a worktree.
+        print(
+            f"[stale-main-guard] WARNING: local '{_MAIN_BRANCH}' is {behind} commit(s) "
+            f"behind origin/{_MAIN_BRANCH}. "
+            f"You are in a worktree (branch: {current!r}). "
+            f"Fast-forward manually: git fetch origin {_MAIN_BRANCH}:{_MAIN_BRANCH}",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not on_main:
+        # Not on main — warn but do not attempt a fast-forward.
+        print(
+            f"[stale-main-guard] WARNING: local '{_MAIN_BRANCH}' is {behind} commit(s) "
+            f"behind origin/{_MAIN_BRANCH}. "
+            f"You are on branch {current!r}. "
+            f"Fast-forward when ready: git fetch origin {_MAIN_BRANCH}:{_MAIN_BRANCH}",
+            file=sys.stderr,
+        )
+        return 0
+
+    # On main — try auto-fast-forward if the tree is clean.
+    if _working_tree_is_clean():
+        if _fast_forward_main():
+            print(
+                f"[stale-main-guard] Auto-fast-forwarded '{_MAIN_BRANCH}' by {behind} "
+                f"commit(s) to match origin/{_MAIN_BRANCH}.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"[stale-main-guard] WARNING: local '{_MAIN_BRANCH}' is {behind} "
+                f"commit(s) behind origin/{_MAIN_BRANCH} and auto-fast-forward failed. "
+                f"Run: git fetch origin {_MAIN_BRANCH}:{_MAIN_BRANCH}",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"[stale-main-guard] WARNING: local '{_MAIN_BRANCH}' is {behind} commit(s) "
+            f"behind origin/{_MAIN_BRANCH}. Working tree has uncommitted changes — "
+            f"skipping auto-fast-forward. Run when ready: "
+            f"git fetch origin {_MAIN_BRANCH}:{_MAIN_BRANCH}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+def main() -> int:
+    return run_guard()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- U14: Add `mechanical-executor` agent (model: haiku, Bash-only, op-discriminated) for cheap mechanical work dispatched by saga commands
- U15: Release-triad sync guard — tests that `plugin.json`, `marketplace.json`, and `CHANGELOG.md` agree on version for every plugin
- U16: SHA-stamp stager + stale-main-after-squash guard for release ritual closes
- Fix: narrow `json.loads` return types in `test_release_triad.py` to satisfy mypy strict checking

Implements R16, R17, R18 from the saga tiering & execution campaign plan.

## Test plan

- [ ] `uv run ruff format --check .` — passes
- [ ] `uv run ruff check .` — passes
- [ ] `uv run python scripts/validate_plugins.py` — passes (warning only, expected)
- [ ] `uv run python marketplace/validator/validate.py` — all 7 plugins valid
- [ ] `uv run pytest` — 842 passed
- [ ] `uv run mypy plugins/ scripts/ tests/ --ignore-missing-imports` — no issues

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe