### PR TITLE
epic2: dynamic-workflow authoring (U10-U13, R9-R12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.31.0 - 2026-06-21
+
+- Add `scripts/execution_spec.py` (R9 keystone): the structured execution-spec schema and the
+  Claude Code workflow-script emitter. `/plan` authors **one** spec (units with a per-unit
+  `{model, effort}` tier, return contracts, dependency barriers, escalations, and enumerated
+  fan-out targets) and emits a runnable `.workflow.js` from it; saga records only an
+  `orchestration_ref`, never vendoring backend machinery.
+- Enforce two authoring-time invariants at EMIT time so a mis-built spec fails loudly: a fan-out
+  unit with no enumerated targets fails emit (R10, never a silent filter), and a pilot at a
+  different tier than its fan-out fails emit (R3, a mis-tiered pilot is an invalid oracle).
+- Bake the `workflow_structuredoutput_budget` lesson (cap output, mandatory final emit, skim, batch)
+  into generated cheap-tier (haiku) agents, and bake enumerated-target post-run reconciliation into
+  fan-out agents.
+- Add `references/execution-spec.md` documenting the spec shape, the R3/R10 invariants, and the CLI
+  (`validate` / `emit`).
+
 ## 0.30.0 - 2026-06-21
 
 - Add `plugins/saga/agents/mechanical-executor.md`: cheap-tier (haiku, Bash-only)

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.32.0 - 2026-06-21
+
+- Capability-portable degradation (R11 / U12): every authored plan now carries a runnable
+  inline/serial **baseline** alongside the dynamic-workflow script, so a plan executes on ANY
+  host. Add `execution_spec.emit_inline_baseline()` (the always-runnable floor — no Workflow
+  tool, no `agent()` harness; preserves every unit and its per-unit `{model, effort}` tier and
+  enumerates fan-out targets) and `execution_spec.recompile_for_tier()` (re-emit the same spec
+  for a possibly-downgraded orchestration tier). New `execution_spec.py baseline` CLI subcommand.
+- Add `lifecycle_state.recheck_orchestration_capability()`: on an off-host resume it re-checks the
+  Workflow tool and recompiles **only** the orchestration tier DOWN
+  (`cc-workflows-ultracode → team-execution → inline`), preserving unit specs + per-unit tiers and
+  surfacing a one-line downgrade note. AE3: it never errors and never silently runs nothing — an
+  unknown or unavailable tier floors to the always-runnable inline baseline. New
+  `lifecycle_state.py recheck-capability` CLI subcommand.
+- Record the downgrade durably: add the `orchestration_downgrade` saga field (one-line note;
+  empty on a host that ran the authored tier; backward-compatible default for older sagas).
+- Document the degradation flow in `references/execution-spec.md` and the new field in
+  `references/saga-spec.md`.
+
 ## 0.31.0 - 2026-06-21
 
 - Add `scripts/execution_spec.py` (R9 keystone): the structured execution-spec schema and the

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.33.0 - 2026-06-21
+
+- Add R12 override-rate reader (`scripts/override_rate_reader.py`): scans saga envelopes and
+  surfaces override-rate, over/under-tier direction, and budget-exhaustion (capability
+  degradation) signals. Zero-data reports "no data yet" (no divide-by-zero). Read-only; CLI
+  supports `--json` for machine output.
+- Wire the reader into `/retro` Phase 1.6: a dedicated evidence-gathering step runs the reader
+  and includes its output verbatim; reference added to the SKILL.md reference-files section.
+- Signal accrues post-merge as `/plan` records recommended vs operator-chosen backends (U3);
+  this surface enables evidence-driven default re-weighting (R12's intent).
+
 ## 0.32.0 - 2026-06-21
 
 - Capability-portable degradation (R11 / U12): every authored plan now carries a runnable

--- a/plugins/saga/references/execution-spec.md
+++ b/plugins/saga/references/execution-spec.md
@@ -66,6 +66,48 @@ emit** (the final action MUST be the StructuredOutput call, even on partial work
 tool calls). A budget-exhausted cheap agent that never emits its result is the failure this
 prevents.
 
+## Capability-portable degradation (R11 / U12)
+
+Every authored plan is **capability-portable**: it carries a runnable **inline/serial
+baseline** alongside the dynamic-workflow script, so it executes on ANY host — with or
+without the Workflow tool. The dynamic-workflow layer (`emit_workflow_script`) applies only
+on a capable host.
+
+On an **off-host resume** the Workflow tool is re-checked and the orchestration tier
+recompiles DOWN — and **only the orchestration tier**. The unit specs and per-unit
+`{model, effort}` tiers are PRESERVED across the recompile; a downgrade changes only *how*
+units are dispatched (serial, inline), never *which* units run or *at what tier*.
+
+The flow has three moving parts:
+
+1. **`lifecycle_state.recheck_orchestration_capability(...)`** — the capability probe. Given
+   the resumed `orchestration_mode` and whether the Workflow tool is available, it returns a
+   structured decision: `{downgraded, from, to, note, workflow_available}`. It **never errors
+   and never silently runs nothing** (AE3): on a capable host `downgraded=False` and the
+   authored tier is kept; off-host it returns a runnable lower tier (`team-execution`, or the
+   always-runnable `inline` floor) plus a one-line `note`. An unknown stored mode floors to
+   `inline` rather than raising. Tiers ladder, most-capable first:
+   `cc-workflows-ultracode → team-execution → inline`.
+
+2. **`execution_spec.recompile_for_tier(spec, mode)`** — re-emits the *same* spec for the
+   (possibly downgraded) tier: `cc-workflows-ultracode` → the dynamic `.workflow.js`; any
+   other tier → the inline/serial baseline (`emit_inline_baseline`). Both preserve unit specs
+   and per-unit tiers; the function always returns a runnable artifact.
+
+3. **`saga.orchestration_downgrade`** — the recorded note. The downgrade is durable, not
+   silent: the one-line note from step 1 is written to the saga so a later `/retro`/`/optimize`
+   pass (and the operator) can see the plan ran degraded and why.
+
+```bash
+# Re-check host capability on an off-host resume and recompile the orchestration tier.
+uv run python plugins/saga/scripts/lifecycle_state.py recheck-capability \
+    --orchestration-mode cc-workflows-ultracode --no-workflow
+# -> {"downgraded": true, "from": "cc-workflows-ultracode", "to": "team-execution", "note": "...", ...}
+
+# Emit the runnable inline/serial baseline (the R11 floor) from a spec.
+uv run python plugins/saga/scripts/execution_spec.py baseline spec.json -o baseline.md
+```
+
 ## CLI
 
 ```bash
@@ -74,4 +116,7 @@ uv run python plugins/saga/scripts/execution_spec.py validate spec.json
 
 # Emit a runnable workflow script (stdout, or -o to a file).
 uv run python plugins/saga/scripts/execution_spec.py emit spec.json -o out.workflow.js
+
+# Emit the runnable inline/serial baseline (R11 floor — runs on any host).
+uv run python plugins/saga/scripts/execution_spec.py baseline spec.json -o baseline.md
 ```

--- a/plugins/saga/references/execution-spec.md
+++ b/plugins/saga/references/execution-spec.md
@@ -1,0 +1,77 @@
+# Execution-spec — one spec, two emitters (R9)
+
+`/plan` authors **one** structured execution-spec and emits from it **either** a runnable
+Claude Code workflow script **or** the team-execution markdown protocol. Saga stores only an
+`orchestration_ref` pointer to the emitted artifact; it never vendors backend machinery
+(R9, KTD6). The governance choice (does the verdict need to stick? — see
+[`operator-choice.md`](./operator-choice.md) §3.1) selects *which emitter runs*, not the
+authoring.
+
+The spec schema and the workflow-script emitter live in
+[`../scripts/execution_spec.py`](../scripts/execution_spec.py). The second emitter (the
+`## Team Structure` markdown) is U11's `team_emitter.py`, fed by the same spec.
+
+The worked reference — a hand-authored harness of exactly this shape — is the campaign's own
+sibling `docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js`. Authoring it
+by hand validated the spec by walking it (KTD1) before this emitter automated it.
+
+## Spec shape
+
+```jsonc
+{
+  "name": "my-campaign",
+  "description": "one-line workflow purpose",
+  "repo": "/abs/path/to/repo",        // optional; emitted as the REPO constant
+  "units": [
+    {
+      "unit_id": "U1",
+      "label": "preflight",
+      "tier": { "model": "haiku", "effort": "low" },   // per-unit {model, effort} (R2b)
+      "prompt": "verify grounding facts ...",
+      "returns": ["ready", "drift"],   // the structured-return contract (required keys)
+      "depends_on": [],                // barrier: unit_ids that must finish first
+      "escalation": "HALT on drift",   // operator note surfaced on a resumable HALT
+      "fanout": false,                 // same op over many enumerated targets?
+      "targets": [],                   // REQUIRED & non-empty when fanout=true (R10)
+      "pilot": ""                      // a unit_id that gates the fan-out (same tier, R3)
+    }
+  ]
+}
+```
+
+## The two authoring-time invariants (fail emit)
+
+A mis-built spec is an invalid oracle, so the emitter **fails loudly** rather than emitting a
+broken script. `ExecutionSpec.validate()` runs at emit time and raises `SpecError`:
+
+- **R10 — enumerated fan-out targets.** A `fanout: true` unit with an empty / missing
+  `targets` list fails emit. A fan-out without an explicit target list is a silent filter;
+  the emitted agent additionally reconciles after the run (reports any declared target it did
+  not complete — never silently dropped).
+- **R3 — pilot/fan-out same tier.** A fan-out unit may name a `pilot` (run one target first
+  to de-risk the fan-out). The pilot **must** be at the same `{model, effort}` tier as the
+  fan-out — a mis-tiered pilot validates a different cost surface than the fan-out runs on, so
+  it is an invalid oracle and fails emit.
+
+It also rejects: an empty name / empty units, duplicate `unit_id`s, a `depends_on` / `pilot`
+that does not resolve to a declared unit, a `targets` list without `fanout: true`, and any
+`model` / `effort` outside the closed tier vocabulary (`opus|sonnet|haiku` × `low|medium|high`).
+
+## Cheap-tier budget discipline (baked in)
+
+Generated **cheap-tier** agents (haiku) carry the `workflow_structuredoutput_budget` lesson
+baked into their emitted prompt as a rider: **cap output** (terse, no recaps), **mandatory
+emit** (the final action MUST be the StructuredOutput call, even on partial work), **skim**
+(open only the lines needed, never whole large files), and **batch** (parallel independent
+tool calls). A budget-exhausted cheap agent that never emits its result is the failure this
+prevents.
+
+## CLI
+
+```bash
+# Validate a spec (R3/R10 invariants); exit 2 + a SPEC ERROR on a violation.
+uv run python plugins/saga/scripts/execution_spec.py validate spec.json
+
+# Emit a runnable workflow script (stdout, or -o to a file).
+uv run python plugins/saga/scripts/execution_spec.py emit spec.json -o out.workflow.js
+```

--- a/plugins/saga/references/saga-spec.md
+++ b/plugins/saga/references/saga-spec.md
@@ -122,6 +122,7 @@ construct a `Saga` (no default); all others have the listed default.
 | `orchestration_ref` | str | — | `""` | Pointer into the orchestration (team name, workflow id, …). |
 | `orchestration_recommended` | str | — | `""` | The backend the recommender suggested for this decision (R12). Empty on older sagas. |
 | `orchestration_operator_choice` | str | — | `""` | The backend the operator actually picked (R12). Differs from `orchestration_mode` when overriding. Empty on older sagas. |
+| `orchestration_downgrade` | str | — | `""` | One-line capability-portable downgrade note (R11). Set on an off-host resume when the Workflow tool is unavailable and the orchestration tier recompiled DOWN (unit specs + per-unit tiers preserved); empty on a host that ran the authored tier. Empty on older sagas. |
 | `issue_ref` | str | — | `""` | `owner/repo#N` pointer; empty for plan-only / pre-issue work. |
 | `destination` | enum | — | `plan-only` | Routing intent — **MUST** be in `DESTINATIONS`. Mirrors `lifecycle_state`. |
 | `round` | int | — | `0` | Current PR/iteration round. |

--- a/plugins/saga/scripts/execution_spec.py
+++ b/plugins/saga/scripts/execution_spec.py
@@ -359,6 +359,103 @@ def emit_workflow_script(spec: ExecutionSpec) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Capability-portable inline/serial baseline (R11 / U12)
+# ---------------------------------------------------------------------------
+#
+# Every authored plan carries a runnable inline/serial baseline so it executes on ANY
+# host, with or without the Workflow tool. The dynamic-workflow layer (emit_workflow_script)
+# applies only on a capable host; on an off-host resume the orchestration tier recompiles
+# DOWN (lifecycle_state.recheck_orchestration_capability) and this baseline is what the
+# inline floor runs. The recompile preserves every unit spec and its per-unit {model,
+# effort} tier -- the baseline below annotates each unit with the SAME tier it carried in
+# the dynamic script, so a downgrade changes only HOW units are dispatched (serial, inline)
+# and never WHICH units run or AT WHAT tier.
+
+
+def emit_inline_baseline(spec: ExecutionSpec) -> str:
+    """Emit the runnable inline/serial baseline plan from the spec (R11 floor).
+
+    Validates first (the same R3/R10 invariants -- a mis-built spec has no valid baseline
+    either), then renders a deterministic, host-independent serial checklist: each unit in
+    declared order, dependency barriers honored by ordering, the per-unit ``{model, effort}``
+    tier PRESERVED on every unit (the recompile preserves tiers -- R11), fan-out targets
+    enumerated inline (R10, never a silent filter). This is the always-runnable floor an
+    off-host resume degrades to; it requires no Workflow tool.
+
+    Returned as a Markdown checklist string (the inline executor reads it as its serial
+    run order). It is NOT a .workflow.js -- by construction it dispatches nothing in
+    parallel and calls no agent() harness.
+    """
+    spec.validate()
+
+    lines: list[str] = []
+    lines.append(f"# Inline/serial baseline -- {spec.name}")
+    lines.append("")
+    lines.append(
+        "Runnable on ANY host (no Workflow tool required). The orchestration tier "
+        "recompiled DOWN to inline; unit specs and per-unit {model, effort} tiers preserved."
+    )
+    if spec.description:
+        lines.append("")
+        lines.append(spec.description)
+    if spec.repo:
+        lines.append("")
+        lines.append(f"Repo: {spec.repo}")
+    lines.append("")
+    lines.append("Run each unit IN ORDER (serial); honor the declared dependency barriers.")
+    lines.append("")
+
+    for idx, unit in enumerate(spec.units, start=1):
+        tier = f"{unit.tier.model}/{unit.tier.effort}"
+        lines.append(f"## {idx}. {unit.unit_id}: {unit.label}  [tier: {tier}]")
+        if unit.depends_on:
+            lines.append(f"- depends_on (run after): {', '.join(unit.depends_on)}")
+        if unit.pilot:
+            lines.append(f"- pilot (run first, same tier): {unit.pilot}")
+        if unit.escalation:
+            lines.append(f"- escalation: {unit.escalation}")
+        if unit.fanout:
+            lines.append(
+                f"- fan-out over {len(unit.targets)} enumerated targets "
+                f"(serial, reconcile after -- report any not completed): "
+                f"{', '.join(unit.targets)}"
+            )
+        prompt = _agent_prompt(spec, unit)
+        lines.append("")
+        for prompt_line in prompt.splitlines():
+            lines.append(f"  {prompt_line}" if prompt_line else "")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# The orchestration tiers, mirrored from lifecycle_state.ORCHESTRATION_TIERS, so the
+# emitter can render the correct floor for a given (possibly downgraded) tier without a
+# cross-module import at module scope (the scripts load standalone in tests).
+_WORKFLOW_TIER = "cc-workflows-ultracode"
+_INLINE_TIER = "inline"
+
+
+def recompile_for_tier(spec: ExecutionSpec, orchestration_mode: str) -> str:
+    """Re-emit the spec for a (possibly downgraded) orchestration tier (R11 recompile).
+
+    ONLY the orchestration tier changes -- unit specs and per-unit ``{model, effort}`` tiers
+    are preserved in BOTH emitters. ``cc-workflows-ultracode`` re-emits the dynamic
+    ``.workflow.js`` harness; any other tier (``team-execution`` / ``inline`` / an unknown
+    floor) re-emits the inline/serial baseline, the always-runnable floor. This is the
+    function an off-host resume calls after ``recheck_orchestration_capability`` decides the
+    new tier: it never errors and always returns a runnable artifact (AE3).
+    """
+    spec.validate()
+    if orchestration_mode == _WORKFLOW_TIER:
+        return emit_workflow_script(spec)
+    # team-execution's own emitter is U11's team_emitter.py (markdown protocol); for the
+    # inline floor and as the safe default for any other/unknown tier we emit the
+    # host-independent serial baseline -- never an empty or un-runnable artifact.
+    return emit_inline_baseline(spec)
+
+
+# ---------------------------------------------------------------------------
 # CLI -- validate or emit from a JSON spec file (offline-deterministic)
 # ---------------------------------------------------------------------------
 
@@ -378,6 +475,12 @@ def main(argv: list[str] | None = None) -> int:
     p_emit.add_argument("spec", type=Path)
     p_emit.add_argument("-o", "--out", type=Path, help="write the script here (default: stdout)")
 
+    p_base = sub.add_parser(
+        "baseline", help="emit the runnable inline/serial baseline (R11 floor) from a spec JSON"
+    )
+    p_base.add_argument("spec", type=Path)
+    p_base.add_argument("-o", "--out", type=Path, help="write the baseline here (default: stdout)")
+
     args = parser.parse_args(argv)
     try:
         spec = _load_spec(args.spec)
@@ -385,7 +488,10 @@ def main(argv: list[str] | None = None) -> int:
             spec.validate()
             print(f"OK: {spec.name} ({len(spec.units)} units) is a valid execution-spec.")
             return 0
-        script = emit_workflow_script(spec)
+        if args.cmd == "baseline":
+            script = emit_inline_baseline(spec)
+        else:
+            script = emit_workflow_script(spec)
     except SpecError as exc:
         print(f"SPEC ERROR: {exc}", file=sys.stderr)
         return 2

--- a/plugins/saga/scripts/execution_spec.py
+++ b/plugins/saga/scripts/execution_spec.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Structured execution-spec + Claude Code workflow-script emitter (R9 keystone).
+
+`/plan` authors ONE structured execution-spec and emits from it **either** a runnable
+Claude Code workflow script (this module) **or** the team-execution markdown protocol
+(``team_emitter.py``, U11). Saga stores only an ``orchestration_ref`` pointer; it never
+vendors backend machinery (R9, KTD6). The governance difference is *which emitter runs*,
+not the authoring.
+
+The spec is the single source of truth: units carry a per-unit ``{model, effort}`` tier
+(R2(b)), a return contract, dependency barriers, escalations, and -- for fan-out units --
+an **enumerated** target list with post-run reconciliation (R10, never a silent filter).
+
+Two authoring-time invariants are enforced at EMIT time -- a mis-built spec is an invalid
+oracle, so it must fail loudly rather than silently emit a broken script:
+
+* **R10** -- a fan-out unit with an empty / missing enumerated target list FAILS emit.
+* **R3** -- a pilot at a different ``{model, effort}`` tier than its fan-out FAILS emit
+  (a mis-tiered pilot validates a different cost surface than the fan-out it gates).
+
+The sibling worked reference is
+``docs/plans/2026-06-21-saga-tiering-and-execution-campaign.workflow.js`` -- a hand-authored
+ultracode harness whose shape this emitter reproduces: control-flow only, agents do the
+work, per-unit tiers, dependency barriers, rebase-before-merge, full hands-off auto-merge.
+
+Cheap-tier (haiku / sonnet-low) generated agents carry the
+``workflow_structuredoutput_budget`` lesson baked in (cap output, mandatory final emit,
+skim don't read, batch concurrency) -- a budget-exhausted cheap agent that never emits its
+StructuredOutput is the failure this prevents.
+
+House testability pattern (mirrors ``saga.py`` / ``handoff_envelope.py``): pure functions,
+no I/O at import, dataclasses with explicit ``from_dict`` so a JSON/plan-authored spec
+round-trips deterministically and offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Tier vocabulary (Epic 0 tier rule R1). The emitter does not invent tiers; it only
+# validates that authored tiers are drawn from these closed sets so a typo
+# ("opus-high", "med") fails emit rather than silently producing an un-runnable script.
+MODELS = ("opus", "sonnet", "haiku")
+EFFORTS = ("low", "medium", "high")
+
+# Models cheap enough that the structuredoutput-budget lesson MUST be baked into the
+# generated agent prompt. An opus/high agent has budget headroom; a haiku or a
+# sonnet/low agent over a large surface is exactly the case the lesson guards
+# (workflow_structuredoutput_budget: brevity + mandatory emit + skim + batch).
+_CHEAP_MODELS = ("haiku",)
+
+# The verbatim budget-discipline rider baked into cheap-tier generated agents. This is
+# the workflow_structuredoutput_budget lesson as an instruction the emitted agent reads.
+BUDGET_RIDER = (
+    "BUDGET DISCIPLINE (cheap-tier): you run on a small output budget. "
+    "(1) CAP OUTPUT -- be terse; no human-facing prose, no recaps of files you read. "
+    "(2) MANDATORY EMIT -- your FINAL action MUST be the StructuredOutput call; never end "
+    "the turn without it, even if the work is partial (return what you have + a note). "
+    "(3) SKIM, don't read -- open only the exact lines you need, never whole large files. "
+    "(4) BATCH -- issue independent tool calls in one parallel block, not serially."
+)
+
+
+class SpecError(ValueError):
+    """A spec that violates an authoring-time invariant (R3 / R10) or is malformed.
+
+    Raised at validate/emit time so a mis-built spec fails loudly. Carrying the
+    offending unit id in the message keeps the failure actionable for ``/plan``.
+    """
+
+
+@dataclass(frozen=True)
+class Tier:
+    """A per-unit ``{model, effort}`` tier (R2(b))."""
+
+    model: str
+    effort: str
+
+    def validate(self, where: str) -> None:
+        if self.model not in MODELS:
+            raise SpecError(f"{where}: model {self.model!r} not in {MODELS}")
+        if self.effort not in EFFORTS:
+            raise SpecError(f"{where}: effort {self.effort!r} not in {EFFORTS}")
+
+    @property
+    def is_cheap(self) -> bool:
+        """True iff this tier needs the structuredoutput-budget rider baked in."""
+        return self.model in _CHEAP_MODELS
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], where: str) -> Tier:
+        if "model" not in data or "effort" not in data:
+            raise SpecError(f"{where}: tier needs both 'model' and 'effort'")
+        return cls(model=str(data["model"]), effort=str(data["effort"]))
+
+    def to_dict(self) -> dict[str, str]:
+        return {"model": self.model, "effort": self.effort}
+
+
+@dataclass
+class Unit:
+    """One execution unit -- one ``agent()`` call in the emitted script.
+
+    A *fan-out* unit (``fanout=True``) runs the same operation across many targets;
+    it MUST carry an enumerated ``targets`` list (R10) so the run can reconcile what
+    actually ran against what was declared -- never a silent filter. A fan-out unit
+    MAY name a ``pilot`` unit that gates it (run one target first to de-risk the
+    fan-out); the pilot MUST be at the SAME tier as the fan-out (R3).
+    """
+
+    unit_id: str
+    label: str
+    tier: Tier
+    prompt: str
+    # The structured-return contract: the required keys the agent must emit. Mirrors the
+    # reference's UNIT_SCHEMA `required`. Empty list = no enforced contract (a barrier).
+    returns: list[str] = field(default_factory=list)
+    # Dependency barriers: unit_ids that must complete before this unit runs.
+    depends_on: list[str] = field(default_factory=list)
+    # Escalation: a human/operator note surfaced if the unit HALTs (resumable).
+    escalation: str = ""
+    # Fan-out: same op over many enumerated targets (R10).
+    fanout: bool = False
+    targets: list[str] = field(default_factory=list)
+    # A pilot unit_id that gates this fan-out (run one first). Same-tier required (R3).
+    pilot: str = ""
+
+    def validate(self, where: str) -> None:
+        if not self.unit_id:
+            raise SpecError(f"{where}: a unit needs a non-empty unit_id")
+        self.tier.validate(f"unit {self.unit_id}")
+        if self.fanout and not self.targets:
+            # R10: a fan-out unit MUST enumerate its targets -- never a silent filter.
+            raise SpecError(
+                f"unit {self.unit_id}: fan-out unit declares no enumerated targets "
+                f"(R10 -- a fan-out without an explicit target list is a silent filter)"
+            )
+        if self.targets and not self.fanout:
+            raise SpecError(
+                f"unit {self.unit_id}: targets given but fanout=False -- "
+                f"mark the unit fanout=True or drop the targets"
+            )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Unit:
+        unit_id = str(data.get("unit_id", ""))
+        where = f"unit {unit_id or '<missing id>'}"
+        if "tier" not in data:
+            raise SpecError(f"{where}: missing 'tier'")
+        return cls(
+            unit_id=unit_id,
+            label=str(data.get("label", unit_id)),
+            tier=Tier.from_dict(data["tier"], where),
+            prompt=str(data.get("prompt", "")),
+            returns=[str(r) for r in data.get("returns", [])],
+            depends_on=[str(d) for d in data.get("depends_on", [])],
+            escalation=str(data.get("escalation", "")),
+            fanout=bool(data.get("fanout", False)),
+            targets=[str(t) for t in data.get("targets", [])],
+            pilot=str(data.get("pilot", "")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "unit_id": self.unit_id,
+            "label": self.label,
+            "tier": self.tier.to_dict(),
+            "prompt": self.prompt,
+            "returns": list(self.returns),
+            "depends_on": list(self.depends_on),
+            "escalation": self.escalation,
+            "fanout": self.fanout,
+            "targets": list(self.targets),
+            "pilot": self.pilot,
+        }
+
+
+@dataclass
+class ExecutionSpec:
+    """The structured execution-spec `/plan` authors and the emitters consume.
+
+    One spec, two emitters (R9 / KTD6): ``emit_workflow_script`` (this module) and the
+    team-execution markdown emitter (U11). Saga stores only an ``orchestration_ref``
+    pointer to the emitted artifact.
+    """
+
+    name: str
+    description: str
+    units: list[Unit]
+    # The repo the emitted workflow operates on (the harness `REPO` constant).
+    repo: str = ""
+
+    def unit_by_id(self, unit_id: str) -> Unit | None:
+        for unit in self.units:
+            if unit.unit_id == unit_id:
+                return unit
+        return None
+
+    def validate(self) -> None:
+        """Validate the whole spec, enforcing the R3 + R10 authoring invariants.
+
+        Raises ``SpecError`` on the first violation found (fail emit). Checks, in order:
+        non-empty name + units; unique unit ids; per-unit validity (incl. R10 fan-out
+        targets); every ``depends_on`` / ``pilot`` resolves to a real unit; and R3 --
+        a pilot is at the SAME tier as the fan-out it gates.
+        """
+        if not self.name:
+            raise SpecError("spec needs a non-empty name")
+        if not self.units:
+            raise SpecError("spec needs at least one unit")
+
+        seen: set[str] = set()
+        for unit in self.units:
+            unit.validate(f"spec {self.name}")
+            if unit.unit_id in seen:
+                raise SpecError(f"duplicate unit_id {unit.unit_id!r}")
+            seen.add(unit.unit_id)
+
+        for unit in self.units:
+            for dep in unit.depends_on:
+                if dep not in seen:
+                    raise SpecError(
+                        f"unit {unit.unit_id}: depends_on {dep!r} is not a declared unit"
+                    )
+            if unit.pilot:
+                pilot = self.unit_by_id(unit.pilot)
+                if pilot is None:
+                    raise SpecError(
+                        f"unit {unit.unit_id}: pilot {unit.pilot!r} is not a declared unit"
+                    )
+                if not unit.fanout:
+                    raise SpecError(
+                        f"unit {unit.unit_id}: declares a pilot but is not a fan-out unit"
+                    )
+                # R3: the pilot must be at the SAME tier as the fan-out it gates --
+                # a mis-tiered pilot is an invalid oracle (it validates a different
+                # cost surface than the fan-out runs on).
+                if pilot.tier != unit.tier:
+                    raise SpecError(
+                        f"unit {unit.unit_id}: pilot {unit.pilot!r} tier "
+                        f"{pilot.tier.to_dict()} != fan-out tier {unit.tier.to_dict()} "
+                        f"(R3 -- a mis-tiered pilot is an invalid oracle)"
+                    )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExecutionSpec:
+        if "units" not in data or not isinstance(data["units"], list):
+            raise SpecError("spec needs a 'units' list")
+        return cls(
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            units=[Unit.from_dict(u) for u in data["units"]],
+            repo=str(data.get("repo", "")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "repo": self.repo,
+            "units": [u.to_dict() for u in self.units],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Emitter -- spec -> runnable Claude Code workflow script
+# ---------------------------------------------------------------------------
+
+
+def _js_string(value: str) -> str:
+    """Encode a Python string as a single-quoted JS string literal.
+
+    ``json.dumps`` gives a valid JS string (double-quoted, escaped); we keep that --
+    it is the safest encoder for arbitrary prompt text.
+    """
+    return json.dumps(value)
+
+
+def _agent_prompt(spec: ExecutionSpec, unit: Unit) -> str:
+    """Assemble the prompt text for a unit's emitted ``agent()`` call.
+
+    Bakes the budget rider into cheap-tier (haiku) agents (R9 mitigation) and appends
+    the enumerated-target reconciliation instruction for fan-out units (R10).
+    """
+    parts: list[str] = [unit.prompt]
+    if unit.tier.is_cheap:
+        parts.append(BUDGET_RIDER)
+    if unit.fanout:
+        targets = ", ".join(unit.targets)
+        parts.append(
+            f"FAN-OUT TARGETS ({len(unit.targets)}, enumerated -- run the operation across "
+            f"EXACTLY these, no silent filter): {targets}. "
+            f"RECONCILE after the run: report any declared target you did NOT complete "
+            f"(R10 -- a missing target is a reported gap, never silently dropped)."
+        )
+    if unit.returns:
+        parts.append("Return a structured result with keys: " + ", ".join(unit.returns) + ".")
+    return "\n\n".join(p for p in parts if p)
+
+
+def emit_workflow_script(spec: ExecutionSpec) -> str:
+    """Emit a runnable Claude Code workflow script (.workflow.js) from the spec.
+
+    Validates first (fail emit on R3 / R10), then renders a control-flow-only harness:
+    one ``agent()`` call per unit at its ``{model, effort}`` tier, dependency barriers
+    rendered as ``await`` ordering, fan-out reconciliation + cheap-tier budget riders
+    baked into prompts. The agents do the real work; this script is control flow only.
+
+    Returns the script source as a string (the caller writes it beside the plan and
+    records the path as the saga ``orchestration_ref``).
+    """
+    spec.validate()
+
+    lines: list[str] = []
+    lines.append("// ===========================================================================")
+    lines.append(f"// {spec.name} -- emitted Claude Code workflow harness.")
+    lines.append("// AUTO-EMITTED from a structured execution-spec by execution_spec.py.")
+    lines.append("// CONTROL FLOW ONLY -- every agent reads the plan as its authoritative spec.")
+    lines.append("// Per-unit {model, effort} tiers (R2(b)); R3 pilot/fan-out same-tier +")
+    lines.append("// R10 enumerated-target reconciliation enforced at emit time.")
+    lines.append("// ===========================================================================")
+    lines.append("")
+    lines.append("export const meta = {")
+    lines.append(f"  name: {_js_string(spec.name)},")
+    lines.append(f"  description: {_js_string(spec.description)},")
+    lines.append("}")
+    lines.append("")
+    if spec.repo:
+        lines.append(f"const REPO = {_js_string(spec.repo)}")
+        lines.append("")
+
+    for unit in spec.units:
+        prompt = _agent_prompt(spec, unit)
+        lines.append(f"// ---- {unit.unit_id}: {unit.label} ----")
+        if unit.depends_on:
+            lines.append(f"// depends_on: {', '.join(unit.depends_on)} (barrier)")
+        if unit.pilot:
+            lines.append(f"// pilot: {unit.pilot} (R3 same-tier gate)")
+        if unit.escalation:
+            lines.append(f"// escalation: {unit.escalation}")
+        opts = [
+            f"label: {_js_string(unit.label)}",
+            f"model: {_js_string(unit.tier.model)}",
+            f"effort: {_js_string(unit.tier.effort)}",
+        ]
+        var = unit.unit_id.replace("-", "_").replace(".", "_")
+        lines.append(f"const {var} = await agent(")
+        lines.append(f"  {_js_string(prompt)},")
+        lines.append("  { " + ", ".join(opts) + " },")
+        lines.append(")")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI -- validate or emit from a JSON spec file (offline-deterministic)
+# ---------------------------------------------------------------------------
+
+
+def _load_spec(path: Path) -> ExecutionSpec:
+    return ExecutionSpec.from_dict(json.loads(path.read_text()))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Execution-spec validator + workflow emitter.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_val = sub.add_parser("validate", help="validate a spec JSON (R3/R10 invariants)")
+    p_val.add_argument("spec", type=Path)
+
+    p_emit = sub.add_parser("emit", help="emit a workflow script from a spec JSON")
+    p_emit.add_argument("spec", type=Path)
+    p_emit.add_argument("-o", "--out", type=Path, help="write the script here (default: stdout)")
+
+    args = parser.parse_args(argv)
+    try:
+        spec = _load_spec(args.spec)
+        if args.cmd == "validate":
+            spec.validate()
+            print(f"OK: {spec.name} ({len(spec.units)} units) is a valid execution-spec.")
+            return 0
+        script = emit_workflow_script(spec)
+    except SpecError as exc:
+        print(f"SPEC ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.out:
+        args.out.write_text(script)
+        print(f"wrote {args.out}")
+    else:
+        print(script)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/saga/scripts/lifecycle_state.py
+++ b/plugins/saga/scripts/lifecycle_state.py
@@ -208,6 +208,107 @@ def recommend_execution_backend(
     }
 
 
+# Orchestration tiers, ordered from the most-capable (dynamic workflows, Claude Code
+# only) down to the always-runnable inline baseline. Capability-portable degradation
+# (R11) only ever recompiles DOWN this ladder — a host that cannot run dynamic
+# workflows still runs team-execution or, at the floor, the inline/serial baseline.
+# The enum strings are the frozen wire contract (mirrors saga.py ORCHESTRATION_MODES).
+ORCHESTRATION_TIERS = ("cc-workflows-ultracode", "team-execution", "inline")
+
+# Only the dynamic-workflow tier needs the Workflow tool. team-execution and inline
+# run on any host, so an off-host resume only ever downgrades AWAY from this one tier.
+_HOST_DEPENDENT_TIERS = frozenset({"cc-workflows-ultracode"})
+
+
+def recheck_orchestration_capability(
+    *,
+    orchestration_mode: str,
+    workflow_available: bool,
+    fallback_mode: str = "team-execution",
+) -> dict[str, object]:
+    """Re-check host capability on resume and recompile ONLY the orchestration tier (R11).
+
+    Capability-portable degradation. Every authored plan carries a runnable inline/serial
+    baseline; the dynamic-workflow layer applies only on a capable host. On an off-host
+    resume the Workflow tool is re-checked here; if the chosen tier is host-dependent
+    (``cc-workflows-ultracode``) and the host cannot run it, this recompiles ONLY the
+    orchestration tier DOWN the :data:`ORCHESTRATION_TIERS` ladder. The unit specs and
+    per-unit ``{model, effort}`` tiers are NOT touched here — they survive the recompile
+    untouched (that preservation is the emitter's job; this function decides the new
+    orchestration tier and the human-readable downgrade note).
+
+    ``fallback_mode`` is the preferred landing tier when a downgrade is needed (default
+    ``team-execution``, the next rung down — still parallel/gated, just host-portable).
+    If the caller asks for a fallback that is itself host-dependent or unknown, this floors
+    to ``inline`` — the always-runnable baseline — rather than picking another tier that
+    might also be unavailable.
+
+    AE3 contract — this NEVER errors and NEVER silently runs nothing:
+
+    * **Host CAN run the chosen tier** (``workflow_available`` True, or the mode is not
+      host-dependent): ``downgraded=False``, ``to == orchestration_mode`` — run as authored.
+    * **Host CANNOT run the chosen tier**: ``downgraded=True``, ``to`` is a runnable tier
+      (never empty), and ``note`` is a one-line, surfaceable downgrade message.
+    * **Unknown / empty mode**: treated as the inline baseline — ``downgraded=False``,
+      ``to == "inline"`` — never an exception, never an empty target.
+
+    Returns a JSON-serializable dict::
+
+        {
+          "downgraded": bool,
+          "from": <the mode as resumed>,       # echoed input
+          "to": <the runnable orchestration tier>,   # NEVER empty
+          "note": <one-line downgrade note, or ""> ,
+          "workflow_available": bool,           # echoed capability probe
+        }
+    """
+
+    resumed = orchestration_mode or "inline"
+
+    # An unknown stored mode is floored to the inline baseline rather than trusted — a
+    # host that cannot identify the tier still runs SOMETHING (AE3: never run nothing).
+    if resumed not in ORCHESTRATION_TIERS:
+        return {
+            "downgraded": False,
+            "from": resumed,
+            "to": "inline",
+            "note": "",
+            "workflow_available": workflow_available,
+        }
+
+    host_can_run = workflow_available or resumed not in _HOST_DEPENDENT_TIERS
+    if host_can_run:
+        # The authored tier is runnable here — no downgrade, run as authored.
+        return {
+            "downgraded": False,
+            "from": resumed,
+            "to": resumed,
+            "note": "",
+            "workflow_available": workflow_available,
+        }
+
+    # Off-host: recompile the orchestration tier DOWN. Prefer the requested fallback, but
+    # only if it is itself a runnable (host-portable, known) tier; otherwise floor to
+    # inline — never land on another host-dependent tier that might also be unavailable.
+    if fallback_mode in ORCHESTRATION_TIERS and fallback_mode not in _HOST_DEPENDENT_TIERS:
+        target = fallback_mode
+    else:
+        target = "inline"
+
+    note = (
+        f"Downgraded orchestration {resumed} -> {target}: the Workflow tool is "
+        f"unavailable on this host. Unit specs and per-unit tiers preserved; only "
+        f"the orchestration tier recompiled."
+    )
+    return {
+        "downgraded": True,
+        "from": resumed,
+        "to": target,
+        "note": note,
+        "workflow_available": workflow_available,
+    }
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -235,6 +336,26 @@ def _build_parser() -> argparse.ArgumentParser:
     backend.add_argument("--no-code-surface", action="store_true")
     backend.add_argument("--no-workflow", action="store_true")
 
+    recheck = subparsers.add_parser(
+        "recheck-capability",
+        help="re-check host capability on resume and recompile the orchestration tier (R11)",
+    )
+    recheck.add_argument(
+        "--orchestration-mode",
+        default="inline",
+        help="the tier as resumed (cc-workflows-ultracode|team-execution|inline)",
+    )
+    recheck.add_argument(
+        "--no-workflow",
+        action="store_true",
+        help="the Workflow tool is unavailable on this host (off-host resume)",
+    )
+    recheck.add_argument(
+        "--fallback-mode",
+        default="team-execution",
+        help="preferred landing tier on a downgrade (default: team-execution; floors to inline)",
+    )
+
     return parser
 
 
@@ -261,6 +382,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             adversarial_confidence=args.adversarial_confidence,
             has_code_surface=not args.no_code_surface,
             workflow_available=not args.no_workflow,
+        )
+        print(json.dumps(result))
+        return 0
+    if args.command == "recheck-capability":
+        result = recheck_orchestration_capability(
+            orchestration_mode=args.orchestration_mode,
+            workflow_available=not args.no_workflow,
+            fallback_mode=args.fallback_mode,
         )
         print(json.dumps(result))
         return 0

--- a/plugins/saga/scripts/override_rate_reader.py
+++ b/plugins/saga/scripts/override_rate_reader.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Override-rate reader: R12 analysis half (U13).
+
+Scans all saga envelopes and surfaces:
+
+* **override_rate** — fraction of decisions where the operator's explicit pick
+  (``orchestration_operator_choice``) differs from the recommender's suggestion
+  (``orchestration_recommended``).  Only sagas where *both* fields are non-empty
+  are counted — ``""`` means "no recommendation recorded" and is excluded.
+* **over_tier** — cases where the operator escalated to a richer backend than
+  the recommendation (``inline`` → ``team-execution`` or
+  ``cc-workflows-ultracode``; ``team-execution`` → ``cc-workflows-ultracode``).
+* **under_tier** — cases where the operator de-escalated to a cheaper backend
+  (``cc-workflows-ultracode`` → ``team-execution`` or ``inline``;
+  ``team-execution`` → ``inline``).
+* **budget_exhaustion** — sagas that recorded a non-empty
+  ``orchestration_downgrade`` note; each note is a capability-portable
+  off-host degradation event (U12 / R11).
+
+Zero-data contract (no sagas / no recorded decisions):
+  All rates are ``None`` (not 0.0) so callers can distinguish "no data yet"
+  from "data shows 0 %".  A ``None`` rate MUST print "no data yet" rather than
+  divide-by-zero.
+
+CLI::
+
+    python3 override_rate_reader.py [--root <path>]
+    python3 override_rate_reader.py [--root <path>] --json
+
+Pure functions + injectable ``root`` follow the ``saga.py`` house pattern so
+offline tests never touch the real filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tier ordering (for over/under-tier classification)
+# ---------------------------------------------------------------------------
+
+# The three orchestration backends, ranked cheapest → richest.
+# A pick richer than the recommendation = over-tier; cheaper = under-tier.
+_TIER_ORDER: dict[str, int] = {
+    "inline": 0,
+    "team-execution": 1,
+    "cc-workflows-ultracode": 2,
+}
+
+
+def _tier_rank(mode: str) -> int | None:
+    """Return the numeric tier rank for *mode*, or None for unknown / empty."""
+    return _TIER_ORDER.get(mode)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DecisionRecord:
+    """One orchestration decision pulled from a saga envelope."""
+
+    saga_id: str
+    recommended: str  # orchestration_recommended (may be "")
+    operator_choice: str  # orchestration_operator_choice (may be "")
+    actual_mode: str  # orchestration_mode (the running mode, may differ)
+    downgrade: str  # orchestration_downgrade (non-empty → degradation event)
+
+
+@dataclass(frozen=True)
+class OverrideRateSummary:
+    """The full R12 surface.
+
+    ``override_rate`` / ``over_tier_rate`` / ``under_tier_rate`` are ``None``
+    when there are no recorded decisions (zero-data guard).
+    """
+
+    total_sagas: int
+    decisions_with_data: int  # sagas where both recommended + choice are non-empty
+    override_count: int  # decisions where choice != recommended
+    over_tier_count: int  # decision escalated to richer backend
+    under_tier_count: int  # decision de-escalated to cheaper backend
+    budget_exhaustion_count: int  # sagas with non-empty orchestration_downgrade
+
+    @property
+    def override_rate(self) -> float | None:
+        """Fraction of decisions where operator overrode the recommendation."""
+        if self.decisions_with_data == 0:
+            return None
+        return self.override_count / self.decisions_with_data
+
+    @property
+    def over_tier_rate(self) -> float | None:
+        """Fraction of decisions that escalated to a richer backend."""
+        if self.decisions_with_data == 0:
+            return None
+        return self.over_tier_count / self.decisions_with_data
+
+    @property
+    def under_tier_rate(self) -> float | None:
+        """Fraction of decisions that de-escalated to a cheaper backend."""
+        if self.decisions_with_data == 0:
+            return None
+        return self.under_tier_count / self.decisions_with_data
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "total_sagas": self.total_sagas,
+            "decisions_with_data": self.decisions_with_data,
+            "override_count": self.override_count,
+            "over_tier_count": self.over_tier_count,
+            "under_tier_count": self.under_tier_count,
+            "budget_exhaustion_count": self.budget_exhaustion_count,
+            "override_rate": self.override_rate,
+            "over_tier_rate": self.over_tier_rate,
+            "under_tier_rate": self.under_tier_rate,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Saga envelope reader (avoids importing saga.py to stay lightweight)
+# ---------------------------------------------------------------------------
+
+_STATE_DIR = Path(".claude/saga")
+_SAGAS_DIR = _STATE_DIR / "sagas"
+_ENVELOPE_FIELDS = {
+    "orchestration_recommended",
+    "orchestration_operator_choice",
+    "orchestration_mode",
+    "orchestration_downgrade",
+    "saga_id",
+}
+
+
+def _parse_frontmatter_fields(text: str, fields: set[str]) -> dict[str, str]:
+    """Extract a subset of YAML-like frontmatter fields from an envelope file.
+
+    Only parses the leading ``---`` block; stops at the second ``---`` delimiter
+    or EOF.  Each line is ``key: value``; multi-word values are captured verbatim.
+    Returns ``""`` for fields not present in the frontmatter (backward-compat).
+    """
+    result: dict[str, str] = dict.fromkeys(fields, "")
+    in_front = False
+    for line in text.splitlines():
+        if line.strip() == "---":
+            if not in_front:
+                in_front = True
+                continue
+            else:
+                break  # closing delimiter
+        if not in_front:
+            continue
+        if ":" in line:
+            key, _, raw_val = line.partition(":")
+            key = key.strip()
+            if key in fields:
+                result[key] = raw_val.strip()
+    return result
+
+
+def _all_latest_envelopes(root: Path) -> list[Path]:
+    """Return the newest envelope file for every saga directory under *root*.
+
+    Uses filename ordering (same lexicographic contract as ``saga.py``) — mtime
+    is never consulted.
+    """
+    sagas_dir = root / _SAGAS_DIR
+    if not sagas_dir.is_dir():
+        return []
+    envelopes: list[Path] = []
+    for saga_dir in sagas_dir.iterdir():
+        if not saga_dir.is_dir():
+            continue
+        candidates = [p for p in saga_dir.iterdir() if p.is_file() and p.suffix == ".md"]
+        if not candidates:
+            continue
+        # Filename-ordered: sort lexicographically (timestamp prefix ensures order).
+        envelopes.append(max(candidates, key=lambda p: p.name))
+    return envelopes
+
+
+# ---------------------------------------------------------------------------
+# Core analysis function
+# ---------------------------------------------------------------------------
+
+
+def read_override_rate(root: Path) -> tuple[OverrideRateSummary, list[DecisionRecord]]:
+    """Scan all saga envelopes under *root* and return R12 signals.
+
+    Returns ``(summary, records)`` where *records* is the raw per-saga list.
+    Both are derived purely from envelope files — no subprocess, no network.
+    """
+    envelopes = _all_latest_envelopes(root)
+    records: list[DecisionRecord] = []
+
+    for env_path in envelopes:
+        try:
+            text = env_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fm = _parse_frontmatter_fields(text, _ENVELOPE_FIELDS)
+        records.append(
+            DecisionRecord(
+                saga_id=fm.get("saga_id", env_path.parent.name),
+                recommended=fm.get("orchestration_recommended", ""),
+                operator_choice=fm.get("orchestration_operator_choice", ""),
+                actual_mode=fm.get("orchestration_mode", ""),
+                downgrade=fm.get("orchestration_downgrade", ""),
+            )
+        )
+
+    total_sagas = len(records)
+    decisions_with_data = 0
+    override_count = 0
+    over_tier_count = 0
+    under_tier_count = 0
+    budget_exhaustion_count = 0
+
+    for rec in records:
+        # Budget-exhaustion: any recorded downgrade note.
+        if rec.downgrade:
+            budget_exhaustion_count += 1
+
+        # Override-rate: only when both fields are present.
+        if not rec.recommended or not rec.operator_choice:
+            continue
+        decisions_with_data += 1
+
+        if rec.operator_choice != rec.recommended:
+            override_count += 1
+            rec_rank = _tier_rank(rec.recommended)
+            choice_rank = _tier_rank(rec.operator_choice)
+            if rec_rank is not None and choice_rank is not None:
+                if choice_rank > rec_rank:
+                    over_tier_count += 1
+                elif choice_rank < rec_rank:
+                    under_tier_count += 1
+
+    summary = OverrideRateSummary(
+        total_sagas=total_sagas,
+        decisions_with_data=decisions_with_data,
+        override_count=override_count,
+        over_tier_count=over_tier_count,
+        under_tier_count=under_tier_count,
+        budget_exhaustion_count=budget_exhaustion_count,
+    )
+    return summary, records
+
+
+# ---------------------------------------------------------------------------
+# Human-readable report
+# ---------------------------------------------------------------------------
+
+
+def _pct(rate: float | None) -> str:
+    """Format a rate as a percentage string, or 'no data yet'."""
+    if rate is None:
+        return "no data yet"
+    return f"{rate * 100:.1f}%"
+
+
+def format_report(summary: OverrideRateSummary, records: list[DecisionRecord]) -> str:
+    """Return a human-readable R12 signal report."""
+    lines: list[str] = [
+        "## R12 Orchestration Signals",
+        "",
+        f"Sagas scanned: {summary.total_sagas}",
+        f"Decisions with recommendation data: {summary.decisions_with_data}",
+        "",
+        "### Override Rate",
+        f"  Operator overrode the recommendation: {_pct(summary.override_rate)}"
+        + (
+            f" ({summary.override_count}/{summary.decisions_with_data})"
+            if summary.decisions_with_data > 0
+            else ""
+        ),
+        "",
+        "### Tier Direction (of overrides)",
+        f"  Over-tier (escalated to richer backend):  {_pct(summary.over_tier_rate)}"
+        + (
+            f" ({summary.over_tier_count}/{summary.decisions_with_data})"
+            if summary.decisions_with_data > 0
+            else ""
+        ),
+        f"  Under-tier (de-escalated to cheaper backend): {_pct(summary.under_tier_rate)}"
+        + (
+            f" ({summary.under_tier_count}/{summary.decisions_with_data})"
+            if summary.decisions_with_data > 0
+            else ""
+        ),
+        "",
+        "### Budget-Exhaustion / Capability Degradation",
+        f"  Sagas with a recorded orchestration downgrade: {summary.budget_exhaustion_count}",
+    ]
+
+    if summary.decisions_with_data == 0:
+        lines += [
+            "",
+            "No recommendation data recorded yet.  Override-rate and tier-direction",
+            "signals accrue as /plan records recommended vs operator-chosen backends.",
+            "Run again after a few orchestration decisions to see signal.",
+        ]
+
+    if any(r.downgrade for r in records):
+        lines.append("")
+        lines.append("### Downgrade Notes")
+        for rec in records:
+            if rec.downgrade:
+                lines.append(f"  {rec.saga_id}: {rec.downgrade}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Surface R12 override-rate + budget-exhaustion signals from saga data."
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repo root (default: cwd).  Must contain .claude/saga/.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit a machine-readable JSON summary instead of the human report.",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    summary, records = read_override_rate(root)
+
+    if args.as_json:
+        print(json.dumps(summary.as_dict(), indent=2))
+    else:
+        print(format_report(summary, records))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/plugins/saga/scripts/saga.py
+++ b/plugins/saga/scripts/saga.py
@@ -173,6 +173,11 @@ class Saga:
     # Both default to "" so older sagas that lack these fields still parse without error.
     orchestration_recommended: str = ""
     orchestration_operator_choice: str = ""
+    # Capability-portable degradation record (R11 / U12). On an off-host resume the
+    # orchestration tier recompiles DOWN (Workflow tool unavailable); the one-line
+    # downgrade note is recorded here so the degradation is durable, not silent. Empty
+    # on a host that ran the authored tier; defaults to "" so older sagas still parse.
+    orchestration_downgrade: str = ""
 
     # Pointers (link, never duplicate, another owner's state).
     issue_ref: str = ""  # owner/repo#N (empty for plan-only)
@@ -237,6 +242,7 @@ FRONTMATTER_FIELDS: tuple[str, ...] = (
     "orchestration_ref",
     "orchestration_recommended",
     "orchestration_operator_choice",
+    "orchestration_downgrade",
     "issue_ref",
     "destination",
     "round",
@@ -1061,6 +1067,7 @@ def _build_save_saga(args: argparse.Namespace) -> Saga:
         next_step=args.next_step,
         orchestration_mode=args.orchestration_mode,
         orchestration_ref=args.orchestration_ref,
+        orchestration_downgrade=args.orchestration_downgrade,
         issue_ref=args.issue_ref,
         destination=args.destination,
         round=args.round or 0,
@@ -1102,6 +1109,11 @@ def _add_save_parser(sub: Any) -> None:
     p.add_argument("--destination", choices=list(DESTINATIONS), default="plan-only")
     p.add_argument("--orchestration-mode", choices=list(ORCHESTRATION_MODES), default="inline")
     p.add_argument("--orchestration-ref", default="")
+    p.add_argument(
+        "--orchestration-downgrade",
+        default="",
+        help="one-line capability-portable downgrade note (R11; recorded on off-host resume)",
+    )
     p.add_argument("--issue-ref", default="")
     p.add_argument("--next-step", default="")
     p.add_argument("--plan-path", default="")

--- a/plugins/saga/scripts/team_emitter.py
+++ b/plugins/saga/scripts/team_emitter.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Team-execution markdown emitter — the R9 second emitter (U11).
+
+`/plan` authors ONE structured execution-spec (``execution_spec.py``, U10) and emits
+from it **either** a runnable Claude Code workflow script (U10) **or** this team-
+execution markdown protocol.  The governance difference is *which emitter runs*, not
+the authoring — the spec is the single source of truth (R9, KTD6).
+
+This emitter produces the ``## Team Structure`` section (mirroring
+``team-execution/skills/team-execution/SKILL.md:234``) from the spec's units:
+
+* **Workers** — one row per spec unit (each unit is a discrete phase of work).
+* **Reviewers** — always the base reviewer set required by team-execution protocol.
+* **Validators** — the base scanner set; extended per-unit via ``validators`` metadata.
+* **Execution Gates** — the standard consensus + remediation protocol.
+* **Reference Files** — the team-execution protocol reference set.
+
+Saga records the path to the emitted plan file as ``orchestration_ref`` (a pointer,
+never a copy of team-execution machinery — R9, KTD6).  The emitter returns the markdown
+string; the caller writes it beside the plan and passes the path to
+``saga.py save --orchestration-ref <path>``.
+
+House testability pattern (mirrors ``execution_spec.py`` / ``saga.py``): pure functions,
+no I/O at import.  The ``emit_team_structure`` function is the single testable surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# The base reviewer set the team-execution protocol always requires.
+# These are the three mandatory base reviewers from the SKILL.md template.
+_BASE_REVIEWERS: list[tuple[str, str]] = [
+    ("devils-advocate-reviewer", "Devil's Advocate Reviewer"),
+    ("security-reviewer", "Security Reviewer"),
+    ("architecture-reviewer", "Architecture Reviewer"),
+]
+
+# The base validator set (security-scanner is the baseline).
+_BASE_VALIDATORS: list[tuple[str, str]] = [
+    ("security-scanner", "Scanner"),
+]
+
+# The reference files the team-execution protocol requires (verbatim from SKILL.md).
+_REFERENCE_FILES: list[str] = [
+    "team-execution/skills/team-execution/references/reviewer-registry.md",
+    "team-execution/skills/team-execution/references/review-criteria.md",
+    "team-execution/skills/team-execution/references/consensus-protocol.md",
+    "team-execution/skills/team-execution/references/validator-registry.md",
+    "team-execution/skills/team-execution/references/validator-criteria.md",
+    "team-execution/skills/team-execution/references/validator-execution-order.md",
+    "team-execution/skills/team-execution/references/validator-evidence-state.md",
+    "team-execution/skills/team-execution/references/validator-spawn-quirks.md",
+    "team-execution/skills/team-execution/references/validator-pane-behavior.md",
+]
+
+# The standard execution-gate protocol (verbatim from SKILL.md).
+_EXECUTION_GATES: list[str] = [
+    "Reviewer consensus threshold: >= 9.0/10 from every reviewer.",
+    "Reviewer non-consensus blocks validators unless the user explicitly overrides.",
+    "Scanners run before PR/CI/merge/nonprod coordination.",
+    "Tester hard-fail blocks completion.",
+    "Maximum 3 remediation loops before escalation.",
+]
+
+
+def emit_team_structure(spec: Any) -> str:
+    """Emit the ``## Team Structure`` markdown section from an ``ExecutionSpec``.
+
+    The spec is the same object ``execution_spec.py`` builds — validated by the caller
+    before passing here.  This emitter never vendors team-execution machinery (R9): it
+    produces a conforming markdown section the team-execution skill reads, nothing more.
+
+    Returns the markdown string.  The caller writes it to the plan file and passes the
+    path to ``saga.py save --orchestration-ref <path>`` so saga records only a pointer.
+
+    Parameters
+    ----------
+    spec:
+        A validated ``ExecutionSpec`` (from ``execution_spec.ExecutionSpec.from_dict``).
+        The units become worker rows; the base reviewer / validator sets are fixed.
+    """
+    spec.validate()
+
+    lines: list[str] = []
+
+    # ---- Header ----
+    lines.append("## Team Structure")
+    lines.append("")
+    lines.append(
+        f"<!-- emitted from execution-spec '{spec.name}' by team_emitter.py (R9, KTD6) -->"
+    )
+    lines.append(
+        "<!-- governance: team-execution (gated consensus); "
+        "for advisory consensus use emit_workflow_script instead -->"
+    )
+    lines.append("")
+
+    # ---- Workers ---- one row per spec unit
+    lines.append("### Workers")
+    lines.append("| Agent | Role | Mode | Responsibilities |")
+    lines.append("|-------|------|------|------------------|")
+    for i, unit in enumerate(spec.units, start=1):
+        agent = f"worker-{i}"
+        role = unit.label
+        responsibilities = unit.prompt.split("\n")[0][:120] if unit.prompt else unit.label
+        lines.append(f"| `{agent}` | {role} | bypassPermissions | {responsibilities} |")
+    lines.append("")
+
+    # ---- Reviewers ---- always the base set
+    lines.append("### Reviewers")
+    lines.append("| Agent | Role | Required | Selection Reason |")
+    lines.append("|-------|------|----------|------------------|")
+    for agent, role in _BASE_REVIEWERS:
+        lines.append(f"| `{agent}` | {role} | yes | Base reviewer |")
+    lines.append("")
+
+    # ---- Validators ---- base set; the team-execution skill selects further per plan
+    lines.append("### Validators")
+    lines.append("| Agent | Group | Required | Selection Reason | Blocking |")
+    lines.append("|-------|-------|----------|------------------|----------|")
+    for agent, group in _BASE_VALIDATORS:
+        lines.append(
+            f"| `{agent}` | {group} | yes | Base validator | hard-fail blocks automation |"
+        )
+    lines.append("")
+
+    # ---- Execution Gates ----
+    lines.append("### Execution Gates")
+    for gate in _EXECUTION_GATES:
+        lines.append(f"- {gate}")
+    lines.append("")
+
+    # ---- Reference Files ----
+    lines.append("### Reference Files")
+    for ref in _REFERENCE_FILES:
+        lines.append(f"- `{ref}`")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI -- emit the team-structure markdown from a JSON spec file
+# ---------------------------------------------------------------------------
+
+
+def _load_spec(path: Path) -> Any:
+    """Load and return an ``ExecutionSpec`` from a JSON file.
+
+    Imports ``execution_spec`` lazily so this module is importable without it on the
+    path (tests import it directly from the file path).
+    """
+    # Resolve execution_spec relative to this file so the CLI works from any cwd.
+    spec_module_path = Path(__file__).parent / "execution_spec.py"
+    import importlib.util
+
+    _spec = importlib.util.spec_from_file_location("execution_spec", spec_module_path)
+    assert _spec is not None and _spec.loader is not None
+    mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod.ExecutionSpec.from_dict(json.loads(path.read_text()))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit a team-execution ## Team Structure section from a spec JSON (R9, U11)."
+    )
+    parser.add_argument("spec", type=Path, help="Path to the execution-spec JSON file.")
+    parser.add_argument(
+        "-o",
+        "--out",
+        type=Path,
+        help="Write the markdown here (default: stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        spec = _load_spec(args.spec)
+        markdown = emit_team_structure(spec)
+    except Exception as exc:  # SpecError or IO
+        print(f"EMIT ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.out:
+        args.out.write_text(markdown)
+        print(f"wrote {args.out}")
+    else:
+        print(markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/saga/skills/retro/SKILL.md
+++ b/plugins/saga/skills/retro/SKILL.md
@@ -181,6 +181,32 @@ dir; an **optional generic-sub-agent fan-out (one per session)** synthesizes the
 operator-choice, **never** via an `agents/` dir (this plugin has none; use generic `Explore` / `Task`).
 The orchestrator never reads a raw `.jsonl` or a skeleton file — paths only.
 
+**1.6 R12 orchestration telemetry (read-only).** Run the override-rate reader to surface
+backend choice-vs-recommendation signals across all sagas:
+
+```bash
+python3 plugins/saga/scripts/override_rate_reader.py --root . [--json]
+```
+
+This surfaces three R12 signals:
+
+- **Override rate** — fraction of decisions where the operator's explicit pick differed from
+  the recommender's suggestion (only sagas where both `orchestration_recommended` and
+  `orchestration_operator_choice` are recorded count toward the denominator).
+- **Tier direction** — of those overrides, how many escalated to a richer backend
+  (over-tier) vs. de-escalated to a cheaper one (under-tier).
+- **Budget-exhaustion / capability degradation** — sagas with a non-empty
+  `orchestration_downgrade` note (recorded by U12 on off-host resume).
+
+**Zero-data contract**: if no sagas have been recorded with recommendation data yet, the
+reader reports "no data yet" rather than a rate. Do not fabricate a narrative from zero data;
+carry the "no data yet" state into the retro doc as-is and note that signal accrues over time.
+
+This pass is **read-only** — the reader never writes to disk. Include the output verbatim in
+the Phase-1 evidence block. A non-zero override rate or a skew toward over/under-tier is
+signal worth surfacing in Phase 2 interview and the Phase-3 retro doc, so any future default
+re-weighting is evidence-driven (R12's intent: measure before re-weighting).
+
 ---
 
 ## Phase 2 — Structured interview
@@ -325,3 +351,6 @@ It never blocks the router.
 - `loop/references/dispatch-table.md` — the outbound routing reference (read, never restate).
 - `../brainstorm/SKILL.md` — the canonical channel-inline convention (cite, never duplicate).
 - `../../references/saga-spec.md` — the saga contract (`restore` / `ticks`; `/retro` is read-only).
+- `../../scripts/override_rate_reader.py` — R12 telemetry reader: scans saga envelopes for
+  override-rate, over/under-tier, and budget-exhaustion signals (Phase 1.6). Zero-data reports
+  "no data yet"; read-only; `--json` for machine-readable output.

--- a/tests/test_capability_degrade.py
+++ b/tests/test_capability_degrade.py
@@ -1,0 +1,315 @@
+"""Oracle tests for capability-portable degradation (U12, R11).
+
+Every authored plan carries a runnable inline/serial baseline; on an off-host resume the
+Workflow tool is re-checked, a one-line downgrade is surfaced, and ONLY the orchestration
+tier recompiles down (unit specs + per-unit ``{model, effort}`` tiers preserved). The
+downgrade is recorded on the saga.
+
+AE3 is the load-bearing oracle: an off-host resume must DOWNGRADE WITH A NOTE — it must
+NEVER error and NEVER silently run nothing. The tests asserting a runnable, non-empty
+``to`` tier and that no input raises must not be loosened to "pass".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+SCRIPTS = ROOT / "plugins" / "saga" / "scripts"
+
+
+def _load(script_name: str) -> ModuleType:
+    path = SCRIPTS / script_name
+    spec = importlib.util.spec_from_file_location(script_name.removesuffix(".py"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so `from __future__ import annotations` + dataclass field-type
+    # resolution can look the module up (required on Python 3.14; harmless on 3.12).
+    sys.modules[script_name.removesuffix(".py")] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def lifecycle() -> ModuleType:
+    return _load("lifecycle_state.py")
+
+
+@pytest.fixture
+def es() -> ModuleType:
+    return _load("execution_spec.py")
+
+
+def _spec_dict() -> dict[str, object]:
+    """A small valid spec spanning three distinct per-unit tiers (so tier-preservation
+    across a recompile is observable)."""
+    return {
+        "name": "degrade-demo",
+        "description": "capability-portable degradation demo",
+        "repo": "/tmp/repo",
+        "units": [
+            {
+                "unit_id": "U1",
+                "label": "preflight",
+                "tier": {"model": "haiku", "effort": "low"},
+                "prompt": "verify grounding facts on origin/main",
+                "returns": ["ready", "drift"],
+                "escalation": "HALT on drift",
+            },
+            {
+                "unit_id": "U2",
+                "label": "build",
+                "tier": {"model": "sonnet", "effort": "high"},
+                "prompt": "implement the unit",
+                "depends_on": ["U1"],
+                "returns": ["done", "files"],
+            },
+            {
+                "unit_id": "U3",
+                "label": "fan out",
+                "tier": {"model": "opus", "effort": "high"},
+                "prompt": "audit each target",
+                "depends_on": ["U2"],
+                "fanout": True,
+                "targets": ["a", "b", "c"],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# recheck_orchestration_capability — the capability probe (R11)
+# ---------------------------------------------------------------------------
+
+
+def test_on_host_keeps_authored_tier_no_downgrade(lifecycle: ModuleType) -> None:
+    """A capable host (Workflow tool available) keeps the authored dynamic-workflow tier."""
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="cc-workflows-ultracode",
+        workflow_available=True,
+    )
+    assert result["downgraded"] is False
+    assert result["to"] == "cc-workflows-ultracode"
+    assert result["note"] == ""
+
+
+def test_off_host_downgrades_with_a_one_line_note(lifecycle: ModuleType) -> None:
+    """AE3 — off-host resume of a dynamic-workflow plan DOWNGRADES with a surfaceable note."""
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="cc-workflows-ultracode",
+        workflow_available=False,
+    )
+    assert result["downgraded"] is True
+    assert result["from"] == "cc-workflows-ultracode"
+    # Recompiled DOWN to a host-portable tier (not the dynamic-workflow tier).
+    assert result["to"] == "team-execution"
+    assert result["to"] != "cc-workflows-ultracode"
+    # The downgrade is SURFACED: a non-empty, single-line note.
+    assert result["note"]
+    assert "\n" not in result["note"]
+
+
+def test_off_host_never_lands_on_an_unrunnable_or_empty_tier(lifecycle: ModuleType) -> None:
+    """AE3 — the landing tier is NEVER empty and NEVER the host-dependent tier (never run
+    nothing). Floor to inline if the requested fallback is itself host-dependent."""
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="cc-workflows-ultracode",
+        workflow_available=False,
+        fallback_mode="cc-workflows-ultracode",  # a host-dependent (unavailable) fallback
+    )
+    assert result["downgraded"] is True
+    assert result["to"] == "inline"  # floored to the always-runnable baseline
+    assert result["to"]  # never empty
+
+
+def test_inline_fallback_is_honored_when_requested(lifecycle: ModuleType) -> None:
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="cc-workflows-ultracode",
+        workflow_available=False,
+        fallback_mode="inline",
+    )
+    assert result["downgraded"] is True
+    assert result["to"] == "inline"
+
+
+def test_team_execution_tier_is_host_portable_no_downgrade(lifecycle: ModuleType) -> None:
+    """team-execution runs on any host, so an off-host resume of a team-execution plan is
+    NOT a downgrade — it runs as authored."""
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="team-execution",
+        workflow_available=False,
+    )
+    assert result["downgraded"] is False
+    assert result["to"] == "team-execution"
+    assert result["note"] == ""
+
+
+def test_inline_tier_off_host_is_a_noop(lifecycle: ModuleType) -> None:
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode="inline",
+        workflow_available=False,
+    )
+    assert result["downgraded"] is False
+    assert result["to"] == "inline"
+
+
+def test_empty_or_unknown_mode_floors_to_inline_never_errors(lifecycle: ModuleType) -> None:
+    """AE3 — an empty or unrecognized stored mode floors to the inline baseline rather than
+    raising or returning nothing."""
+    for mode in ("", "garbage-tier", "Inline", "WORKFLOW"):
+        result = lifecycle.recheck_orchestration_capability(
+            orchestration_mode=mode,
+            workflow_available=False,
+        )
+        assert result["to"] == "inline"
+        assert result["to"]  # never empty — never "run nothing"
+
+
+@pytest.mark.parametrize("mode", ["cc-workflows-ultracode", "team-execution", "inline", "", "x"])
+@pytest.mark.parametrize("available", [True, False])
+def test_recheck_never_errors_and_always_returns_a_runnable_tier(
+    lifecycle: ModuleType, mode: str, available: bool
+) -> None:
+    """AE3 sweep — across the full cross product, the probe never raises and ALWAYS names a
+    runnable orchestration tier (one of the known tiers, never empty)."""
+    result = lifecycle.recheck_orchestration_capability(
+        orchestration_mode=mode,
+        workflow_available=available,
+    )
+    assert result["to"] in lifecycle.ORCHESTRATION_TIERS
+    assert isinstance(result["downgraded"], bool)
+    assert "note" in result
+
+
+def test_recheck_cli_emits_json(lifecycle: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = lifecycle.main(
+        [
+            "recheck-capability",
+            "--orchestration-mode",
+            "cc-workflows-ultracode",
+            "--no-workflow",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["downgraded"] is True
+    assert payload["to"] == "team-execution"
+
+
+# ---------------------------------------------------------------------------
+# The recompile preserves unit specs + per-unit tiers (R11)
+# ---------------------------------------------------------------------------
+
+
+def test_recompile_to_inline_preserves_every_unit_and_its_tier(es: ModuleType) -> None:
+    """R11 — recompiling DOWN to inline keeps every unit AND its per-unit {model, effort}
+    tier; only the orchestration tier (dispatch shape) changes."""
+    spec = es.ExecutionSpec.from_dict(_spec_dict())
+    baseline = es.recompile_for_tier(spec, "inline")
+    # Every unit survives.
+    for unit in spec.units:
+        assert unit.unit_id in baseline
+        assert unit.label in baseline
+        # The per-unit tier is preserved (rendered verbatim).
+        assert f"{unit.tier.model}/{unit.tier.effort}" in baseline
+
+
+def test_recompile_to_workflow_tier_emits_the_dynamic_script(es: ModuleType) -> None:
+    spec = es.ExecutionSpec.from_dict(_spec_dict())
+    out = es.recompile_for_tier(spec, "cc-workflows-ultracode")
+    assert "await agent(" in out  # the dynamic harness, not the baseline
+    # Per-unit tiers preserved in the dynamic emit too.
+    assert '"opus"' in out and '"haiku"' in out and '"sonnet"' in out
+
+
+def test_recompile_unknown_tier_floors_to_runnable_baseline(es: ModuleType) -> None:
+    """AE3 — an unknown target tier still yields a runnable (non-empty) baseline, never an
+    empty or un-runnable artifact."""
+    spec = es.ExecutionSpec.from_dict(_spec_dict())
+    out = es.recompile_for_tier(spec, "some-future-tier")
+    assert out.strip()  # non-empty
+    assert "U1" in out  # the units are present and runnable
+
+
+def test_inline_baseline_is_host_independent_no_agent_harness(es: ModuleType) -> None:
+    """The baseline is the always-runnable floor: it dispatches nothing in parallel and
+    calls no agent() harness — it runs without the Workflow tool."""
+    spec = es.ExecutionSpec.from_dict(_spec_dict())
+    baseline = es.emit_inline_baseline(spec)
+    assert "await agent(" not in baseline
+    assert "serial" in baseline.lower()
+
+
+def test_inline_baseline_enumerates_fanout_targets(es: ModuleType) -> None:
+    """R10 carries into the baseline — fan-out targets are enumerated, never silently
+    filtered, even in the serial floor."""
+    spec = es.ExecutionSpec.from_dict(_spec_dict())
+    baseline = es.emit_inline_baseline(spec)
+    for target in ("a", "b", "c"):
+        assert target in baseline
+    assert "reconcile" in baseline.lower()
+
+
+def test_inline_baseline_rejects_a_mis_built_spec(es: ModuleType) -> None:
+    """A mis-built spec (R10 fan-out with no targets) has no valid baseline either —
+    emit fails loudly rather than producing a silent-filter floor."""
+    bad = _spec_dict()
+    units = cast("list[dict[str, object]]", bad["units"])
+    units[2]["targets"] = []  # fan-out with no enumerated targets
+    spec = es.ExecutionSpec.from_dict(bad)
+    with pytest.raises(es.SpecError):
+        es.emit_inline_baseline(spec)
+
+
+def test_baseline_cli_writes_a_file(es: ModuleType, tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(json.dumps(_spec_dict()))
+    out_file = tmp_path / "baseline.md"
+    rc = es.main(["baseline", str(spec_file), "-o", str(out_file)])
+    assert rc == 0
+    body = out_file.read_text()
+    assert "Inline/serial baseline" in body
+    assert "U1" in body
+
+
+# ---------------------------------------------------------------------------
+# The downgrade is RECORDED on the saga (R11), backward-compatibly
+# ---------------------------------------------------------------------------
+
+
+def test_saga_records_the_downgrade_note(tmp_path: Path) -> None:
+    saga_mod = _load("saga.py")
+    note = "Downgraded cc-workflows-ultracode -> team-execution: Workflow tool unavailable."
+    saga = saga_mod.Saga(
+        saga_id="task-degrade",
+        kind="task",
+        id="degrade",
+        orchestration_mode="team-execution",
+        orchestration_downgrade=note,
+    )
+    text = saga_mod.render_envelope(saga)
+    assert "orchestration_downgrade:" in text
+    reloaded = saga_mod.parse_envelope(text)
+    assert reloaded.orchestration_downgrade == note
+
+
+def test_absent_downgrade_field_still_loads(tmp_path: Path) -> None:
+    """Backward-compat — an older saga lacking the field parses with the "" default."""
+    saga_mod = _load("saga.py")
+    saga = saga_mod.Saga(saga_id="task-old", kind="task", id="old")
+    text = saga_mod.render_envelope(saga)
+    # Simulate an older file by stripping the new line entirely.
+    stripped = "\n".join(
+        line for line in text.splitlines() if not line.startswith("orchestration_downgrade:")
+    )
+    assert "orchestration_downgrade:" not in stripped
+    reloaded = saga_mod.parse_envelope(stripped)
+    assert reloaded.orchestration_downgrade == ""

--- a/tests/test_override_rate.py
+++ b/tests/test_override_rate.py
@@ -1,0 +1,437 @@
+"""Tests for the R12 override-rate reader (U13).
+
+Tests cover:
+
+* **Fixtures with data** → correct override-rate, over/under-tier, and
+  budget-exhaustion counts.
+* **Empty corpus** → all rates are None ("no data yet"), no divide-by-zero.
+* **Partial data** (only one of recommended/choice recorded) → excluded from
+  denominator.
+* **Tier direction** → over-tier and under-tier detection.
+* **Budget-exhaustion** → ``orchestration_downgrade`` non-empty → counted.
+* **Format report** → zero-data string contains "no data yet"; data present
+  shows percentages.
+* **CLI smoke** → ``--json`` flag emits valid JSON; no filesystem side-effects.
+
+Determinism / offline discipline:
+  All tests construct envelope files inside ``tmp_path``; the reader is given
+  the ``tmp_path`` root so the real ``.claude/saga/`` is never read or written.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+SCRIPTS_DIR = ROOT / "plugins" / "saga" / "scripts"
+
+
+def _load_module(name: str) -> ModuleType:
+    path = SCRIPTS_DIR / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name.removesuffix(".py")] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def orr() -> ModuleType:
+    """Loaded override_rate_reader module."""
+    return _load_module("override_rate_reader.py")
+
+
+# ---------------------------------------------------------------------------
+# Envelope fixture helpers
+# ---------------------------------------------------------------------------
+
+_SAGA_DIR_TMPL = ".claude/saga/sagas"
+
+
+def _write_envelope(
+    root: Path,
+    saga_id: str,
+    *,
+    recommended: str = "",
+    operator_choice: str = "",
+    mode: str = "inline",
+    downgrade: str = "",
+) -> Path:
+    """Write a minimal saga envelope file to *root*."""
+    saga_dir = root / _SAGA_DIR_TMPL / saga_id
+    saga_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "---",
+        f"saga_id: {saga_id}",
+        "kind: issue",
+        "id: 1",
+        "schema_version: 1.0",
+        f"orchestration_mode: {mode}",
+        f"orchestration_recommended: {recommended}",
+        f"orchestration_operator_choice: {operator_choice}",
+        f"orchestration_downgrade: {downgrade}",
+        "---",
+        "",
+        "## body",
+    ]
+    path = saga_dir / "20260621-120000.md"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Zero-data (empty corpus) tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_corpus_returns_none_rates(orr: ModuleType, tmp_path: Path) -> None:
+    """An empty saga directory yields None for all rates (no divide-by-zero)."""
+    # Create the sagas directory so the reader finds it but no envelopes.
+    (tmp_path / _SAGA_DIR_TMPL).mkdir(parents=True)
+    summary, records = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 0
+    assert summary.decisions_with_data == 0
+    assert summary.override_rate is None
+    assert summary.over_tier_rate is None
+    assert summary.under_tier_rate is None
+    assert summary.budget_exhaustion_count == 0
+    assert records == []
+
+
+def test_empty_corpus_missing_sagas_dir(orr: ModuleType, tmp_path: Path) -> None:
+    """No ``.claude/saga/sagas/`` directory at all → same zero-data result."""
+    summary, records = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 0
+    assert summary.override_rate is None
+
+
+# ---------------------------------------------------------------------------
+# Partial data (only one field recorded) tests
+# ---------------------------------------------------------------------------
+
+
+def test_saga_with_only_recommended_excluded(orr: ModuleType, tmp_path: Path) -> None:
+    """A saga with recommended but no operator_choice is not counted in decisions_with_data."""
+    _write_envelope(tmp_path, "issue-1", recommended="team-execution", operator_choice="")
+    summary, records = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 1
+    assert summary.decisions_with_data == 0
+    assert summary.override_rate is None
+
+
+def test_saga_with_only_operator_choice_excluded(orr: ModuleType, tmp_path: Path) -> None:
+    """A saga with operator_choice but no recommended is not counted."""
+    _write_envelope(tmp_path, "issue-1", recommended="", operator_choice="inline")
+    summary, records = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 1
+    assert summary.decisions_with_data == 0
+    assert summary.override_rate is None
+
+
+# ---------------------------------------------------------------------------
+# No-override tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_override_when_choice_matches_recommendation(orr: ModuleType, tmp_path: Path) -> None:
+    """Operator followed the recommendation → override_rate == 0.0."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        recommended="team-execution",
+        operator_choice="team-execution",
+        mode="team-execution",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.decisions_with_data == 1
+    assert summary.override_count == 0
+    assert summary.override_rate == pytest.approx(0.0)
+    assert summary.over_tier_count == 0
+    assert summary.under_tier_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Override tests — mixed corpus
+# ---------------------------------------------------------------------------
+
+
+def test_override_rate_computed_correctly(orr: ModuleType, tmp_path: Path) -> None:
+    """3 sagas: 1 follows recommendation, 2 override → rate = 2/3."""
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="inline")
+    _write_envelope(tmp_path, "issue-2", recommended="inline", operator_choice="team-execution")
+    _write_envelope(
+        tmp_path,
+        "issue-3",
+        recommended="team-execution",
+        operator_choice="cc-workflows-ultracode",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 3
+    assert summary.decisions_with_data == 3
+    assert summary.override_count == 2
+    assert summary.override_rate == pytest.approx(2 / 3)
+
+
+# ---------------------------------------------------------------------------
+# Over-tier tests
+# ---------------------------------------------------------------------------
+
+
+def test_over_tier_inline_to_team_execution(orr: ModuleType, tmp_path: Path) -> None:
+    """inline → team-execution is an over-tier escalation."""
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="team-execution")
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.over_tier_count == 1
+    assert summary.under_tier_count == 0
+
+
+def test_over_tier_inline_to_ultracode(orr: ModuleType, tmp_path: Path) -> None:
+    """inline → cc-workflows-ultracode is an over-tier escalation."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        recommended="inline",
+        operator_choice="cc-workflows-ultracode",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.over_tier_count == 1
+    assert summary.under_tier_count == 0
+
+
+def test_over_tier_team_execution_to_ultracode(orr: ModuleType, tmp_path: Path) -> None:
+    """team-execution → cc-workflows-ultracode is an over-tier escalation."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        recommended="team-execution",
+        operator_choice="cc-workflows-ultracode",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.over_tier_count == 1
+    assert summary.under_tier_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Under-tier tests
+# ---------------------------------------------------------------------------
+
+
+def test_under_tier_team_execution_to_inline(orr: ModuleType, tmp_path: Path) -> None:
+    """team-execution → inline is an under-tier de-escalation."""
+    _write_envelope(tmp_path, "issue-1", recommended="team-execution", operator_choice="inline")
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.under_tier_count == 1
+    assert summary.over_tier_count == 0
+
+
+def test_under_tier_ultracode_to_inline(orr: ModuleType, tmp_path: Path) -> None:
+    """cc-workflows-ultracode → inline is an under-tier de-escalation."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        recommended="cc-workflows-ultracode",
+        operator_choice="inline",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.under_tier_count == 1
+    assert summary.over_tier_count == 0
+
+
+def test_under_tier_ultracode_to_team_execution(orr: ModuleType, tmp_path: Path) -> None:
+    """cc-workflows-ultracode → team-execution is an under-tier de-escalation."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        recommended="cc-workflows-ultracode",
+        operator_choice="team-execution",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.under_tier_count == 1
+    assert summary.over_tier_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Budget-exhaustion / downgrade tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_downgrade_no_budget_exhaustion(orr: ModuleType, tmp_path: Path) -> None:
+    """A saga with no downgrade note → budget_exhaustion_count == 0."""
+    _write_envelope(tmp_path, "issue-1", downgrade="")
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.budget_exhaustion_count == 0
+
+
+def test_downgrade_note_counted(orr: ModuleType, tmp_path: Path) -> None:
+    """A non-empty orchestration_downgrade → counted as a degradation event."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        downgrade="off-host: Workflow tool unavailable; downgraded inline",
+    )
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.budget_exhaustion_count == 1
+
+
+def test_multiple_downgrades_all_counted(orr: ModuleType, tmp_path: Path) -> None:
+    """Multiple sagas with downgrade notes → all counted."""
+    _write_envelope(tmp_path, "issue-1", downgrade="downgraded to inline")
+    _write_envelope(tmp_path, "issue-2", downgrade="downgraded to team-execution")
+    _write_envelope(tmp_path, "issue-3", downgrade="")
+    summary, _ = orr.read_override_rate(tmp_path)
+    assert summary.budget_exhaustion_count == 2
+    assert summary.total_sagas == 3
+
+
+# ---------------------------------------------------------------------------
+# Mixed corpus tests (comprehensive)
+# ---------------------------------------------------------------------------
+
+
+def test_full_corpus(orr: ModuleType, tmp_path: Path) -> None:
+    """Full corpus: 5 sagas with mixed conditions."""
+    # Saga 1: follows recommendation (inline → inline)
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="inline")
+    # Saga 2: over-tier (inline → team-execution)
+    _write_envelope(tmp_path, "issue-2", recommended="inline", operator_choice="team-execution")
+    # Saga 3: under-tier (cc-workflows-ultracode → inline) + downgrade
+    _write_envelope(
+        tmp_path,
+        "issue-3",
+        recommended="cc-workflows-ultracode",
+        operator_choice="inline",
+        downgrade="off-host downgrade to inline",
+    )
+    # Saga 4: no recommendation data (partial — excluded from denominator)
+    _write_envelope(tmp_path, "issue-4", recommended="", operator_choice="")
+    # Saga 5: downgrade only, no recommendation data
+    _write_envelope(tmp_path, "issue-5", downgrade="downgraded to team-execution")
+
+    summary, records = orr.read_override_rate(tmp_path)
+    assert summary.total_sagas == 5
+    assert summary.decisions_with_data == 3
+    assert summary.override_count == 2
+    assert summary.over_tier_count == 1
+    assert summary.under_tier_count == 1
+    assert summary.budget_exhaustion_count == 2
+    assert summary.override_rate == pytest.approx(2 / 3)
+    assert summary.over_tier_rate == pytest.approx(1 / 3)
+    assert summary.under_tier_rate == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# format_report tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_no_data_says_no_data_yet(orr: ModuleType, tmp_path: Path) -> None:
+    """Zero-data report contains 'no data yet' in override-rate line."""
+    (tmp_path / _SAGA_DIR_TMPL).mkdir(parents=True)
+    summary, records = orr.read_override_rate(tmp_path)
+    report = orr.format_report(summary, records)
+    assert "no data yet" in report
+    # Must not contain a percentage sign in the override rate line.
+    # (Rates are None; only budget-exhaustion count, which is 0, is shown.)
+    assert "Override Rate" in report
+    assert "no data yet" in report
+
+
+def test_format_report_with_data_shows_percentages(orr: ModuleType, tmp_path: Path) -> None:
+    """When data is present, the report shows percentages."""
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="team-execution")
+    _write_envelope(tmp_path, "issue-2", recommended="inline", operator_choice="inline")
+    summary, records = orr.read_override_rate(tmp_path)
+    report = orr.format_report(summary, records)
+    assert "%" in report
+    # Override count = 1, decisions = 2 → 50.0%
+    assert "50.0%" in report
+
+
+def test_format_report_shows_downgrade_notes(orr: ModuleType, tmp_path: Path) -> None:
+    """Downgrade notes appear in the report under a dedicated section."""
+    _write_envelope(
+        tmp_path,
+        "issue-1",
+        downgrade="off-host: downgraded to inline",
+    )
+    summary, records = orr.read_override_rate(tmp_path)
+    report = orr.format_report(summary, records)
+    assert "Downgrade Notes" in report
+    assert "off-host: downgraded to inline" in report
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_json_output(orr: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:  # type: ignore[type-arg]
+    """``--json`` flag emits valid JSON with the expected keys."""
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="team-execution")
+    orr.main(["--root", str(tmp_path), "--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    expected_keys = {
+        "total_sagas",
+        "decisions_with_data",
+        "override_count",
+        "over_tier_count",
+        "under_tier_count",
+        "budget_exhaustion_count",
+        "override_rate",
+        "over_tier_rate",
+        "under_tier_rate",
+    }
+    assert expected_keys <= set(data.keys())
+    assert data["override_count"] == 1
+    assert data["decisions_with_data"] == 1
+
+
+def test_cli_human_report(
+    orr: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,  # type: ignore[type-arg]
+) -> None:
+    """Default (no ``--json``) emits a human-readable report."""
+    (tmp_path / _SAGA_DIR_TMPL).mkdir(parents=True)
+    orr.main(["--root", str(tmp_path)])
+    captured = capsys.readouterr()
+    assert "R12 Orchestration Signals" in captured.out
+    assert "no data yet" in captured.out
+
+
+def test_cli_no_filesystem_side_effects(orr: ModuleType, tmp_path: Path) -> None:
+    """Reader never writes to disk."""
+    _write_envelope(tmp_path, "issue-1", recommended="inline", operator_choice="inline")
+    before = {str(p) for p in tmp_path.rglob("*") if p.is_file()}
+    orr.read_override_rate(tmp_path)
+    after = {str(p) for p in tmp_path.rglob("*") if p.is_file()}
+    assert before == after, "read_override_rate wrote unexpected files"
+
+
+# ---------------------------------------------------------------------------
+# as_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_summary_as_dict_round_trips(orr: ModuleType, tmp_path: Path) -> None:
+    """``summary.as_dict()`` contains all expected keys and correct values."""
+    _write_envelope(tmp_path, "issue-1", recommended="team-execution", operator_choice="inline")
+    summary, _ = orr.read_override_rate(tmp_path)
+    d = summary.as_dict()
+    assert d["total_sagas"] == 1
+    assert d["decisions_with_data"] == 1
+    assert d["override_count"] == 1
+    assert d["under_tier_count"] == 1
+    assert d["over_tier_count"] == 0
+    assert d["override_rate"] == pytest.approx(1.0)
+    assert d["under_tier_rate"] == pytest.approx(1.0)
+    assert d["over_tier_rate"] == pytest.approx(0.0)

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.30.0"
+    assert plugin_json["version"] == "0.31.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.32.0"
+    assert plugin_json["version"] == "0.33.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.31.0"
+    assert plugin_json["version"] == "0.32.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]

--- a/tests/test_team_emitter.py
+++ b/tests/test_team_emitter.py
@@ -1,0 +1,341 @@
+"""Oracle tests for the team-execution markdown emitter (U11, R9 second emitter).
+
+Spec says: ``tests/test_team_emitter.py`` (new) — the same spec [as U10] yields valid
+Team Structure markdown, matching the parsed structure of workers / reviewers /
+validators / gates from ``team-execution/SKILL.md:234``.
+
+The load-bearing oracles here are:
+* The ``## Team Structure`` heading and all four sub-section headings must be present.
+* Each spec unit generates a worker row (parsed-structure match for the template).
+* The base reviewer set (devils-advocate-reviewer, security-reviewer,
+  architecture-reviewer) is always present.
+* The base validator set (security-scanner) is always present.
+* The standard execution gates are always present.
+* The ``orchestration_ref`` semantic: the emitter returns a string the caller writes +
+  passes to ``saga.py save --orchestration-ref``; the emitter never writes the file
+  itself (pure function) — asserted by calling it without touching the filesystem.
+* ``never vendor team-execution machinery`` (R9): the emitter imports nothing from the
+  team-execution plugin directory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+EXECUTION_SPEC_SCRIPT = ROOT / "plugins" / "saga" / "scripts" / "execution_spec.py"
+TEAM_EMITTER_SCRIPT = ROOT / "plugins" / "saga" / "scripts" / "team_emitter.py"
+
+
+def _load_execution_spec() -> ModuleType:
+    """Load execution_spec.py as a module (same pattern as test_workflow_emitter.py)."""
+    spec = importlib.util.spec_from_file_location("execution_spec", EXECUTION_SPEC_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["execution_spec"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_team_emitter() -> ModuleType:
+    """Load team_emitter.py as a module."""
+    spec = importlib.util.spec_from_file_location("team_emitter", TEAM_EMITTER_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["team_emitter"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_spec_dict() -> dict[str, object]:
+    """A minimal valid spec with varied tiers — the same shape as test_workflow_emitter.py."""
+    return {
+        "name": "demo-campaign",
+        "description": "a demo execution spec",
+        "repo": "/tmp/repo",
+        "units": [
+            {
+                "unit_id": "U1",
+                "label": "preflight",
+                "tier": {"model": "haiku", "effort": "low"},
+                "prompt": "verify grounding facts on origin/main",
+                "returns": ["ready", "drift"],
+                "escalation": "HALT on drift",
+            },
+            {
+                "unit_id": "U2",
+                "label": "build",
+                "tier": {"model": "sonnet", "effort": "high"},
+                "prompt": "implement the unit",
+                "depends_on": ["U1"],
+                "returns": ["done", "files"],
+            },
+            {
+                "unit_id": "U3",
+                "label": "judge",
+                "tier": {"model": "opus", "effort": "high"},
+                "prompt": "review the diff",
+                "depends_on": ["U2"],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path: a valid spec yields valid Team Structure markdown.
+# ---------------------------------------------------------------------------
+
+
+def test_emit_team_structure_returns_string() -> None:
+    """emit_team_structure returns a non-empty string (pure function, no I/O)."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_top_level_heading_present() -> None:
+    """The output must start with '## Team Structure' (matches SKILL.md:234)."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "## Team Structure" in result
+
+
+def test_all_four_subsection_headings_present() -> None:
+    """All four parsed-structure subsections must be present (SKILL.md template)."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "### Workers" in result
+    assert "### Reviewers" in result
+    assert "### Validators" in result
+    assert "### Execution Gates" in result
+
+
+def test_reference_files_section_present() -> None:
+    """The Reference Files section must list the team-execution protocol references."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "### Reference Files" in result
+    assert "reviewer-registry.md" in result
+    assert "consensus-protocol.md" in result
+
+
+def test_one_worker_row_per_unit() -> None:
+    """Each spec unit maps to one worker row in the Workers table."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    # 3 units -> worker-1, worker-2, worker-3
+    assert "`worker-1`" in result
+    assert "`worker-2`" in result
+    assert "`worker-3`" in result
+    # worker-4 must NOT be present (no 4th unit)
+    assert "`worker-4`" not in result
+
+
+def test_worker_rows_carry_unit_labels() -> None:
+    """Worker rows include the unit label as the Role column."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "preflight" in result
+    assert "build" in result
+    assert "judge" in result
+
+
+def test_base_reviewers_always_present() -> None:
+    """The three mandatory base reviewers are always present (SKILL.md template)."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "`devils-advocate-reviewer`" in result
+    assert "`security-reviewer`" in result
+    assert "`architecture-reviewer`" in result
+
+
+def test_base_validator_present() -> None:
+    """The base security-scanner validator is always present."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "`security-scanner`" in result
+
+
+def test_execution_gates_present() -> None:
+    """The standard consensus gate text is present in the Execution Gates section."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "9.0/10" in result
+    assert "Reviewer non-consensus blocks validators" in result
+    assert "Maximum 3 remediation loops" in result
+
+
+# ---------------------------------------------------------------------------
+# Governance comment: the emitter labels the choice (never vendors machinery).
+# ---------------------------------------------------------------------------
+
+
+def test_governance_comment_present() -> None:
+    """The emitted markdown annotates the governance choice (team-execution / gated)."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    # Must name team-execution as the governance choice and contrast with advisory.
+    assert "team-execution" in result
+    assert "gated consensus" in result
+
+
+def test_spec_name_in_emitter_comment() -> None:
+    """The spec name appears in the header comment for traceability."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    result = te_mod.emit_team_structure(spec)
+    assert "demo-campaign" in result
+
+
+# ---------------------------------------------------------------------------
+# orchestration_ref semantic: emitter is pure (no filesystem write).
+# ---------------------------------------------------------------------------
+
+
+def test_emitter_is_pure_no_filesystem_write(tmp_path: Path) -> None:
+    """emit_team_structure does NOT write any files — it is a pure function.
+
+    Saga records orchestration_ref via saga.py save --orchestration-ref; the emitter
+    returns the string for the caller to write.  This test confirms no side effects.
+    """
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    spec = es_mod.ExecutionSpec.from_dict(_valid_spec_dict())
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        before_files = set(tmp_path.iterdir())
+        result = te_mod.emit_team_structure(spec)
+        after_files = set(tmp_path.iterdir())
+    finally:
+        os.chdir(original_cwd)
+
+    # No new files written by the emitter.
+    assert after_files == before_files
+    # But the result string is still valid.
+    assert "## Team Structure" in result
+
+
+# ---------------------------------------------------------------------------
+# Single-unit spec: boundary condition.
+# ---------------------------------------------------------------------------
+
+
+def test_single_unit_spec_emits_one_worker_row() -> None:
+    """A single-unit spec produces exactly one worker row."""
+    es_mod = _load_execution_spec()
+    te_mod = _load_team_emitter()
+    data: dict[str, object] = {
+        "name": "tiny",
+        "description": "one-unit spec",
+        "units": [
+            {
+                "unit_id": "U1",
+                "label": "do it all",
+                "tier": {"model": "sonnet", "effort": "high"},
+                "prompt": "implement everything",
+            }
+        ],
+    }
+    spec = es_mod.ExecutionSpec.from_dict(data)
+    result = te_mod.emit_team_structure(spec)
+    assert "`worker-1`" in result
+    assert "`worker-2`" not in result
+    assert "do it all" in result
+
+
+# ---------------------------------------------------------------------------
+# CLI surface: emit to stdout and to a file.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_emit_to_stdout(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI with no -o flag prints the markdown to stdout."""
+    te_mod = _load_team_emitter()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_valid_spec_dict()))
+    rc = te_mod.main([str(spec_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "## Team Structure" in out
+
+
+def test_cli_emit_writes_file(tmp_path: Path) -> None:
+    """CLI with -o writes the markdown to the given path."""
+    te_mod = _load_team_emitter()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_valid_spec_dict()))
+    out_path = tmp_path / "team.md"
+    rc = te_mod.main([str(spec_path), "-o", str(out_path)])
+    assert rc == 0
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "## Team Structure" in content
+    assert "`worker-1`" in content
+
+
+def test_cli_bad_spec_returns_2(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI returns exit code 2 on a bad spec (e.g. missing units)."""
+    te_mod = _load_team_emitter()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps({"name": "bad", "description": "x", "units": []}))
+    rc = te_mod.main([str(spec_path)])
+    assert rc == 2
+    assert "EMIT ERROR" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Never vendors team-execution machinery (R9).
+# ---------------------------------------------------------------------------
+
+
+def test_emitter_does_not_import_team_execution_plugin() -> None:
+    """The emitter source must not import from the team-execution plugin directory.
+
+    R9: saga records a pointer, never vendors backend machinery.  A static check
+    on the source file is sufficient and offline-deterministic.
+    """
+    source = TEAM_EMITTER_SCRIPT.read_text()
+    # No direct import of team-execution plugin modules (which live under
+    # plugins/team-execution/). A reference to the SKILL.md template in a string
+    # constant is fine; an `import` statement importing that plugin's code is not.
+    forbidden = "from plugins.team_execution"
+    assert forbidden not in source, (
+        "team_emitter.py must not import team-execution plugin code (R9 -- never vendor machinery)"
+    )
+    forbidden2 = "import plugins.team_execution"
+    assert forbidden2 not in source, (
+        "team_emitter.py must not import team-execution plugin code (R9 -- never vendor machinery)"
+    )

--- a/tests/test_workflow_emitter.py
+++ b/tests/test_workflow_emitter.py
@@ -1,0 +1,401 @@
+"""Oracle tests for the execution-spec schema + workflow-script emitter (U10, R9 keystone).
+
+Covers the plan's stated test expectation: a spec emits a valid script with per-unit
+tiers; missing enumerated targets (R10) and mis-tiered pilots (R3) are REJECTED at emit.
+
+The R3/R10 rejection tests are the load-bearing oracle: they assert that a mis-built spec
+FAILS emit, so weakening them would let an invalid (un-runnable / mis-tiered) workflow
+escape authoring. They must never be loosened to "pass".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+SCRIPT = ROOT / "plugins" / "saga" / "scripts" / "execution_spec.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("execution_spec", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec so `from __future__ import annotations` +
+    # dataclass field-type resolution can look the module up (required on Python 3.14;
+    # harmless on 3.12).
+    sys.modules["execution_spec"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_spec_dict() -> dict[str, object]:
+    """A minimal valid spec: a haiku preflight, a sonnet build, an opus judgment unit."""
+    return {
+        "name": "demo-campaign",
+        "description": "a demo execution spec",
+        "repo": "/tmp/repo",
+        "units": [
+            {
+                "unit_id": "U1",
+                "label": "preflight",
+                "tier": {"model": "haiku", "effort": "low"},
+                "prompt": "verify grounding facts on origin/main",
+                "returns": ["ready", "drift"],
+                "escalation": "HALT on drift",
+            },
+            {
+                "unit_id": "U2",
+                "label": "build",
+                "tier": {"model": "sonnet", "effort": "high"},
+                "prompt": "implement the unit",
+                "depends_on": ["U1"],
+                "returns": ["done", "files"],
+            },
+            {
+                "unit_id": "U3",
+                "label": "judge",
+                "tier": {"model": "opus", "effort": "high"},
+                "prompt": "review the diff",
+                "depends_on": ["U2"],
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path: a valid spec emits a runnable script with per-unit tiers.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_spec_emits_script_with_per_unit_tiers() -> None:
+    mod = _load()
+    spec = mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    spec.validate()  # no raise
+    script = mod.emit_workflow_script(spec)
+
+    # The harness shape: meta export + control-flow agent() calls, one per unit.
+    assert "export const meta" in script
+    assert script.count("await agent(") == 3
+    # Per-unit {model, effort} tiers are rendered on each agent() call (R2(b)).
+    assert 'model: "haiku"' in script
+    assert 'effort: "low"' in script
+    assert 'model: "sonnet"' in script
+    assert 'effort: "high"' in script
+    assert 'model: "opus"' in script
+    # The repo constant is emitted when present.
+    assert 'const REPO = "/tmp/repo"' in script
+    # A dependency barrier is documented for the dependent unit.
+    assert "depends_on: U1" in script
+
+
+def test_round_trip_to_dict_from_dict() -> None:
+    mod = _load()
+    original = _valid_spec_dict()
+    spec = mod.ExecutionSpec.from_dict(original)
+    rebuilt = mod.ExecutionSpec.from_dict(spec.to_dict())
+    assert rebuilt.name == spec.name
+    assert [u.unit_id for u in rebuilt.units] == ["U1", "U2", "U3"]
+    assert rebuilt.units[0].tier.model == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# R10: a fan-out unit without enumerated targets FAILS emit.
+# ---------------------------------------------------------------------------
+
+
+def test_fanout_without_targets_fails_emit() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "U4",
+            "label": "fan it out",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "run the op across targets",
+            "fanout": True,
+            # targets intentionally OMITTED -> R10 violation
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError) as exc:
+        mod.emit_workflow_script(spec)
+    assert "R10" in str(exc.value)
+    assert "U4" in str(exc.value)
+
+
+def test_fanout_with_enumerated_targets_emits_and_reconciles() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "U4",
+            "label": "fan it out",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "run the op across targets",
+            "fanout": True,
+            "targets": ["alpha", "beta", "gamma"],
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    script = mod.emit_workflow_script(spec)
+    # Enumerated targets are surfaced AND a reconciliation instruction is baked in (R10).
+    assert "alpha, beta, gamma" in script
+    assert "RECONCILE" in script
+    assert "FAN-OUT TARGETS (3" in script
+
+
+def test_targets_without_fanout_flag_fails() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "U4",
+            "label": "stray targets",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "x",
+            "targets": ["a"],
+            # fanout omitted -> targets without fanout is a malformed unit
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError):
+        spec.validate()
+
+
+# ---------------------------------------------------------------------------
+# R3: a pilot at a different tier than its fan-out FAILS emit.
+# ---------------------------------------------------------------------------
+
+
+def test_pilot_same_tier_emits() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "Upilot",
+            "label": "pilot one target",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "pilot the op on one target",
+        }
+    )
+    units.append(
+        {
+            "unit_id": "Ufan",
+            "label": "fan out same tier",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "run across targets",
+            "fanout": True,
+            "targets": ["a", "b"],
+            "pilot": "Upilot",
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    script = mod.emit_workflow_script(spec)  # no raise
+    assert "pilot: Upilot" in script
+
+
+def test_pilot_different_model_fails_emit() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "Upilot",
+            "label": "pilot",
+            "tier": {"model": "opus", "effort": "high"},  # opus pilot
+            "prompt": "pilot",
+        }
+    )
+    units.append(
+        {
+            "unit_id": "Ufan",
+            "label": "fan out",
+            "tier": {"model": "sonnet", "effort": "high"},  # sonnet fan-out -> tier mismatch
+            "prompt": "fan",
+            "fanout": True,
+            "targets": ["a", "b"],
+            "pilot": "Upilot",
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError) as exc:
+        mod.emit_workflow_script(spec)
+    assert "R3" in str(exc.value)
+    assert "Ufan" in str(exc.value)
+
+
+def test_pilot_different_effort_fails_emit() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "Upilot",
+            "label": "pilot",
+            "tier": {"model": "sonnet", "effort": "medium"},  # medium effort
+            "prompt": "pilot",
+        }
+    )
+    units.append(
+        {
+            "unit_id": "Ufan",
+            "label": "fan out",
+            "tier": {"model": "sonnet", "effort": "high"},  # high effort -> mismatch
+            "prompt": "fan",
+            "fanout": True,
+            "targets": ["a", "b"],
+            "pilot": "Upilot",
+        }
+    )
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError):
+        mod.emit_workflow_script(spec)
+
+
+# ---------------------------------------------------------------------------
+# Cheap-tier budget rider baked into haiku agents (workflow_structuredoutput_budget).
+# ---------------------------------------------------------------------------
+
+
+def test_cheap_tier_agent_carries_budget_rider() -> None:
+    mod = _load()
+    spec = mod.ExecutionSpec.from_dict(_valid_spec_dict())
+    script = mod.emit_workflow_script(spec)
+    # U1 is haiku -> the budget rider (cap/emit/skim/batch) is baked into its prompt.
+    assert "BUDGET DISCIPLINE" in script
+    assert "MANDATORY EMIT" in script
+    assert "SKIM" in script
+
+
+def test_opus_agent_has_no_budget_rider() -> None:
+    mod = _load()
+    # A spec with ONLY opus units -> no budget rider anywhere (headroom).
+    data: dict[str, object] = {
+        "name": "rich",
+        "description": "all opus",
+        "units": [
+            {
+                "unit_id": "U1",
+                "label": "judge",
+                "tier": {"model": "opus", "effort": "high"},
+                "prompt": "judge it",
+            }
+        ],
+    }
+    spec = mod.ExecutionSpec.from_dict(data)
+    script = mod.emit_workflow_script(spec)
+    assert "BUDGET DISCIPLINE" not in script
+
+
+# ---------------------------------------------------------------------------
+# Malformed specs are rejected with actionable messages.
+# ---------------------------------------------------------------------------
+
+
+def test_bad_tier_value_fails() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    first = units[0]
+    assert isinstance(first, dict)
+    first["tier"] = {"model": "gpt", "effort": "low"}
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError):
+        spec.validate()
+
+
+def test_duplicate_unit_id_fails() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    dup = dict(units[0])
+    units.append(dup)
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError):
+        spec.validate()
+
+
+def test_unknown_dependency_fails() -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    last = units[-1]
+    assert isinstance(last, dict)
+    last["depends_on"] = ["Unope"]
+    spec = mod.ExecutionSpec.from_dict(data)
+    with pytest.raises(mod.SpecError):
+        spec.validate()
+
+
+def test_empty_units_fails() -> None:
+    mod = _load()
+    spec = mod.ExecutionSpec.from_dict({"name": "x", "description": "y", "units": []})
+    with pytest.raises(mod.SpecError):
+        spec.validate()
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (validate / emit) round-trips through a temp JSON file.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_validate_ok(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    mod = _load()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_valid_spec_dict()))
+    rc = mod.main(["validate", str(spec_path)])
+    assert rc == 0
+    assert "valid execution-spec" in capsys.readouterr().out
+
+
+def test_cli_validate_rejects_bad_fanout(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mod = _load()
+    data = _valid_spec_dict()
+    units = data["units"]
+    assert isinstance(units, list)
+    units.append(
+        {
+            "unit_id": "U4",
+            "label": "bad",
+            "tier": {"model": "sonnet", "effort": "high"},
+            "prompt": "x",
+            "fanout": True,
+        }
+    )
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(data))
+    rc = mod.main(["emit", str(spec_path)])
+    assert rc == 2
+    assert "SPEC ERROR" in capsys.readouterr().err
+
+
+def test_cli_emit_writes_file(tmp_path: Path) -> None:
+    mod = _load()
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_valid_spec_dict()))
+    out = tmp_path / "out.workflow.js"
+    rc = mod.main(["emit", str(spec_path), "-o", str(out)])
+    assert rc == 0
+    assert "await agent(" in out.read_text()


