### PR TITLE
fix(saga): wire R12 recommended-vs-chosen producer path + R13 MultiEdit hook test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -83,7 +83,7 @@
     {
       "name": "saga",
       "source": "./plugins/saga",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
       "author": {
         "name": "Infiquetra",

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -27,6 +27,20 @@
 
 ## 2026-06-21
 
+### Dead-wiring has TWO axes — a new saga field needs BOTH a real producer AND a real consumer, or the telemetry is silently inert  {#dead-wiring-needs-producer-and-consumer}
+
+**Context.** The tiering campaign's U3 shipped `orchestration_recommended` / `orchestration_operator_choice` on the `Saga` dataclass, in `FRONTMATTER_FIELDS` (so they serialize + parse + load backward-compatibly), AND the full R12 consumer (`override_rate_reader.py` reads them; `/retro` counts only sagas where both are non-empty). Everything looked done. But **nothing wrote them**: `_build_save_saga` never set them, the `save` argparse had no flags for them, and neither `/plan` nor `/work` instructed recording them. So `override_rate_reader` always reported "no data yet" in production — a complete, tested, wired-on-the-read-side feature that produced zero signal because the write side was missing.
+
+**Evidence.** PR fix/r12-producer-r13-test (saga 0.34.0). Producer path: `plugins/saga/scripts/saga.py:1058` `_build_save_saga` now sets `orchestration_recommended` from the new `--orchestration-recommended` flag and `orchestration_operator_choice` from its flag (defaulting to `--orchestration-mode`); flags added at the `save` subparser next to `--orchestration-mode`. `/plan` Phase 5.3 + `/work` Phase 1.4 SKILLs now pass `--orchestration-recommended`. End-to-end test `tests/test_override_rate.py::test_real_saga_save_feeds_override_rate_reader` drives the REAL `saga.py save` twice (override + match) and asserts the consumer sees real data, not "no data yet".
+
+**Mechanism.** The "dead saga write" lesson recurred on its mirror axis. The prior campaign lessons all caught *writes with no consumer* (a saga advance/field added with no downstream reader → dropped). This is the inverse: a *consumer with no producer*. Both are dead wiring; checking only one direction (does this field have a reader?) passed while the field was inert. A field is live only when a real producer writes it AND a real consumer reads it — and a serializer + a dataclass slot + an argparse-less default is not a producer.
+
+**Validation.** New end-to-end producer→consumer test green (NOT a hand-crafted frontmatter fixture — it runs the actual CLI save entrypoint through `_build_save_saga`); full suite 928 passed.
+
+**Generalizable rule.** Dead-wiring has two axes: before declaring a new saga field done, verify it has BOTH a real producer (a code path that actually sets it on save, reachable from a caller — flag + `_build_save_saga` assignment + SKILL instruction) AND a real consumer (a reader that changes behavior). Serialization/parse round-trip proves neither; it only proves the field survives I/O. Test the seam end-to-end through the real entrypoint, not via a fixture that fabricates the on-disk shape.
+
+**Refs.** [#validate-plugins-only-scans-top-level-md](#validate-plugins-only-scans-top-level-md); the recurring "dead-wiring saga writes" lessons in MEMORY (caught + dropped in `/work`, `/founder-review`, `/retro`).
+
 ### `validate_plugins.py` only scans top-level `plugins/*.md` — its "no plugin files found" is a healthy pass, not a worktree artifact  {#validate-plugins-only-scans-top-level-md}
 
 **Context.** Running the U17 final gate fleet-wide from a fresh worktree, `scripts/validate_plugins.py` printed `⚠️ No plugin files found in .../plugins` and exited 0. The instinct is "the worktree broke path resolution." It did not.

--- a/plugins/saga/.claude-plugin/plugin.json
+++ b/plugins/saga/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saga",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Infiquetra engineering lifecycle plugin spanning five phases: Think, Plan & execute, Hand off to mission-control, Review, and Improve & route (covers office-hours through resume, plus /loop routing).",
   "author": {
     "name": "Infiquetra",

--- a/plugins/saga/CHANGELOG.md
+++ b/plugins/saga/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.34.0 - 2026-06-21
+
+- Wire the R12 producer path so override-rate telemetry is no longer inert. `saga.py save` gains
+  `--orchestration-recommended` and `--orchestration-operator-choice` (both `choices=ORCHESTRATION_MODES`,
+  default empty); `_build_save_saga` now sets `orchestration_recommended` from the flag and
+  `orchestration_operator_choice` from its flag, defaulting to `--orchestration-mode` (the operator's
+  chosen backend IS their choice). Backward-compatible: absent flags → `""`; older sagas still load.
+- `/plan` (Phase 5.3) and `/work` (Phase 1.4) now instruct recording `--orchestration-recommended`
+  alongside `--orchestration-mode` on each orchestration decision, so `override_rate_reader` sees real
+  recommended-vs-chosen data instead of "no data yet".
+- Tests: end-to-end producer→consumer test drives the real `saga.py save` twice (an override + a match)
+  then asserts `override_rate_reader` reports non-zero data; a MultiEdit invalid-JSON case for the
+  marketplace validation hook.
+
 ## 0.33.0 - 2026-06-21
 
 - Add R12 override-rate reader (`scripts/override_rate_reader.py`): scans saga envelopes and

--- a/plugins/saga/scripts/saga.py
+++ b/plugins/saga/scripts/saga.py
@@ -1067,6 +1067,13 @@ def _build_save_saga(args: argparse.Namespace) -> Saga:
         next_step=args.next_step,
         orchestration_mode=args.orchestration_mode,
         orchestration_ref=args.orchestration_ref,
+        orchestration_recommended=args.orchestration_recommended,
+        # The operator's explicit pick. Absent flag → the chosen backend IS the
+        # operator's choice (record it as ``--orchestration-mode``); a literal ""
+        # mode stays "" so older callers don't fabricate a decision.
+        orchestration_operator_choice=(
+            args.orchestration_operator_choice or args.orchestration_mode
+        ),
         orchestration_downgrade=args.orchestration_downgrade,
         issue_ref=args.issue_ref,
         destination=args.destination,
@@ -1108,6 +1115,18 @@ def _add_save_parser(sub: Any) -> None:
     p.add_argument("--progress-pct", type=int, default=0)
     p.add_argument("--destination", choices=list(DESTINATIONS), default="plan-only")
     p.add_argument("--orchestration-mode", choices=list(ORCHESTRATION_MODES), default="inline")
+    p.add_argument(
+        "--orchestration-recommended",
+        choices=list(ORCHESTRATION_MODES),
+        default="",
+        help="what recommend_execution_backend() suggested (R12; pairs with the chosen mode)",
+    )
+    p.add_argument(
+        "--orchestration-operator-choice",
+        choices=list(ORCHESTRATION_MODES),
+        default="",
+        help="the operator's explicit pick (R12; omit to derive from --orchestration-mode)",
+    )
     p.add_argument("--orchestration-ref", default="")
     p.add_argument(
         "--orchestration-downgrade",

--- a/plugins/saga/skills/plan/SKILL.md
+++ b/plugins/saga/skills/plan/SKILL.md
@@ -300,14 +300,19 @@ python3 plugins/saga/scripts/saga.py save \
   --destination <plan-only|pr|merge|nonprod-deploy> \
   --adr-refs "ADR-NNNN|ADR-MMMM" \
   --decisions "KTD1: rationale. KTD2: rationale." \
-  --orchestration-mode <inline|team-execution|cc-workflows-ultracode>
+  --orchestration-mode <inline|team-execution|cc-workflows-ultracode> \
+  --orchestration-recommended <recommend_execution_backend() output>
 ```
+
+Also pass `--orchestration-recommended <the backend the recommender suggested>` so the tick records
+recommended-vs-chosen on this decision (R12 override-rate telemetry); `orchestration_operator_choice`
+auto-derives from `--orchestration-mode`, so the only added burden is naming the recommendation.
 
 `--id` is the only strictly required flag (`--kind` defaults to `issue`); for ad-hoc work pass
 `--kind task --id <slug>`. `--lifecycle-phase plan`, `--plan-path`, `--destination`, `--adr-refs`,
-`--decisions` (the KTD mirror), and `--orchestration-mode` carry the `/plan` consumer row from
-`references/saga-spec.md` §11. When resuming (Phase 0.3 matched), this appends a tick to the existing
-saga directory rather than minting a new one.
+`--decisions` (the KTD mirror), `--orchestration-mode`, and `--orchestration-recommended` carry the
+`/plan` consumer row from `references/saga-spec.md` §11. When resuming (Phase 0.3 matched), this appends
+a tick to the existing saga directory rather than minting a new one.
 
 ### 5.4 Route
 

--- a/plugins/saga/skills/work/SKILL.md
+++ b/plugins/saga/skills/work/SKILL.md
@@ -171,7 +171,10 @@ chat memory alone as durable evidence after a resume.
 Offer the execution backend per `references/operator-choice.md` and the **runnable
 `recommend_execution_backend()` CLI call** in `references/execution-strategy.md`: compute the
 recommendation from the work shape, pre-select it, surface the alternatives (overlap offers both),
-confirm with the operator, and record what they picked via `--orchestration-mode`.
+confirm with the operator, and record what they picked via `--orchestration-mode`. Also pass
+`--orchestration-recommended <the recommend_execution_backend() output>` so the tick records
+recommended-vs-chosen on this decision (R12 override-rate telemetry); `orchestration_operator_choice`
+auto-derives from `--orchestration-mode`, so the only added burden is naming the recommendation.
 
 Then mint/advance the work-thread saga to `lifecycle_phase=work`. Set `--issue-ref` (the issue case — the
 saga-spec §11 `issue_ref`-adoption write), `--plan-path` whenever a plan exists, and save **on the work
@@ -188,6 +191,7 @@ python3 plugins/saga/scripts/saga.py save \
   --plan-path docs/plans/YYYY-MM-DD-<topic>-plan.md \
   --destination <plan-only|pr|merge|nonprod-deploy> \
   --orchestration-mode <inline|team-execution|cc-workflows-ultracode> \
+  --orchestration-recommended <recommend_execution_backend() output> \
   --rounds-seen "1"
 ```
 

--- a/tests/test_marketplace_hook.py
+++ b/tests/test_marketplace_hook.py
@@ -241,6 +241,41 @@ def test_edit_producing_invalid_json_is_blocked(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# MultiEdit tool: post-edit validation over the on-disk file + edits list
+# ---------------------------------------------------------------------------
+
+
+def test_multiedit_producing_invalid_json_is_blocked(tmp_path: Path) -> None:
+    """A MultiEdit whose applied edits yield invalid JSON → exit 2, offending line named.
+
+    The hook reads the on-disk file and applies the ``edits`` list in-memory
+    (validate_json_hook.py:81-93), so this drives the real MultiEdit branch with
+    the stdin shape the hook parses (``tool_input.edits``).
+    """
+    target = tmp_path / "marketplace.json"
+    target.write_text('{\n  "plugins": [],\n  "version": "3.0.0"\n}\n')
+
+    payload = {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "file_path": str(target),
+            "edits": [
+                # First edit is fine on its own; the second introduces an extra
+                # closer so the post-edit content no longer parses.
+                {"old_string": '"3.0.0"', "new_string": '"3.1.0"'},
+                {"old_string": '"plugins": []', "new_string": '"plugins": []]'},
+            ],
+        },
+    }
+    result = _run_hook(payload)
+    assert result.returncode == 2, (
+        f"Expected exit 2 (block); got {result.returncode}, stderr={result.stderr!r}"
+    )
+    assert "marketplace.json" in result.stderr, f"stderr must name the file; got: {result.stderr!r}"
+    assert "line" in result.stderr, f"stderr must name the offending line; got: {result.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
 # Offending-line helper unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_override_rate.py
+++ b/tests/test_override_rate.py
@@ -49,6 +49,12 @@ def orr() -> ModuleType:
     return _load_module("override_rate_reader.py")
 
 
+@pytest.fixture
+def saga() -> ModuleType:
+    """Loaded saga engine module (the real producer of envelope frontmatter)."""
+    return _load_module("saga.py")
+
+
 # ---------------------------------------------------------------------------
 # Envelope fixture helpers
 # ---------------------------------------------------------------------------
@@ -435,3 +441,110 @@ def test_summary_as_dict_round_trips(orr: ModuleType, tmp_path: Path) -> None:
     assert d["override_rate"] == pytest.approx(1.0)
     assert d["under_tier_rate"] == pytest.approx(1.0)
     assert d["over_tier_rate"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end producer → consumer (R12)
+# ---------------------------------------------------------------------------
+
+
+def _stub_saga_git(saga: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``saga.save``'s subprocess seam a no-op so the test never shells out.
+
+    ``save`` threads ``runner`` as a keyword-only default captured at definition
+    time, so we patch both ``saga.subprocess.run`` and the captured default on the
+    git-touching functions (mirrors test_saga_saga's ``_set_runner``).
+    """
+
+    def fake_run(*_args: object, **_kwargs: object) -> object:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(saga.subprocess, "run", fake_run)
+    for fn_name in ("save", "current_git_state"):
+        fn = getattr(saga, fn_name)
+        new_kwdefaults = dict(fn.__kwdefaults__ or {})
+        new_kwdefaults["runner"] = fake_run
+        monkeypatch.setattr(fn, "__kwdefaults__", new_kwdefaults)
+
+
+def test_real_saga_save_feeds_override_rate_reader(
+    orr: ModuleType,
+    saga: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,  # type: ignore[type-arg]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the REAL ``saga.py save`` producer feeds the R12 consumer.
+
+    Exercises the full producer→consumer path (NOT hand-crafted frontmatter):
+    drive ``saga.main(["save", ...])`` twice through ``_build_save_saga`` — once
+    recording an override (mode != recommended) and once a match — then run the
+    override-rate reader over the same saga dir and assert it sees real data
+    (denominator > 0, the override counted), i.e. NOT "no data yet".
+    """
+    monkeypatch.chdir(tmp_path)
+    _stub_saga_git(saga, monkeypatch)
+
+    # Decision 1: an OVERRIDE — operator chose cc-workflows-ultracode over the
+    # recommended team-execution. operator_choice auto-derives from --orchestration-mode.
+    assert (
+        saga.main(
+            [
+                "save",
+                "--kind",
+                "task",
+                "--id",
+                "override-decision",
+                "--lifecycle-phase",
+                "plan",
+                "--orchestration-mode",
+                "cc-workflows-ultracode",
+                "--orchestration-recommended",
+                "team-execution",
+            ]
+        )
+        == 0
+    )
+    # Decision 2: operator FOLLOWED the recommendation (mode == recommended).
+    assert (
+        saga.main(
+            [
+                "save",
+                "--kind",
+                "task",
+                "--id",
+                "matched-decision",
+                "--lifecycle-phase",
+                "plan",
+                "--orchestration-mode",
+                "inline",
+                "--orchestration-recommended",
+                "inline",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()  # discard the save JSON the CLI prints
+
+    # Consumer reads the SAME root the producer wrote to.
+    summary, records = orr.read_override_rate(tmp_path)
+
+    # Real data, not "no data yet": both decisions recorded both fields.
+    assert summary.total_sagas == 2
+    assert summary.decisions_with_data == 2
+    assert summary.override_count == 1  # only decision 1 overrode
+    assert summary.over_tier_count == 1  # team-execution → cc-workflows-ultracode is over-tier
+    assert summary.under_tier_count == 0
+    assert summary.override_rate == pytest.approx(0.5)
+
+    # The human report must NOT fall through to the zero-data branch.
+    report = orr.format_report(summary, records)
+    assert "no data yet" not in report
+    assert "50.0%" in report
+
+    # The override decision's operator_choice auto-derived from --orchestration-mode.
+    override_rec = next(r for r in records if r.recommended == "team-execution")
+    assert override_rec.operator_choice == "cc-workflows-ultracode"
+    assert override_rec.actual_mode == "cc-workflows-ultracode"

--- a/tests/test_saga_plugin.py
+++ b/tests/test_saga_plugin.py
@@ -45,7 +45,7 @@ def test_infiquetra_lifecycle_metadata_and_marketplace_entry_match() -> None:
     entry = next(p for p in marketplace["plugins"] if p["name"] == "saga")
 
     assert plugin_json["name"] == "saga"
-    assert plugin_json["version"] == "0.33.0"
+    assert plugin_json["version"] == "0.34.0"
     assert entry["version"] == plugin_json["version"]
     assert entry["source"] == "./plugins/saga"
     assert "lifecycle" in plugin_json["description"]


### PR DESCRIPTION
Closes two verified gaps left by the just-merged tiering campaign.

## GAP 1 — R12 producer dead-wire (the material one)

The campaign's U3 shipped `orchestration_recommended` / `orchestration_operator_choice` end-to-end on the *read* side: dataclass slots, the YAML serializer, `FRONTMATTER_FIELDS` (backward-compatible parse), the consumer (`override_rate_reader.py`), and `/retro` counting only sagas where both are non-empty. **But nothing wrote them** — `_build_save_saga` never set them, the `save` argparse had no flags, and neither `/plan` nor `/work` instructed recording them. Result: override-rate analysis always reported "no data yet" in production. A complete, tested, wired-on-the-read-side feature producing zero signal because the producer was missing.

Producer path closed:
- **`saga.py save`** gains `--orchestration-recommended` and `--orchestration-operator-choice` (`choices=ORCHESTRATION_MODES`, default empty). `_build_save_saga` (saga.py:1058) sets `orchestration_recommended` from its flag and `orchestration_operator_choice` from its flag, **defaulting to `--orchestration-mode`** when absent (the operator's chosen backend IS their choice). Backward-compatible: absent flags → `""`; older sagas still load.
- **`/plan` Phase 5.3** and **`/work` Phase 1.4** now record `--orchestration-recommended <recommend_execution_backend() output>` alongside `--orchestration-mode` on each orchestration decision. `operator_choice` auto-derives, so the only added caller burden is naming the recommendation.

**End-to-end test** (`tests/test_override_rate.py::test_real_saga_save_feeds_override_rate_reader`): drives the **real** `saga.py save` CLI entrypoint twice — once with `--orchestration-mode cc-workflows-ultracode --orchestration-recommended team-execution` (an override), once with mode==recommended — then runs `override_rate_reader` over that saga dir and asserts it sees real data (denominator 2, override counted, 50% rate), i.e. NOT "no data yet". Not a hand-crafted frontmatter fixture — it exercises producer→consumer through `_build_save_saga`. Uses `tmp_path`/`chdir` so it never leaks under repo-root `.claude/`.

## GAP 2 — R13 MultiEdit hook coverage

The marketplace JSON validator hook applies edits in-memory for MultiEdit (`validate_json_hook.py:81-93`) but had no test sending a MultiEdit payload producing invalid JSON. Added `tests/test_marketplace_hook.py::test_multiedit_producing_invalid_json_is_blocked`: feeds a MultiEdit `tool_input` (the real stdin shape) whose applied edits yield invalid JSON; asserts returncode == 2 and the offending line is named in stderr.

## Release triad (saga 0.33.0 → 0.34.0)

`plugins/saga/.claude-plugin/plugin.json`, the `saga` entry in `.claude-plugin/marketplace.json` (re-validated with `python3 -m json.tool`), and `plugins/saga/CHANGELOG.md` (new 0.34.0 entry). Version drift-guard test (`tests/test_saga_plugin.py`) updated to 0.34.0.

## Journal

One `LEARNINGS.md` entry: dead-wiring has TWO axes — a new saga field needs BOTH a real producer AND a real consumer; U3 shipped field + serializer + consumer but not the producer, so the telemetry was inert.

## Gate (all green from the worktree)

`ruff check` · `ruff format --check` · `validate_plugins.py` · `marketplace/validator/validate.py` · `mypy plugins/ scripts/ tests/` · `pytest` → **928 passed**. No `.claude/`-leak guard failure (new tests use tmp_path).

https://claude.ai/code/session_013vNceYnYtbB6VdZVzvvWTe