### PR TITLE
docs(saga): SHA-fill the 0.37.0 backend-handoff DECISIONS entry

### DIFF
--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -24,7 +24,7 @@
 
 ## 2026-06-21
 
-### Parallel-layer emitter, refute-N judge-panels, /plan author-validate-approve-persist-emit, /work halt-not-degrade, and provenance guard at save() (PR pending — SHA-fill on merge)  {#parallel-refuteN-emitter-plan-work-wiring}
+### Parallel-layer emitter, refute-N judge-panels, /plan author-validate-approve-persist-emit, /work halt-not-degrade, and provenance guard at save() (#250, 88b61be)  {#parallel-refuteN-emitter-plan-work-wiring}
 
 **Decision.** Seven key design calls that together close the R9 keystone:
 


### PR DESCRIPTION
Post-merge SHA-fill of the DECISIONS entry for the plan→work backend-handoff feature (merged as #250, squash `88b61be`). Docs-only.

https://claude.ai/code/session_01QAvWLiBhJEmxtXJA2p2iG8