### PR DESCRIPTION
## Summary

- **U10 (R9 keystone):** `execution_spec.py` — structured execution-spec schema + workflow-script emitter. Authors one spec (units with per-unit `{model, effort}`, return contracts, dependency barriers, enumerated fan-out targets) and emits a runnable `.workflow.js`. Enforces R3 (pilot↔fan-out same-tier invariant) and R10 (enumerated-target requirement) at emit time.
- **U11 (R9 second emitter):** `team_emitter.py` — second emitter from the same spec producing `## Team Structure` markdown; saga records `orchestration_ref` pointer.
- **U12 (R11):** Capability-portable degradation — every plan carries an inline/serial baseline; `lifecycle_state.recheck_orchestration_capability()` downgrades only the orchestration tier on off-host resume, preserving unit specs + per-unit tiers.
- **U13 (R12):** `override_rate_reader.py` — reads U3's recorded recommendation+choice fields and surfaces override-rate, over/under-tier direction, and budget-exhaustion signals; wired into `/retro` Phase 1.6.

Version triad: saga `0.31.0` → `0.32.0` → `0.33.0` across U10/U12/U13 (epic4 took 0.30.0 ahead of this branch; CHANGELOG and triad shifted accordingly in rebase resolution).

## Test plan

- [ ] `tests/test_workflow_emitter.py` — U10: spec emits valid script; missing enumerated targets and mis-tiered pilots rejected
- [ ] `tests/test_team_emitter.py` — U11: same spec yields valid Team Structure markdown
- [ ] `tests/test_capability_degrade.py` — U12: AE3 off-host resume degrades with note, never errors
- [ ] `tests/test_override_rate.py` — U13: recorded fixtures → correct rate; empty → graceful
- [ ] Full gate: `ruff format --check`, `ruff check`, plugin validators, `pytest` (926 passed), `mypy` (clean)

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe